### PR TITLE
refactor: increase directive limit and add install ping

### DIFF
--- a/cli/src/main/kotlin/io/askimo/cli/ChatCli.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/ChatCli.kt
@@ -89,6 +89,7 @@ fun main(args: Array<String>) {
     val appContext = AppContext.initialize(mode)
 
     Analytics.initialize()
+    Analytics.sendInstallPingIfNeeded()
     val hasRag = AskimoHome.projectsDir().toFile().let { it.exists() && (it.listFiles()?.isNotEmpty() == true) }
     Analytics.track(
         AnalyticsEvent.APP_STARTED,

--- a/cli/src/test/kotlin/io/askimo/core/chat/repository/ChatDirectiveRepositoryIT.kt
+++ b/cli/src/test/kotlin/io/askimo/core/chat/repository/ChatDirectiveRepositoryIT.kt
@@ -292,4 +292,19 @@ class ChatDirectiveRepositoryIT {
             assertEquals(maxContent, retrieved.content)
         }
     }
+
+    @Test
+    fun `should reject oversized content from server upsert`() {
+        val oversized = ChatDirective(
+            name = "from-server",
+            content = "a".repeat(DIRECTIVE_CONTENT_MAX_LENGTH + 1),
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            repository.upsertFromServer(listOf(oversized))
+        }
+
+        assertTrue(exception.message!!.contains("cannot exceed ${DIRECTIVE_CONTENT_MAX_LENGTH} characters"))
+        assertNull(repository.get(oversized.id))
+    }
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -468,6 +468,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
     // Initialize analytics first, then track retention and show star prompt
     LaunchedEffect(Unit) {
         Analytics.initialize()
+        Analytics.sendInstallPingIfNeeded()
         val hasRag = withContext(Dispatchers.IO) {
             AskimoHome.projectsDir().toFile().let { it.exists() && it.listFiles()?.isNotEmpty() == true }
         }

--- a/shared/src/main/kotlin/io/askimo/core/analytics/Analytics.kt
+++ b/shared/src/main/kotlin/io/askimo/core/analytics/Analytics.kt
@@ -4,8 +4,13 @@
  */
 package io.askimo.core.analytics
 
+import io.askimo.core.VersionInfo
 import io.askimo.core.config.AppConfig
 import io.askimo.core.logging.logger
+import io.askimo.core.util.AskimoHome
+import io.askimo.core.util.httpPost
+import java.net.http.HttpClient
+import java.nio.file.Files
 
 /**
  * Business analytics singleton — tracks anonymous feature usage for Askimo.t.
@@ -34,6 +39,9 @@ object Analytics {
 
     private lateinit var queue: AnalyticsQueue
     private lateinit var reporter: AnalyticsReporter
+
+    /** Flag file name written after a successful install ping. */
+    private const val INSTALL_PING_FILE = ".install_ping_sent"
 
     /** Epoch-ms at [initialize] time, used to bucket session duration in [trackSessionEnd]. */
     @Volatile private var sessionStartMs: Long = 0L
@@ -94,6 +102,44 @@ object Analytics {
             else -> return
         }
         track(AnalyticsEvent.RETURNING_USER, mapOf("launch_count_bucket" to bucket))
+    }
+
+    fun sendInstallPingIfNeeded() {
+        val flagPath = AskimoHome.base().resolve(INSTALL_PING_FILE)
+        val currentVersion = VersionInfo.version
+        // Re-send if the flag file is absent OR contains a different (older) version
+        if (Files.exists(flagPath) && runCatching { Files.readString(flagPath).trim() }.getOrNull() == currentVersion) return
+        val endpoint = AppConfig.analytics.endpoint
+        val payload = buildInstallPingPayload()
+        Thread({
+            runCatching {
+                val (status, _) = httpPost(
+                    url = endpoint,
+                    body = payload,
+                    connectTimeoutMs = 10_000,
+                    readTimeoutMs = 15_000,
+                    httpVersion = HttpClient.Version.HTTP_2,
+                )
+                if (status in 200..299) {
+                    runCatching {
+                        Files.createDirectories(flagPath.parent)
+                        // Write the current version so upgrades trigger a new ping
+                        Files.writeString(flagPath, currentVersion)
+                    }
+                    log.debug("Install ping sent for version $currentVersion (HTTP $status)")
+                } else {
+                    log.trace("Install ping HTTP $status — will retry on next launch")
+                }
+            }.onFailure { log.trace("Install ping failed: ${it.message} — will retry on next launch") }
+        }, "askimo-install-ping").also { it.isDaemon = true }.start()
+    }
+
+    private fun buildInstallPingPayload(): String {
+        val os = System.getProperty("os.name", "unknown")
+            .replace("\\", "\\\\").replace("\"", "\\\"")
+        val version = VersionInfo.version
+            .replace("\\", "\\\\").replace("\"", "\\\"")
+        return """[{"event":"${AnalyticsEvent.INSTALL_PING.eventName}","appVersion":"$version","os":"$os"}]"""
     }
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/analytics/AnalyticsEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/analytics/AnalyticsEvent.kt
@@ -326,6 +326,13 @@ enum class AnalyticsEvent(
         "analytics_opt_out",
         "User opted out of analytics.",
     ),
+
+    // ── Install ping ──────────────────────────────────────────────────────────
+
+    INSTALL_PING(
+        "install_ping",
+        "Anonymous one-time install count ping. Only appVersion and os are sent — no device identity.",
+    ),
     ;
 
     override fun toString(): String = eventName

--- a/shared/src/main/kotlin/io/askimo/core/chat/domain/ChatDirective.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/domain/ChatDirective.kt
@@ -36,7 +36,7 @@ data class ChatDirective(
 )
 
 const val DIRECTIVE_NAME_MAX_LENGTH = 128
-const val DIRECTIVE_CONTENT_MAX_LENGTH = 8192
+const val DIRECTIVE_CONTENT_MAX_LENGTH = 32768
 
 /**
  * Exposed table definition for chat_directives.
@@ -45,7 +45,9 @@ const val DIRECTIVE_CONTENT_MAX_LENGTH = 8192
 object ChatDirectivesTable : Table("chat_directives") {
     val id = varchar("id", 36)
     val name = varchar("name", DIRECTIVE_NAME_MAX_LENGTH)
-    val content = varchar("content", DIRECTIVE_CONTENT_MAX_LENGTH)
+
+    // Keep DB column unbounded TEXT; enforce max length at application layer.
+    val content = text("content")
 
     /** PERSONAL (default) or TEAM — stored as plain string for SQLite compatibility. */
     val scope = varchar("scope", 16).default(DirectiveScope.PERSONAL.name)

--- a/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatDirectiveRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatDirectiveRepository.kt
@@ -54,6 +54,15 @@ private fun ResultRow.toChatDirective(): ChatDirective = ChatDirective(
     deletedAt = this[ChatDirectivesTable.deletedAt],
 )
 
+private fun validateDirectiveLengths(directive: ChatDirective) {
+    require(directive.name.length <= DIRECTIVE_NAME_MAX_LENGTH) {
+        "Directive name cannot exceed $DIRECTIVE_NAME_MAX_LENGTH characters"
+    }
+    require(directive.content.length <= DIRECTIVE_CONTENT_MAX_LENGTH) {
+        "Directive content cannot exceed $DIRECTIVE_CONTENT_MAX_LENGTH characters"
+    }
+}
+
 /**
  * Repository for managing chat directives stored in SQLite database.
  */
@@ -66,12 +75,7 @@ class ChatDirectiveRepository internal constructor(
      * @throws IllegalArgumentException if name or content exceed max length
      */
     fun save(directive: ChatDirective): ChatDirective {
-        require(directive.name.length <= DIRECTIVE_NAME_MAX_LENGTH) {
-            "Directive name cannot exceed $DIRECTIVE_NAME_MAX_LENGTH characters"
-        }
-        require(directive.content.length <= DIRECTIVE_CONTENT_MAX_LENGTH) {
-            "Directive content cannot exceed $DIRECTIVE_CONTENT_MAX_LENGTH characters"
-        }
+        validateDirectiveLengths(directive)
 
         transaction(database) {
             ChatDirectivesTable.upsert {
@@ -113,12 +117,7 @@ class ChatDirectiveRepository internal constructor(
      * @return true if updated, false if directive doesn't exist
      */
     fun update(directive: ChatDirective): Boolean {
-        require(directive.name.length <= DIRECTIVE_NAME_MAX_LENGTH) {
-            "Directive name cannot exceed $DIRECTIVE_NAME_MAX_LENGTH characters"
-        }
-        require(directive.content.length <= DIRECTIVE_CONTENT_MAX_LENGTH) {
-            "Directive content cannot exceed $DIRECTIVE_CONTENT_MAX_LENGTH characters"
-        }
+        validateDirectiveLengths(directive)
 
         return transaction(database) {
             ChatDirectivesTable.update({ ChatDirectivesTable.id eq directive.id }) {
@@ -232,13 +231,14 @@ class ChatDirectiveRepository internal constructor(
                 }
 
             for (directive in directives) {
+                validateDirectiveLengths(directive)
                 val storedUpdatedAt = existingById[directive.id]
 
                 if (storedUpdatedAt == null) {
                     ChatDirectivesTable.insert {
                         it[id] = directive.id
-                        it[name] = directive.name.take(DIRECTIVE_NAME_MAX_LENGTH)
-                        it[content] = directive.content.take(DIRECTIVE_CONTENT_MAX_LENGTH)
+                        it[name] = directive.name
+                        it[content] = directive.content
                         it[scope] = directive.scope.name
                         it[createdBy] = directive.createdBy
                         it[createdAt] = directive.createdAt
@@ -248,8 +248,8 @@ class ChatDirectiveRepository internal constructor(
                     }
                 } else if (directive.updatedAt.isAfter(storedUpdatedAt)) {
                     ChatDirectivesTable.update({ ChatDirectivesTable.id eq directive.id }) {
-                        it[name] = directive.name.take(DIRECTIVE_NAME_MAX_LENGTH)
-                        it[content] = directive.content.take(DIRECTIVE_CONTENT_MAX_LENGTH)
+                        it[name] = directive.name
+                        it[content] = directive.content
                         it[scope] = directive.scope.name
                         it[createdBy] = directive.createdBy
                         it[updatedAt] = directive.updatedAt


### PR DESCRIPTION
- add Analytics.sendInstallPingIfNeeded invocation to CLI and Desktop startup
- introduce INSTALL_PING analytics event with payload
- increase ChatDirective content size limit from 8192 to 32768 chars
- adjust database column to unbounded TEXT and validate length with new constant
- add integration test ensuring oversized directives are rejected