### PR TITLE
feat(ui): add project description, navigation to new project

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ AGPLv3. See [LICENSE](./LICENSE).
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=haiphucnguyen%2Faskimo&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=askimo-ai%2Faskimo&type=date&legend=top-left">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=askimo-ai/askimo&type=date&theme=dark&legend=top-left" />
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=askimo-ai/askimo&type=date&legend=top-left" />

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/Icons.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/Icons.kt
@@ -1,0 +1,345 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.ui.common.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Base
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Base icon with an explicit tint. Prefer the semantic variants below
+ * so that tint choices stay consistent across all 8 themes.
+ */
+@Composable
+fun appIcon(
+    imageVector: ImageVector,
+    contentDescription: String? = null,
+    tint: Color,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = imageVector,
+        contentDescription = contentDescription,
+        tint = tint,
+        modifier = modifier,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Primary / active icons
+// Uses onSurface — NEVER primary (near-black in dark theme → invisible)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Active / selected-state icon.
+ * Examples: active sort arrow, history collapse/expand, logo tint.
+ */
+@Composable
+fun primaryIcon(
+    imageVector: ImageVector,
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = imageVector,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurface,
+        modifier = modifier,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Secondary / muted icons
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Inactive or decorative icon.
+ * Examples: sidebar nav icons, leading icons in menu items, folder/category icons.
+ */
+@Composable
+fun secondaryIcon(
+    imageVector: ImageVector,
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = imageVector,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Dimmed/ghost icon for placeholder or deeply secondary UI.
+ * Uses onSurface at 40% opacity.
+ */
+@Composable
+fun mutedIcon(
+    imageVector: ImageVector,
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = imageVector,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+        modifier = modifier,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Status icons
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Success / completion icon (CheckCircle).
+ * Uses onSurface — safe across all 8 themes including dark mode.
+ *
+ * @param size 24.dp standard; use 32/64.dp for hero placement in dialogs.
+ */
+@Composable
+fun successIcon(
+    contentDescription: String? = null,
+    size: Dp = 24.dp,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.CheckCircle,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurface,
+        modifier = modifier.size(size),
+    )
+}
+
+/**
+ * Error icon. Uses [MaterialTheme.colorScheme.error].
+ */
+@Composable
+fun errorIcon(
+    contentDescription: String? = null,
+    size: Dp = 24.dp,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.Error,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.error,
+        modifier = modifier.size(size),
+    )
+}
+
+/**
+ * Warning icon. Uses [MaterialTheme.colorScheme.error] at 80% opacity.
+ */
+@Composable
+fun warningIcon(
+    contentDescription: String? = null,
+    size: Dp = 24.dp,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.Warning,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
+        modifier = modifier.size(size),
+    )
+}
+
+/**
+ * Info icon. Uses [MaterialTheme.colorScheme.onSurfaceVariant].
+ */
+@Composable
+fun infoIcon(
+    contentDescription: String? = null,
+    size: Dp = 24.dp,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.Info,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier.size(size),
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Action icons  (menus, toolbars, context actions)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Delete / remove action. Uses [MaterialTheme.colorScheme.error].
+ */
+@Composable
+fun deleteIcon(
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.Delete,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.error,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Edit / rename action. Uses [MaterialTheme.colorScheme.onSurfaceVariant].
+ */
+@Composable
+fun editIcon(
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.Edit,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Share / export action. Uses [MaterialTheme.colorScheme.onSurfaceVariant].
+ */
+@Composable
+fun shareIcon(
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.Share,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Copy action. Switches between copy and checkmark when [copied] is true.
+ * Uses [MaterialTheme.colorScheme.onSurfaceVariant].
+ */
+@Composable
+fun copyIcon(
+    copied: Boolean = false,
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = if (copied) Icons.Default.CheckCircle else Icons.Default.ContentCopy,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Overflow / more-options (⋮). Uses [MaterialTheme.colorScheme.onSurfaceVariant].
+ */
+@Composable
+fun moreOptionsIcon(
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.MoreVert,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Close / dismiss. Uses [MaterialTheme.colorScheme.onSurfaceVariant].
+ */
+@Composable
+fun closeIcon(
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.Close,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain-specific icons
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Star / pin icon for starred/pinned items in menus and lists.
+ * Uses onSurfaceVariant — NOT primary (invisible in dark theme).
+ */
+@Composable
+fun starIcon(
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.Star,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Folder / project icon. Uses [MaterialTheme.colorScheme.onSurfaceVariant].
+ */
+@Composable
+fun folderIcon(
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.Default.FolderOpen,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Chat / session icon. Uses [MaterialTheme.colorScheme.onSurfaceVariant].
+ */
+@Composable
+fun chatIcon(
+    contentDescription: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = Icons.AutoMirrored.Filled.Chat,
+        contentDescription = contentDescription,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/NewProjectDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/NewProjectDialog.kt
@@ -70,6 +70,7 @@ private const val SUCCESS_COUNTDOWN_SECONDS = 5
 fun newProjectDialog(
     onDismiss: () -> Unit,
     onCreateProject: (name: String, description: String?) -> Unit,
+    onNavigateToProject: ((projectId: String) -> Unit)? = null,
     projectService: ProjectService = GlobalContext.get().get(),
 ) {
     var projectName by remember { mutableStateOf("") }
@@ -167,6 +168,12 @@ fun newProjectDialog(
                     createdProject.name,
                     createdProject.description,
                 )
+
+                // Navigate immediately if handler provided (skips countdown screen)
+                if (onNavigateToProject != null) {
+                    onDismiss()
+                    onNavigateToProject(createdProject.id)
+                }
             } catch (e: Exception) {
                 log.error("Failed to create project", e)
                 dialogState.setError(e, errorCreateFailed.format(e.message ?: "Unknown error"))

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectsView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/project/ProjectsView.kt
@@ -4,6 +4,7 @@
  */
 package io.askimo.ui.project
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
@@ -119,6 +120,13 @@ fun projectsView(
                         Text(stringResource("project.new"))
                     }
                 }
+
+                Text(
+                    text = stringResource("projects.description"),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 6.dp, bottom = 4.dp),
+                )
 
                 Spacer(modifier = Modifier.height(16.dp))
 
@@ -280,6 +288,10 @@ private fun projectTable(
         shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 1.dp,
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.outlineVariant,
+        ),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsView.kt
@@ -4,6 +4,7 @@
  */
 package io.askimo.ui.session
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
@@ -277,6 +278,7 @@ private fun sessionTable(
         shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surface,
         tonalElevation = 1.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
@@ -133,6 +133,7 @@ fun navigationSidebar(
     onNavigateToSessions: () -> Unit,
     onNavigateToPlans: () -> Unit = {},
     onNavigateToSkills: () -> Unit = {},
+    onNewProject: () -> Unit = {},
     onSelectProject: (String) -> Unit = {},
     onResumeSession: (String) -> Unit,
     onDeleteSession: (String) -> Unit,
@@ -173,6 +174,7 @@ fun navigationSidebar(
             onNavigateToSessions = onNavigateToSessions,
             onNavigateToPlans = onNavigateToPlans,
             onNavigateToSkills = onNavigateToSkills,
+            onNewProject = onNewProject,
             onSelectProject = onSelectProject,
             onResumeSession = onResumeSession,
             onDeleteSession = onDeleteSession,
@@ -231,6 +233,7 @@ private fun expandedNavigationSidebar(
     onNavigateToSessions: () -> Unit,
     onNavigateToPlans: () -> Unit,
     onNavigateToSkills: () -> Unit,
+    onNewProject: () -> Unit,
     onSelectProject: (String) -> Unit,
     onResumeSession: (String) -> Unit,
     onDeleteSession: (String) -> Unit,
@@ -313,16 +316,42 @@ private fun expandedNavigationSidebar(
 
             // Projects
             if (showProjectsInSidebar) {
-                NavigationDrawerItem(
-                    icon = { Icon(Icons.Default.FolderOpen, contentDescription = null) },
-                    label = { Text(stringResource("project.title"), style = MaterialTheme.typography.labelLarge) },
-                    selected = isProjectsSelected,
-                    onClick = onToggleProjects,
+                val projectsInteractionSource = remember { MutableInteractionSource() }
+                val isProjectsHovered by projectsInteractionSource.collectIsHoveredAsState()
+
+                Box(
                     modifier = Modifier
                         .padding(horizontal = (12 * fontScale).dp)
-                        .pointerHoverIcon(PointerIcon.Hand),
-                    colors = AppComponents.navigationDrawerItemColors(),
-                )
+                        .hoverable(projectsInteractionSource),
+                ) {
+                    NavigationDrawerItem(
+                        icon = { Icon(Icons.Default.FolderOpen, contentDescription = null) },
+                        label = { Text(stringResource("project.title"), style = MaterialTheme.typography.labelLarge) },
+                        selected = isProjectsSelected,
+                        onClick = onToggleProjects,
+                        badge = {
+                            if (isProjectsHovered) {
+                                themedTooltip(text = stringResource("project.new.dialog.title")) {
+                                    IconButton(
+                                        onClick = onNewProject,
+                                        modifier = Modifier
+                                            .size(24.dp)
+                                            .pointerHoverIcon(PointerIcon.Hand),
+                                    ) {
+                                        Icon(
+                                            Icons.Default.Add,
+                                            contentDescription = stringResource("project.new.dialog.title"),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.size(18.dp),
+                                        )
+                                    }
+                                }
+                            }
+                        },
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                        colors = AppComponents.navigationDrawerItemColors(),
+                    )
+                }
             }
 
             // Plans
@@ -770,7 +799,7 @@ private fun pinnedProjectItem(
             AppComponents.dropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
                 DropdownMenuItem(
                     text = { Text(stringResource("action.unpin")) },
-                    leadingIcon = { Icon(Icons.Default.Star, contentDescription = null, tint = MaterialTheme.colorScheme.primary) },
+                    leadingIcon = { Icon(Icons.Default.Star, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
                     onClick = {
                         showMenu = false
                         onUnpin()
@@ -880,7 +909,7 @@ private fun pinnedSessionItem(
             ) {
                 DropdownMenuItem(
                     text = { Text(stringResource("action.unpin")) },
-                    leadingIcon = { Icon(Icons.Default.Star, contentDescription = null, tint = MaterialTheme.colorScheme.primary) },
+                    leadingIcon = { Icon(Icons.Default.Star, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
                     onClick = {
                         showMenu = false
                         onUnpin()

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -182,6 +182,7 @@ project.not.selected=No project selected
 
 # Projects View
 projects.title=Projects
+projects.description=Organize your chats around a topic and attach files, folders, or URLs as knowledge sources, so the AI always has the right context for that project.
 projects.error=❌ {0}
 projects.empty=No projects found.
 projects.empty.hint=💡Create a new project to organize your chat sessions!

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -182,6 +182,7 @@ project.not.selected=Kein Projekt ausgewählt
 
 # Projects View
 projects.title=Projekte
+projects.description=Organisieren Sie Ihre Chats rund um ein Thema und hängen Sie Dateien, Ordner oder URLs als Wissensquellen an, damit die KI immer den richtigen Kontext für das jeweilige Projekt hat.
 projects.error=❌ {0}
 projects.empty=Keine Projekte gefunden.
 projects.empty.hint=💡 Erstellen Sie ein neues Projekt, um Ihre Chat-Sitzungen zu organisieren!

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -180,8 +180,10 @@ project.delete.confirm.button=Eliminar proyecto
 project.delete.confirm.cancel=Cancelar
 project.not.found=Proyecto no encontrado
 project.not.selected=No se ha seleccionado ningún proyecto
+
 # Projects View
 projects.title=Proyectos
+projects.description=Organiza tus chats en torno a un tema y adjunta archivos, carpetas o URL como fuentes de conocimiento, para que la IA siempre tenga el contexto adecuado para ese proyecto.
 projects.error=❌ {0}
 projects.empty=No se encontraron proyectos.
 projects.empty.hint=💡 ¡Crea un nuevo proyecto para organizar tus sesiones de chat!

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -180,8 +180,10 @@ project.delete.confirm.button=Supprimer le projet
 project.delete.confirm.cancel=Annuler
 project.not.found=Projet introuvable
 project.not.selected=Aucun projet sélectionné
+
 # Projects View
 projects.title=Projets
+projects.description=Organisez vos discussions autour d'un sujet et joignez des fichiers, des dossiers ou des URL comme sources de connaissances, afin que l'IA dispose toujours du contexte approprié pour ce projet.
 projects.error=❌ {0}
 projects.empty=Aucun projet trouvé.
 projects.empty.hint=💡 Créez un nouveau projet pour organiser vos sessions de chat !

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -182,6 +182,7 @@ project.not.selected=プロジェクトが選択されていません
 
 # Projects View
 projects.title=プロジェクト
+projects.description=トピックごとにチャットを整理し、知識ソースとしてファイル、フォルダ、またはURLを添付することで、AIが常にそのプロジェクトに適切なコンテキストを把握できるようにします。
 projects.error=❌ {0}
 projects.empty=プロジェクトが見つかりません。
 projects.empty.hint=💡 新しいプロジェクトを作成して、チャットセッションを整理しましょう！

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -183,6 +183,7 @@ project.not.selected=선택된 프로젝트가 없습니다
 
 # Projects View
 projects.title=프로젝트
+projects.description=주제별로 채팅을 구성하고 파일, 폴더 또는 URL을 지식 소스로 첨부하여, AI가 항상 해당 프로젝트에 대한 올바른 컨텍스트를 갖도록 합니다.
 projects.error=❌ {0}
 projects.empty=프로젝트를 찾을 수 없습니다.
 projects.empty.hint=💡 새 프로젝트를 생성하여 채팅 세션을 정리하세요!

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -182,6 +182,7 @@ project.not.selected=Nenhum projeto selecionado
 
 # Projects View
 projects.title=Projetos
+projects.description=Organize seus chats em torno de um tópico e anexe arquivos, pastas ou URLs como fontes de conhecimento, para que a IA sempre tenha o contexto certo para esse projeto.
 projects.error=❌ {0}
 projects.empty=Nenhum projeto encontrado.
 projects.empty.hint=💡 Crie um novo projeto para organizar suas sessões de chat!

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -182,6 +182,7 @@ project.not.selected=Chưa chọn dự án nào
 
 # Projects View
 projects.title=Dự án
+projects.description=Tổ chức các cuộc trò chuyện của bạn xoay quanh một chủ đề và đính kèm các tệp, thư mục hoặc URL làm nguồn kiến thức, để AI luôn có đúng ngữ cảnh cho dự án đó.
 projects.error=❌ {0}
 projects.empty=Không tìm thấy dự án nào.
 projects.empty.hint=💡 Tạo dự án mới để tổ chức các phiên trò chuyện!

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -182,6 +182,7 @@ project.not.selected=未选择项目
 
 # Projects View
 projects.title=项目
+projects.description=围绕主题组织您的聊天，并将文件、文件夹或 URL 作为知识源附加，以便 AI 始终掌握该项目的正确上下文。
 projects.error=❌ {0}
 projects.empty=未找到任何项目。
 projects.empty.hint=💡 创建一个新项目来组织你的聊天会话！

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -182,6 +182,7 @@ project.not.selected=尚未選擇專案
 
 # Projects View
 projects.title=專案
+projects.description=圍繞主題組織您的聊天，並將檔案、資料夾或 URL 作為知識來源附加，以便 AI 始終掌握該專案的正確上下文。
 projects.error=❌ {0}
 projects.empty=找不到任何專案。
 projects.empty.hint=💡 建立新專案以整理你的聊天工作階段！

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -100,6 +99,7 @@ import io.askimo.ui.chat.chatView
 import io.askimo.ui.common.components.dangerButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
+import io.askimo.ui.common.components.successIcon
 import io.askimo.ui.common.dialog.errorDialog
 import io.askimo.ui.common.dialog.updateCheckDialog
 import io.askimo.ui.common.i18n.provideLocalization
@@ -1443,12 +1443,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                         horizontalArrangement = Arrangement.spacedBy(12.dp),
                                         verticalAlignment = Alignment.Top,
                                     ) {
-                                        Icon(
-                                            imageVector = Icons.Default.CheckCircle,
-                                            contentDescription = null,
-                                            tint = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(32.dp),
-                                        )
+                                        successIcon(size = 32.dp)
                                         Column(
                                             verticalArrangement = Arrangement.spacedBy(8.dp),
                                             modifier = Modifier.weight(1f),
@@ -1670,6 +1665,12 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                             onDismiss = { showNewProjectDialog = false },
                             onCreateProject = { _, _ ->
                                 projectsViewModel.refresh()
+                            },
+                            onNavigateToProject = { projectId ->
+                                showNewProjectDialog = false
+                                projectsViewModel.refresh()
+                                selectedProjectId = projectId
+                                currentView = View.PROJECT_DETAIL
                             },
                         )
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
@@ -107,6 +107,7 @@ fun navigationSidebar(
         onNavigateToSessions = onNavigateToSessions,
         onNavigateToPlans = onNavigateToPlans,
         onNavigateToSkills = onNavigateToSkills,
+        onNewProject = onNewProject,
         onSelectProject = onSelectProject,
         onResumeSession = onResumeSession,
         onDeleteSession = onDeleteSession,


### PR DESCRIPTION
- Add a new icon component for project-related icons in desktop-shared.
- Expose an `onNewProject` callback in the navigation sidebar to create projects.
- Add `projects.description` strings to all i18n resource files for better context guidance.
- Update the NewProjectDialog to accept an optional `onNavigateToProject` handler that skips the countdown screen.
- Improve border styling of project and session tables for a cleaner UI.
- Update success icon usage in the main app startup UI.