### PR TITLE
feat(ui): update dialog dimensions and UI layout styling

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.event.EventBus
@@ -945,10 +946,15 @@ fun aiMessageEditDialog(
 ) {
     var editedContent by remember { mutableStateOf(message.content) }
 
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+        ),
+    ) {
         Surface(
             modifier = Modifier
-                .width(700.dp)
+                .width(900.dp)
                 .padding(16.dp),
             shape = MaterialTheme.shapes.large,
             tonalElevation = 8.dp,
@@ -970,7 +976,7 @@ fun aiMessageEditDialog(
                     onValueChange = { editedContent = it },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(400.dp),
+                        .height(600.dp),
                     textStyle = MaterialTheme.typography.bodyMedium,
                     colors = AppComponents.outlinedTextFieldColors(),
                     label = { Text(stringResource("message.ai.edit.content.label")) },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/CodeViewerBlock.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/CodeViewerBlock.kt
@@ -4,7 +4,9 @@
  */
 package io.askimo.ui.common.ui
 
+import androidx.compose.foundation.HorizontalScrollbar
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
@@ -17,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -76,41 +79,41 @@ fun codeViewerBlock(
     }
     val dividerColor = Color(lineNumberColor.red, lineNumberColor.green, lineNumberColor.blue, 0.15f)
 
-    // Row height is driven by content (IntrinsicSize.Min).
-    // Vertical scrolling is handled by the caller — this composable only manages horizontal scrolling.
-    Row(
-        modifier = modifier
-            .background(backgroundColor)
-            .height(IntrinsicSize.Min),
-    ) {
-        // ── Gutter: line numbers ──────────────────────────────────────────────
-        Column(
+    // Outer Column: code row + scrollbar below
+    Column(modifier = modifier.background(backgroundColor)) {
+        // ── Code row (gutter + content) ───────────────────────────────────────
+        Row(
             modifier = Modifier
-                .width(lineNumberWidth)
-                .fillMaxHeight()
-                .background(gutterBackground)
-                .padding(vertical = 12.dp),
-            horizontalAlignment = Alignment.End,
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min),
         ) {
-            lines.forEachIndexed { index, _ ->
-                Text(
-                    text = "${index + 1}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontFamily = FontFamily.Monospace,
-                    color = lineNumberColor,
-                    modifier = Modifier.padding(end = 8.dp),
-                )
+            // ── Gutter: line numbers ──────────────────────────────────────────
+            Column(
+                modifier = Modifier
+                    .width(lineNumberWidth)
+                    .fillMaxHeight()
+                    .background(gutterBackground)
+                    .padding(vertical = 12.dp),
+                horizontalAlignment = Alignment.End,
+            ) {
+                lines.forEachIndexed { index, _ ->
+                    Text(
+                        text = "${index + 1}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontFamily = FontFamily.Monospace,
+                        color = lineNumberColor,
+                        modifier = Modifier.padding(end = 8.dp),
+                    )
+                }
             }
-        }
 
-        Box(
-            modifier = Modifier
-                .width(1.dp)
-                .fillMaxHeight()
-                .background(dividerColor),
-        )
+            Box(
+                modifier = Modifier
+                    .width(1.dp)
+                    .fillMaxHeight()
+                    .background(dividerColor),
+            )
 
-        Box(modifier = Modifier.weight(1f)) {
             Text(
                 text = highlightedCode,
                 style = MaterialTheme.typography.bodyMedium,
@@ -118,10 +121,25 @@ fun codeViewerBlock(
                 color = contentColor,
                 softWrap = false,
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .weight(1f)
                     .horizontalScroll(hScrollState)
-                    .padding(top = 12.dp, bottom = 20.dp, start = 12.dp, end = 12.dp),
+                    .padding(top = 12.dp, bottom = 12.dp, start = 12.dp, end = 12.dp),
             )
         }
+
+        HorizontalScrollbar(
+            adapter = rememberScrollbarAdapter(hScrollState),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 4.dp, vertical = 2.dp),
+            style = ScrollbarStyle(
+                minimalHeight = 16.dp,
+                thickness = 6.dp,
+                shape = MaterialTheme.shapes.small,
+                hoverDurationMillis = 150,
+                unhoverColor = contentColor.copy(alpha = 0.20f),
+                hoverColor = contentColor.copy(alpha = 0.50f),
+            ),
+        )
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ExportSessionDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ExportSessionDialog.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.export.ExportFormat
@@ -113,10 +114,13 @@ fun exportSessionDialog(
             showFileBrowser = false
         }
     }
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
         Surface(
             modifier = Modifier
-                .width(550.dp)
+                .width(600.dp)
                 .padding(16.dp),
             shape = MaterialTheme.shapes.large,
             tonalElevation = 8.dp,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
@@ -9,9 +9,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -28,7 +28,6 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -48,6 +47,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import io.askimo.core.chat.domain.ChatDirective
 import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.components.primaryButton
@@ -68,12 +68,7 @@ fun manageDirectivesDialog(
     var editContent by remember { mutableStateOf("") }
     var editError by remember { mutableStateOf<String?>(null) }
 
-    var isAdding by remember { mutableStateOf(false) }
-    var newName by remember { mutableStateOf("") }
-    var newContent by remember { mutableStateOf("") }
-    var newApplyToCurrent by remember { mutableStateOf(false) }
-    var newNameError by remember { mutableStateOf<String?>(null) }
-    var newContentError by remember { mutableStateOf<String?>(null) }
+    var showNewDirectiveDialog by remember { mutableStateOf(false) }
 
     // Track which directives have expanded content
     var expandedDirectives by remember { mutableStateOf<Set<String>>(emptySet()) }
@@ -82,16 +77,32 @@ fun manageDirectivesDialog(
     val nameRequiredError = stringResource("directive.edit.name.required")
     val contentRequiredError = stringResource("directive.edit.content.required")
 
-    Dialog(onDismissRequest = onDismiss) {
+    if (showNewDirectiveDialog) {
+        newDirectiveDialog(
+            onDismiss = { showNewDirectiveDialog = false },
+            onConfirm = { name, content, applyToCurrent ->
+                onAdd(name, content, applyToCurrent)
+                showNewDirectiveDialog = false
+            },
+        )
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
         Surface(
             modifier = Modifier
-                .width(700.dp)
+                .width(900.dp)
+                .height(700.dp)
                 .padding(16.dp),
             shape = MaterialTheme.shapes.large,
             tonalElevation = 8.dp,
         ) {
             Column(
-                modifier = Modifier.padding(24.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 // Title
@@ -109,30 +120,28 @@ fun manageDirectivesDialog(
                         onClick = onDismiss,
                         modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
-                        Icon(
-                            Icons.Default.Close,
-                            contentDescription = stringResource("action.close"),
-                        )
+                        Icon(Icons.Default.Close, contentDescription = stringResource("action.close"))
                     }
                 }
 
                 HorizontalDivider()
 
                 // Directives list
-                if (directives.isEmpty() && !isAdding) {
+                if (directives.isEmpty()) {
                     Text(
                         text = stringResource("directive.manage.empty"),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier
                             .fillMaxWidth()
+                            .weight(1f)
                             .padding(vertical = 32.dp),
                     )
                 } else {
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .heightIn(max = 400.dp),
+                            .weight(1f),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         items(directives, key = { it.id }) { directive ->
@@ -150,13 +159,11 @@ fun manageDirectivesDialog(
                                         .animateContentSize(),
                                     verticalArrangement = Arrangement.spacedBy(8.dp),
                                 ) {
-                                    // Directive name row with icon badge and action buttons
                                     Row(
                                         modifier = Modifier.fillMaxWidth(),
                                         horizontalArrangement = Arrangement.SpaceBetween,
                                         verticalAlignment = Alignment.CenterVertically,
                                     ) {
-                                        // Icon badge + name
                                         Row(
                                             verticalAlignment = Alignment.CenterVertically,
                                             horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -182,43 +189,30 @@ fun manageDirectivesDialog(
                                         }
 
                                         if (editingDirective != directive.id) {
-                                            Row(
-                                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                            ) {
+                                            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                                                 IconButton(
                                                     onClick = {
                                                         editingDirective = directive.id
                                                         editName = directive.name
                                                         editContent = directive.content
                                                         editError = null
-                                                        isAdding = false
                                                     },
                                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                                 ) {
-                                                    Icon(
-                                                        Icons.Default.Edit,
-                                                        contentDescription = stringResource("action.edit"),
-                                                        tint = MaterialTheme.colorScheme.onSurface,
-                                                    )
+                                                    Icon(Icons.Default.Edit, contentDescription = stringResource("action.edit"), tint = MaterialTheme.colorScheme.onSurface)
                                                 }
                                                 IconButton(
                                                     onClick = { onDelete(directive.id) },
                                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                                 ) {
-                                                    Icon(
-                                                        Icons.Default.Delete,
-                                                        contentDescription = stringResource("action.delete"),
-                                                        tint = MaterialTheme.colorScheme.error,
-                                                    )
+                                                    Icon(Icons.Default.Delete, contentDescription = stringResource("action.delete"), tint = MaterialTheme.colorScheme.error)
                                                 }
                                             }
                                         }
                                     }
 
                                     if (editingDirective == directive.id) {
-                                        Column(
-                                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                                        ) {
+                                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                                             OutlinedTextField(
                                                 value = editName,
                                                 onValueChange = {
@@ -238,9 +232,7 @@ fun manageDirectivesDialog(
                                                     editContent = it
                                                     editError = null
                                                 },
-                                                modifier = Modifier
-                                                    .fillMaxWidth()
-                                                    .height(200.dp),
+                                                modifier = Modifier.fillMaxWidth().height(200.dp),
                                                 label = { Text(stringResource("directive.edit.content.label")) },
                                                 placeholder = { Text(stringResource("directive.edit.content.placeholder")) },
                                                 maxLines = 10,
@@ -248,48 +240,35 @@ fun manageDirectivesDialog(
                                                 supportingText = editError?.let { { Text(it) } },
                                                 colors = AppComponents.outlinedTextFieldColors(),
                                             )
-
-                                            // Action buttons for edit mode
                                             Row(
                                                 modifier = Modifier.fillMaxWidth(),
                                                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
                                                 verticalAlignment = Alignment.CenterVertically,
                                             ) {
-                                                secondaryButton(
-                                                    onClick = {
+                                                secondaryButton(onClick = {
+                                                    editingDirective = null
+                                                    editName = ""
+                                                    editContent = ""
+                                                    editError = null
+                                                }) { Text(stringResource("settings.cancel")) }
+
+                                                primaryButton(onClick = {
+                                                    if (editName.isBlank()) {
+                                                        editError = nameRequiredError
+                                                    } else if (editContent.isBlank()) {
+                                                        editError = contentRequiredError
+                                                    } else {
+                                                        onUpdate(directive.id, editName.trim(), editContent.trim())
                                                         editingDirective = null
                                                         editName = ""
                                                         editContent = ""
                                                         editError = null
-                                                    },
-                                                ) {
-                                                    Text(stringResource("settings.cancel"))
-                                                }
-
-                                                primaryButton(
-                                                    onClick = {
-                                                        if (editName.isBlank()) {
-                                                            editError = nameRequiredError
-                                                        } else if (editContent.isBlank()) {
-                                                            editError = contentRequiredError
-                                                        } else {
-                                                            onUpdate(directive.id, editName.trim(), editContent.trim())
-                                                            editingDirective = null
-                                                            editName = ""
-                                                            editContent = ""
-                                                            editError = null
-                                                        }
-                                                    },
-                                                ) {
-                                                    Text(stringResource("settings.save"))
-                                                }
+                                                    }
+                                                }) { Text(stringResource("settings.save")) }
                                             }
                                         }
                                     } else {
-                                        // Display mode: expandable content
-                                        Column(
-                                            verticalArrangement = Arrangement.spacedBy(6.dp),
-                                        ) {
+                                        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                                             Text(
                                                 text = directive.content,
                                                 style = MaterialTheme.typography.bodyMedium,
@@ -297,7 +276,6 @@ fun manageDirectivesDialog(
                                                 maxLines = if (isExpanded) Int.MAX_VALUE else 3,
                                                 overflow = if (isExpanded) TextOverflow.Clip else TextOverflow.Ellipsis,
                                             )
-                                            // Show more / Show less toggle (only if content is long enough)
                                             if (directive.content.length > 120 || directive.content.lines().size > 3) {
                                                 Text(
                                                     text = if (isExpanded) stringResource("action.show.less") else stringResource("action.show.more"),
@@ -314,8 +292,6 @@ fun manageDirectivesDialog(
                                                         },
                                                 )
                                             }
-
-                                            // Created date as chip
                                             AssistChip(
                                                 onClick = {},
                                                 label = {
@@ -325,11 +301,7 @@ fun manageDirectivesDialog(
                                                     )
                                                 },
                                                 leadingIcon = {
-                                                    Icon(
-                                                        Icons.Outlined.Schedule,
-                                                        contentDescription = null,
-                                                        modifier = Modifier.size(14.dp),
-                                                    )
+                                                    Icon(Icons.Outlined.Schedule, contentDescription = null, modifier = Modifier.size(14.dp))
                                                 },
                                                 modifier = Modifier.height(28.dp),
                                                 colors = AssistChipDefaults.assistChipColors(
@@ -352,133 +324,18 @@ fun manageDirectivesDialog(
 
                 HorizontalDivider()
 
-                // Add directive section
-                if (isAdding) {
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Text(
-                            text = stringResource("directive.new.title"),
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Text(
-                            text = stringResource("directive.new.guidelines"),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        OutlinedTextField(
-                            value = newName,
-                            onValueChange = {
-                                newName = it
-                                newNameError = null
-                            },
-                            modifier = Modifier.fillMaxWidth(),
-                            label = { Text(stringResource("directive.edit.name.label")) },
-                            placeholder = { Text(stringResource("directive.new.name.placeholder")) },
-                            singleLine = true,
-                            isError = newNameError != null,
-                            supportingText = newNameError?.let { { Text(it) } },
-                            colors = AppComponents.outlinedTextFieldColors(),
-                        )
-                        OutlinedTextField(
-                            value = newContent,
-                            onValueChange = {
-                                newContent = it
-                                newContentError = null
-                            },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(150.dp),
-                            label = { Text(stringResource("directive.edit.content.label")) },
-                            placeholder = { Text(stringResource("directive.new.content.placeholder")) },
-                            maxLines = 8,
-                            isError = newContentError != null,
-                            supportingText = newContentError?.let { { Text(it) } },
-                            colors = AppComponents.outlinedTextFieldColors(),
-                        )
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            Checkbox(
-                                checked = newApplyToCurrent,
-                                onCheckedChange = { newApplyToCurrent = it },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                            )
-                            Text(
-                                text = stringResource("directive.new.apply.current"),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface,
-                            )
-                        }
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            secondaryButton(
-                                onClick = {
-                                    isAdding = false
-                                    newName = ""
-                                    newContent = ""
-                                    newApplyToCurrent = false
-                                    newNameError = null
-                                    newContentError = null
-                                },
-                            ) {
-                                Text(stringResource("settings.cancel"))
-                            }
-                            primaryButton(
-                                onClick = {
-                                    var hasError = false
-                                    if (newName.isBlank()) {
-                                        newNameError = nameRequiredError
-                                        hasError = true
-                                    }
-                                    if (newContent.isBlank()) {
-                                        newContentError = contentRequiredError
-                                        hasError = true
-                                    }
-                                    if (!hasError) {
-                                        onAdd(newName.trim(), newContent.trim(), newApplyToCurrent)
-                                        isAdding = false
-                                        newName = ""
-                                        newContent = ""
-                                        newApplyToCurrent = false
-                                        newNameError = null
-                                        newContentError = null
-                                    }
-                                },
-                            ) {
-                                Text(stringResource("directive.new.create"))
-                            }
-                        }
+                // Bottom bar
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    primaryButton(onClick = { showNewDirectiveDialog = true }) {
+                        Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Text(stringResource("directive.new.title"))
                     }
-                } else {
-                    // Bottom bar: Add button + Close
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        primaryButton(
-                            onClick = {
-                                isAdding = true
-                                editingDirective = null
-                            },
-                        ) {
-                            Icon(
-                                Icons.Default.Add,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp),
-                            )
-                            Text(stringResource("directive.new.title"))
-                        }
-                        secondaryButton(onClick = onDismiss) {
-                            Text(stringResource("action.close"))
-                        }
+                    secondaryButton(onClick = onDismiss) {
+                        Text(stringResource("action.close"))
                     }
                 }
             }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/NewDirectiveDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/NewDirectiveDialog.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
@@ -47,7 +48,12 @@ fun newDirectiveDialog(
     val nameRequiredError = stringResource("directive.edit.name.required")
     val contentRequiredError = stringResource("directive.edit.content.required")
 
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+        ),
+    ) {
         Surface(
             modifier = Modifier
                 .width(800.dp)
@@ -99,7 +105,7 @@ fun newDirectiveDialog(
                     placeholder = { Text(stringResource("directive.new.content.placeholder")) },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(150.dp),
+                        .height(250.dp),
                     maxLines = 8,
                     isError = contentError != null,
                     supportingText = contentError?.let { { Text(it) } },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionActionsMenu.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionActionsMenu.kt
@@ -42,6 +42,7 @@ import io.askimo.ui.shell.DeveloperModePreferences
  * @param onRenameSession Callback invoked when the rename action is triggered
  * @param onExportSession Callback invoked when the export action is triggered
  * @param onDeleteSession Callback invoked when the delete action is triggered
+ * @param onStarSession Callback invoked when the star action is triggered
  * @param onShowSessionSummary Callback invoked when the show session summary action is triggered (developer mode only)
  * @param onMoveSessionToNewProject Callback invoked when the session is moved to a new project
  * @param modifier Optional modifier for the IconButton
@@ -58,6 +59,7 @@ fun sessionActionsMenu(
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
 
     val sessionRepository = remember { DatabaseManager.getInstance().getChatSessionRepository() }
     val projectRepository = remember { DatabaseManager.getInstance().getProjectRepository() }
@@ -244,8 +246,8 @@ fun sessionActionsMenu(
                     )
                 },
                 onClick = {
-                    onDeleteSession(sessionId)
                     expanded = false
+                    showDeleteDialog = true
                 },
                 leadingIcon = {
                     Icon(
@@ -257,5 +259,16 @@ fun sessionActionsMenu(
                 modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
             )
         }
+    }
+
+    if (showDeleteDialog) {
+        deleteSessionDialog(
+            sessionTitle = currentSession?.title ?: sessionId,
+            onConfirm = {
+                showDeleteDialog = false
+                onDeleteSession(sessionId)
+            },
+            onDismiss = { showDeleteDialog = false },
+        )
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionMemoryDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionMemoryDialog.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import io.askimo.core.chat.domain.SessionMemory
 import io.askimo.core.logging.currentFileLogger
 import io.askimo.core.util.JsonUtils
@@ -79,7 +80,10 @@ fun sessionMemoryDialog(
         isLoading = false
     }
 
-    Dialog(onDismissRequest = onDismiss) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
         Surface(
             modifier = Modifier
                 .width(800.dp)

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/GeneralSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/GeneralSettingsSection.kt
@@ -199,7 +199,7 @@ private fun languageSelectionCard() {
                         url = crowdinUrl,
                         styles = TextLinkStyles(
                             style = SpanStyle(
-                                color = MaterialTheme.colorScheme.primary,
+                                color = MaterialTheme.colorScheme.onSurface,
                                 textDecoration = TextDecoration.Underline,
                             ),
                         ),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
@@ -80,6 +80,7 @@ import io.askimo.core.event.internal.SessionsRefreshEvent
 import io.askimo.core.user.domain.UserProfile
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.LocalFontScale
 import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.session.SessionActionMenu
@@ -785,7 +786,7 @@ private fun pinnedProjectItem(
         }
 
         Box(modifier = Modifier.align(Alignment.CenterEnd).padding(end = 8.dp)) {
-            AppComponents.dropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+            dropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
                 DropdownMenuItem(
                     text = { Text(stringResource("action.unpin")) },
                     leadingIcon = { Icon(Icons.Default.Star, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
@@ -892,7 +893,7 @@ private fun pinnedSessionItem(
         }
 
         Box(modifier = Modifier.align(Alignment.CenterEnd).padding(end = 8.dp)) {
-            AppComponents.dropdownMenu(
+            dropdownMenu(
                 expanded = showMenu,
                 onDismissRequest = { showMenu = false },
             ) {
@@ -1091,7 +1092,7 @@ private fun sessionItemWithMenu(
         }
 
         Box(modifier = Modifier.align(Alignment.CenterEnd).padding(end = 8.dp)) {
-            AppComponents.dropdownMenu(
+            dropdownMenu(
                 expanded = showMenu,
                 onDismissRequest = { showMenu = false },
             ) {

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ProjectSidePanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ProjectSidePanel.kt
@@ -78,6 +78,7 @@ import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.ui.themedTooltip
 import kotlinx.coroutines.flow.filterIsInstance
 import java.awt.Cursor
+import java.io.File
 
 /**
  * Tab types for the community project side panel.
@@ -339,7 +340,7 @@ private fun ragSourcesTabContent(
         EventBus.internalEvents
             .filterIsInstance<FilePreviewRequestEvent>()
             .collect { event ->
-                val file = java.io.File(event.filePath)
+                val file = File(event.filePath)
                 if (file.exists() && file.isFile) {
                     selectedNode = FileTreeNode(
                         path = event.filePath,

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/RagSourcesTree.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/RagSourcesTree.kt
@@ -567,7 +567,7 @@ private fun folderNodeItem(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(backgroundColor, androidx.compose.foundation.shape.RoundedCornerShape(4.dp))
+                        .background(backgroundColor, RoundedCornerShape(4.dp))
                         .onClick(matcher = PointerMatcher.mouse(PointerButton.Primary), onClick = {
                             expandedPaths[node.path] = !isExpanded
                             onNodeSelected(node)
@@ -644,7 +644,7 @@ private fun fileNodeItem(
             Row(
                 modifier = modifier
                     .fillMaxWidth()
-                    .background(backgroundColor, androidx.compose.foundation.shape.RoundedCornerShape(4.dp))
+                    .background(backgroundColor, RoundedCornerShape(4.dp))
                     .onClick(matcher = PointerMatcher.mouse(PointerButton.Primary), onClick = { onNodeSelected(node) }, onDoubleClick = { openInFileBrowser(node.path) })
                     .onClick(matcher = PointerMatcher.mouse(PointerButton.Secondary), onClick = { showContextMenu = true })
                     .padding(start = (level * 16 + 16).dp, top = 4.dp, bottom = 4.dp, end = 4.dp)
@@ -725,7 +725,7 @@ private fun urlNodeItem(
             Row(
                 modifier = modifier
                     .fillMaxWidth()
-                    .background(backgroundColor, androidx.compose.foundation.shape.RoundedCornerShape(4.dp))
+                    .background(backgroundColor, RoundedCornerShape(4.dp))
                     .onClick(matcher = PointerMatcher.mouse(PointerButton.Primary), onClick = { onNodeSelected(node) }, onDoubleClick = { openInBrowser(node.url) })
                     .onClick(matcher = PointerMatcher.mouse(PointerButton.Secondary), onClick = { showContextMenu = true })
                     .padding(start = (level * 16).dp, top = 4.dp, bottom = 4.dp, end = 4.dp)


### PR DESCRIPTION
- Increase size for the AI message edit dialog and new directive dialog to improve usability.
- Configure `DialogProperties` to allow custom widths instead of default platform bounds.
- Refactor the manage directives dialog for cleaner sizing and removal of unnecessary components.
- Update general settings language selection text color to improve contrast.
- Simplify class imports in `ProjectSidePanel` and `RagSourcesTree`.