### PR TITLE
refactor(provider): centralize chat model factory logic

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/reflect-config.json
@@ -919,7 +919,11 @@
   "name": "com.github.dockerjava.api.model.PeerNode",
   "allDeclaredFields": true,
   "queryAllDeclaredMethods": true,
-  "queryAllDeclaredConstructors": true
+  "queryAllDeclaredConstructors": true,
+  "methods": [ {
+    "name": "<init>",
+    "parameterTypes": [ ]
+  } ]
 }, {
   "name": "com.github.dockerjava.api.model.Ports",
   "allDeclaredFields": true,
@@ -4960,7 +4964,7 @@
     "parameterTypes": [ "dev.langchain4j.data.message.UserMessage", "dev.langchain4j.model.chat.request.ChatRequestParameters" ]
   } ]
 }, {
-  "name": "io.askimo.core.providers.ChatClient$MockitoMock$uLGJSYTf",
+  "name": "io.askimo.core.providers.ChatClient$MockitoMock$wLZJ0Hoy",
   "queryAllDeclaredConstructors": true,
   "methods": [ {
     "name": "<init>",
@@ -6232,6 +6236,9 @@
     "name": "countEntries",
     "parameterTypes": [ "java.lang.String", "java.lang.Boolean", "java.lang.Boolean" ]
   }, {
+    "name": "print",
+    "parameterTypes": [ "java.lang.String" ]
+  }, {
     "name": "readFile",
     "parameterTypes": [ "java.lang.String" ]
   }, {
@@ -7013,6 +7020,11 @@
     "name": "cellsBusy"
   } ]
 }, {
+  "name": "java.util.concurrent.atomic.Striped64$Cell",
+  "fields": [ {
+    "name": "value"
+  } ]
+}, {
   "name": "java.util.concurrent.locks.AbstractOwnableSynchronizer"
 }, {
   "name": "java.util.concurrent.locks.AbstractQueuedSynchronizer"
@@ -7705,7 +7717,7 @@
     "parameterTypes": [ ]
   } ]
 }, {
-  "name": "org.jline.reader.ParsedLine$MockitoMock$Qz4J2M8C",
+  "name": "org.jline.reader.ParsedLine$MockitoMock$orXQXFKw",
   "queryAllDeclaredConstructors": true,
   "methods": [ {
     "name": "<init>",

--- a/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
@@ -1,0 +1,223 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.providers
+
+import dev.langchain4j.http.client.jdk.JdkHttpClient
+import dev.langchain4j.memory.ChatMemory
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
+import dev.langchain4j.model.embedding.EmbeddingModel
+import dev.langchain4j.model.image.ImageModel
+import dev.langchain4j.model.openai.OpenAiChatModel
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
+import dev.langchain4j.model.openai.OpenAiImageModel
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel
+import dev.langchain4j.rag.content.retriever.ContentRetriever
+import dev.langchain4j.service.AiServices
+import dev.langchain4j.service.tool.ToolProvider
+import io.askimo.core.config.AppConfig
+import io.askimo.core.context.AppContext
+import io.askimo.core.context.ExecutionMode
+import io.askimo.core.telemetry.TelemetryChatModelListener
+import io.askimo.core.util.ProxyUtil
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.net.http.HttpClient
+import java.time.Duration
+
+/**
+ * Abstract base factory for all OpenAI-compatible API providers.
+ *
+ * Subclasses must implement [getProvider] and [defaultSettings].
+ * Everything else has a sensible default that can be selectively overridden.
+ *
+ * @param T Provider-specific settings. Must implement both [ProviderSettings] and [HasBaseUrl].
+ */
+abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
+    where T : ProviderSettings, T : HasBaseUrl {
+
+    /**
+     * Logger named after the concrete subclass so log output identifies the right factory.
+     * Resolved at construction time using the runtime class.
+     */
+    protected val log: Logger = LoggerFactory.getLogger(this::class.java)
+
+    // ── Template-method hooks ──────────────────────────────────────────────────
+
+    /**
+     * Returns the API key sent in every HTTP request to this provider.
+     *
+     * Local providers (Ollama, LocalAI, LmStudio, Docker AI) don't require a real key but
+     * include one as a placeholder to satisfy defensive null/blank checks in certain server
+     * implementations. The default value `"not-needed"` is safe for all such servers.
+     *
+     * Cloud providers (OpenAI-compatible with auth, xAI/Grok) override this to return the
+     * real key from [settings].
+     */
+    protected open fun resolveApiKey(settings: T): String = "not-needed"
+
+    /**
+     * HTTP protocol version used for all connections to this provider.
+     *
+     * Defaults to [HttpClient.Version.HTTP_2]. Override to [HttpClient.Version.HTTP_1_1]
+     * for servers that do not support HTTP/2 (e.g., LmStudio, Docker AI).
+     */
+    protected open fun httpVersion(): HttpClient.Version = HttpClient.Version.HTTP_2
+
+    /**
+     * Fallback model name used for the secondary/utility model when no explicit utility model
+     * is configured in [AppConfig].
+     *
+     * Defaults to [ProviderSettings.defaultModel]. Override for providers where the active
+     * model is tracked elsewhere (e.g., LmStudio and Docker AI read from AppContext.params.model).
+     */
+    protected open fun utilityModelFallback(settings: T): String = settings.defaultModel
+
+    /**
+     * Guards the model-list fetch in [availableModels].
+     *
+     * Return `false` to skip the HTTP call and return an empty list immediately.
+     * Use this when a prerequisite (e.g., base URL or API key) is not yet configured.
+     */
+    protected open fun canFetchModels(settings: T): Boolean = true
+
+    /**
+     * Template method for embedding model availability verification.
+     *
+     * **Local providers** (Ollama, LocalAI, LmStudio, Docker AI) override this to call
+     * [ensureLocalEmbeddingModelAvailable], which verifies the server is reachable and the
+     * requested model is pulled/available.
+     *
+     * **Remote / cloud providers** leave this as a no-op — the embedding endpoint is assumed
+     * to be available whenever the credentials are valid.
+     */
+    protected open fun checkEmbeddingAvailability(baseUrl: String, modelName: String) { /* no-op for remote providers */ }
+
+    /**
+     * Hook to apply additional configuration to the [OpenAiEmbeddingModelBuilder] before [build].
+     *
+     * The default is an identity transform (no changes).
+     * Override when the provider needs extra builder settings for embeddings
+     * (e.g., LmStudio injects an HTTP/1.1 client via [createHttpClientBuilder]).
+     */
+    protected open fun customizeEmbeddingBuilder(
+        settings: T,
+        builder: OpenAiEmbeddingModelBuilder,
+    ): OpenAiEmbeddingModelBuilder = builder
+
+    // ── Shared helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * Creates a JdkHttpClient builder configured with the correct HTTP version and proxy
+     * settings for this provider. Proxy is automatically bypassed for localhost URLs.
+     */
+    protected fun createHttpClientBuilder(baseUrl: String) = JdkHttpClient.builder().httpClientBuilder(
+        ProxyUtil.configureProxy(
+            HttpClient.newBuilder().version(httpVersion()),
+            baseUrl,
+        ),
+    )
+
+    // ── ChatModelFactory implementation ────────────────────────────────────────
+
+    override fun availableModels(settings: T): List<ModelDTO> {
+        if (!canFetchModels(settings)) return emptyList()
+        return ProviderModelUtils.fetchModels(
+            apiKey = resolveApiKey(settings),
+            url = "${settings.baseUrl.trimEnd('/')}/models",
+            providerName = getProvider(),
+            httpVersion = httpVersion(),
+        ).map { ModelDTO.of(getProvider(), it) }
+    }
+
+    override fun create(
+        sessionId: String?,
+        settings: T,
+        toolProvider: ToolProvider?,
+        retriever: ContentRetriever?,
+        executionMode: ExecutionMode,
+        chatMemory: ChatMemory?,
+    ): ChatClient = AiServiceBuilder.buildChatClient(
+        sessionId = sessionId,
+        settings = settings,
+        provider = getProvider(),
+        chatModel = createStreamingModel(settings),
+        secondaryChatModel = createSecondaryModel(settings),
+        chatMemory = chatMemory,
+        toolProvider = toolProvider,
+        retriever = retriever,
+        executionMode = executionMode,
+    )
+
+    override fun createStreamingModel(settings: T): StreamingChatModel {
+        val telemetry = AppContext.getInstance().telemetry
+        return OpenAiStreamingChatModel.builder()
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl))
+            .baseUrl(settings.baseUrl)
+            .apiKey(resolveApiKey(settings))
+            .modelName(settings.defaultModel)
+            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, getProvider().providerKey())))
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: T): ChatModel = OpenAiChatModel.builder()
+        .httpClientBuilder(createHttpClientBuilder(settings.baseUrl))
+        .baseUrl(settings.baseUrl)
+        .apiKey(resolveApiKey(settings))
+        .modelName(AppConfig.models[getProvider()].utilityModel.ifBlank { utilityModelFallback(settings) })
+        .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
+        .logger(log)
+        .logRequests(log.isDebugEnabled)
+        .build()
+
+    override fun createModel(settings: T): ChatModel {
+        val telemetry = AppContext.getInstance().telemetry
+        return OpenAiChatModel.builder()
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl))
+            .baseUrl(settings.baseUrl)
+            .apiKey(resolveApiKey(settings))
+            .modelName(settings.defaultModel)
+            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
+            .logger(log)
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isTraceEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, getProvider().providerKey())))
+            .build()
+    }
+
+    override fun createImageModel(settings: T): ImageModel = OpenAiImageModel.builder()
+        .baseUrl(settings.baseUrl)
+        .apiKey(resolveApiKey(settings))
+        .modelName(AppConfig.models[getProvider()].imageModel)
+        .logger(log)
+        .logRequests(log.isDebugEnabled)
+        .logResponses(log.isTraceEnabled)
+        .build()
+
+    override fun createUtilityClient(settings: T): ChatClient = AiServices.builder(ChatClient::class.java)
+        .chatModel(createSecondaryModel(settings))
+        .build()
+
+    override fun supportsEmbedding(): Boolean = true
+
+    override fun createEmbeddingModel(settings: T): EmbeddingModel {
+        val baseUrl = settings.baseUrl.removeSuffix("/")
+        val modelName = AppConfig.models[getProvider()].embeddingModel
+        checkEmbeddingAvailability(baseUrl, modelName)
+        return customizeEmbeddingBuilder(
+            settings,
+            OpenAiEmbeddingModelBuilder()
+                .apiKey("not-needed")
+                .baseUrl(baseUrl)
+                .modelName(modelName),
+        ).build()
+    }
+
+    override fun getEmbeddingTokenLimit(settings: T): Int = LocalEmbeddingTokenLimits.resolve(AppConfig.models[getProvider()].embeddingModel)
+}

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -4,51 +4,29 @@
  */
 package io.askimo.core.providers.docker
 
-import dev.langchain4j.http.client.jdk.JdkHttpClient
-import dev.langchain4j.memory.ChatMemory
-import dev.langchain4j.model.chat.ChatModel
-import dev.langchain4j.model.chat.StreamingChatModel
-import dev.langchain4j.model.embedding.EmbeddingModel
-import dev.langchain4j.model.image.ImageModel
-import dev.langchain4j.model.openai.OpenAiChatModel
-import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
-import dev.langchain4j.model.openai.OpenAiImageModel
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import dev.langchain4j.rag.content.retriever.ContentRetriever
-import dev.langchain4j.service.AiServices
-import dev.langchain4j.service.tool.ToolProvider
-import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
-import io.askimo.core.context.ExecutionMode
-import io.askimo.core.logging.display
-import io.askimo.core.logging.logger
-import io.askimo.core.providers.AiServiceBuilder
-import io.askimo.core.providers.ChatClient
-import io.askimo.core.providers.ChatModelFactory
-import io.askimo.core.providers.LocalEmbeddingTokenLimits
-import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ModelProvider.DOCKER
-import io.askimo.core.providers.ProviderModelUtils.fetchModels
+import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.providers.ensureLocalEmbeddingModelAvailable
-import io.askimo.core.telemetry.TelemetryChatModelListener
-import io.askimo.core.util.ProxyUtil
 import java.net.http.HttpClient
-import java.time.Duration
 
-class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
-    private val log = logger<DockerAiModelFactory>()
+class DockerAiModelFactory : OpenAiCompatibleChatModelFactory<DockerAiSettings>() {
 
     override fun getProvider(): ModelProvider = DOCKER
 
-    override fun availableModels(settings: DockerAiSettings): List<ModelDTO> = fetchModels(
-        apiKey = "docker-ai",
-        url = "${settings.baseUrl}/models",
-        providerName = DOCKER,
-        httpVersion = HttpClient.Version.HTTP_1_1,
-    ).map { ModelDTO.of(DOCKER, it) }
-
     override fun defaultSettings(): DockerAiSettings = DockerAiSettings()
+
+    /** Docker AI does not support HTTP/2. */
+    override fun httpVersion(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+
+    /**
+     * When no explicit utility model is configured, fall back to whichever model is currently
+     * active in the session rather than [DockerAiSettings.defaultModel].
+     */
+    override fun utilityModelFallback(settings: DockerAiSettings): String = AppContext.getInstance().params.model
+
+    override fun checkEmbeddingAvailability(baseUrl: String, modelName: String) = ensureLocalEmbeddingModelAvailable(getProvider(), baseUrl, modelName)
 
     override fun getNoModelsHelpText(): String = """
         You may not have any models installed yet.
@@ -56,110 +34,4 @@ class DockerAiModelFactory : ChatModelFactory<DockerAiSettings> {
         Make sure Docker AI is running and has models available.
         Visit Docker AI documentation for model installation instructions.
     """.trimIndent()
-
-    override fun create(
-        sessionId: String?,
-        settings: DockerAiSettings,
-        toolProvider: ToolProvider?,
-        retriever: ContentRetriever?,
-        executionMode: ExecutionMode,
-        chatMemory: ChatMemory?,
-    ): ChatClient = AiServiceBuilder.buildChatClient(
-        sessionId = sessionId,
-        settings = settings,
-        provider = DOCKER,
-        chatModel = createStreamingModel(settings),
-        secondaryChatModel = createSecondaryModel(settings),
-        chatMemory = chatMemory,
-        toolProvider = toolProvider,
-        retriever = retriever,
-        executionMode = executionMode,
-    )
-
-    override fun createImageModel(
-        settings: DockerAiSettings,
-    ): ImageModel = OpenAiImageModel.builder()
-        .apiKey("docker-ai")
-        .baseUrl(settings.baseUrl)
-        .modelName(AppConfig.models[DOCKER].imageModel)
-        .logger(log)
-        .logRequests(log.isDebugEnabled)
-        .logResponses(log.isTraceEnabled)
-        .build()
-
-    override fun createStreamingModel(settings: DockerAiSettings): StreamingChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiStreamingChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, DOCKER.name.lowercase())))
-            .build()
-    }
-
-    override fun createSecondaryModel(settings: DockerAiSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey("docker-ai")
-            .modelName(AppConfig.models[DOCKER].utilityModel.ifBlank { AppContext.getInstance().params.model })
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
-            .build()
-    }
-
-    override fun createModel(settings: DockerAiSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey("docker-ai")
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .listeners(listOf(TelemetryChatModelListener(telemetry, DOCKER.name.lowercase())))
-            .build()
-    }
-
-    override fun createUtilityClient(
-        settings: DockerAiSettings,
-    ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryModel(settings))
-        .build()
-
-    override fun supportsEmbedding(): Boolean = true
-
-    override fun createEmbeddingModel(settings: DockerAiSettings): EmbeddingModel {
-        val baseUrl = settings.baseUrl.removeSuffix("/")
-        val modelName = AppConfig.models[DOCKER].embeddingModel
-
-        log.display(
-            """
-            ℹ️  Using Docker AI for embeddings
-               • Docker AI URL: $baseUrl
-               • Embedding model: $modelName
-               • Configure in askimo.yml: models.docker.embedding_model
-            """.trimIndent(),
-        )
-
-        ensureLocalEmbeddingModelAvailable(DOCKER, baseUrl, modelName)
-
-        return OpenAiEmbeddingModelBuilder()
-            .apiKey("not-needed")
-            .baseUrl(baseUrl)
-            .modelName(modelName)
-            .build()
-    }
-
-    override fun getEmbeddingTokenLimit(settings: DockerAiSettings): Int = LocalEmbeddingTokenLimits.resolve(AppConfig.models[DOCKER].embeddingModel)
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
@@ -4,173 +4,34 @@
  */
 package io.askimo.core.providers.lmstudio
 
-import dev.langchain4j.http.client.jdk.JdkHttpClient
-import dev.langchain4j.memory.ChatMemory
-import dev.langchain4j.model.chat.ChatModel
-import dev.langchain4j.model.chat.StreamingChatModel
-import dev.langchain4j.model.embedding.EmbeddingModel
-import dev.langchain4j.model.image.ImageModel
-import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
-import dev.langchain4j.model.openai.OpenAiImageModel
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import dev.langchain4j.rag.content.retriever.ContentRetriever
-import dev.langchain4j.service.AiServices
-import dev.langchain4j.service.tool.ToolProvider
-import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
-import io.askimo.core.context.ExecutionMode
-import io.askimo.core.logging.display
-import io.askimo.core.logging.logger
-import io.askimo.core.providers.AiServiceBuilder
-import io.askimo.core.providers.ChatClient
-import io.askimo.core.providers.ChatModelFactory
-import io.askimo.core.providers.LocalEmbeddingTokenLimits
-import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ModelProvider.LMSTUDIO
-import io.askimo.core.providers.ProviderModelUtils.fetchModels
+import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.providers.ensureLocalEmbeddingModelAvailable
-import io.askimo.core.telemetry.TelemetryChatModelListener
-import io.askimo.core.util.ProxyUtil
 import java.net.http.HttpClient
-import java.time.Duration
 
-class LmStudioModelFactory : ChatModelFactory<LmStudioSettings> {
-
-    private val log = logger<LmStudioModelFactory>()
+class LmStudioModelFactory : OpenAiCompatibleChatModelFactory<LmStudioSettings>() {
 
     override fun getProvider(): ModelProvider = LMSTUDIO
 
-    /**
-     * Creates a JdkHttpClient builder configured with proxy settings.
-     * Automatically skips proxy for localhost URLs.
-     */
-    private fun createHttpClientBuilder(baseUrl: String) = JdkHttpClient.builder().httpClientBuilder(
-        ProxyUtil.configureProxy(
-            HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1),
-            baseUrl,
-        ),
-    )
-
-    override fun availableModels(settings: LmStudioSettings): List<ModelDTO> = fetchModels(
-        apiKey = "lm-studio",
-        url = "${settings.baseUrl}/models",
-        providerName = LMSTUDIO,
-        httpVersion = HttpClient.Version.HTTP_1_1,
-    ).map { ModelDTO.of(LMSTUDIO, it) }
-
     override fun defaultSettings(): LmStudioSettings = LmStudioSettings()
 
-    override fun create(
-        sessionId: String?,
+    /** LmStudio does not support HTTP/2. */
+    override fun httpVersion(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+
+    /**
+     * When no explicit utility model is configured, fall back to whichever model is currently
+     * active in the session rather than [LmStudioSettings.defaultModel].
+     */
+    override fun utilityModelFallback(settings: LmStudioSettings): String = AppContext.getInstance().params.model
+
+    override fun checkEmbeddingAvailability(baseUrl: String, modelName: String) = ensureLocalEmbeddingModelAvailable(getProvider(), baseUrl, modelName)
+
+    /** LmStudio requires an HTTP/1.1 client on the embedding builder as well. */
+    override fun customizeEmbeddingBuilder(
         settings: LmStudioSettings,
-        toolProvider: ToolProvider?,
-        retriever: ContentRetriever?,
-        executionMode: ExecutionMode,
-        chatMemory: ChatMemory?,
-    ): ChatClient = AiServiceBuilder.buildChatClient(
-        sessionId = sessionId,
-        settings = settings,
-        provider = LMSTUDIO,
-        chatModel = createStreamingModel(settings),
-        secondaryChatModel = createSecondaryModel(settings),
-        chatMemory = chatMemory,
-        toolProvider = toolProvider,
-        retriever = retriever,
-        executionMode = executionMode,
-    )
-
-    override fun createImageModel(
-        settings: LmStudioSettings,
-    ): ImageModel {
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-
-        return OpenAiImageModel.builder()
-            .apiKey("lmstudio")
-            .baseUrl(settings.baseUrl)
-            .modelName(AppConfig.models[LMSTUDIO].imageModel)
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .build()
-    }
-
-    override fun createStreamingModel(settings: LmStudioSettings): StreamingChatModel {
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiStreamingChatModel.builder()
-            .baseUrl(settings.baseUrl)
-            .apiKey("lm-studio")
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, LMSTUDIO.name.lowercase())))
-            .build()
-    }
-
-    override fun createSecondaryModel(settings: LmStudioSettings): ChatModel {
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-        return OpenAiChatModel.builder()
-            .baseUrl(settings.baseUrl)
-            .apiKey("lm-studio")
-            .modelName(AppConfig.models[LMSTUDIO].utilityModel.ifBlank { AppContext.getInstance().params.model })
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .build()
-    }
-
-    override fun createModel(settings: LmStudioSettings): ChatModel {
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiChatModel.builder()
-            .baseUrl(settings.baseUrl)
-            .apiKey("lm-studio")
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, LMSTUDIO.name.lowercase())))
-            .build()
-    }
-
-    override fun createUtilityClient(
-        settings: LmStudioSettings,
-    ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryModel(settings))
-        .build()
-
-    override fun supportsEmbedding(): Boolean = true
-
-    override fun createEmbeddingModel(settings: LmStudioSettings): EmbeddingModel {
-        val baseUrl = settings.baseUrl.removeSuffix("/")
-        val modelName = AppConfig.models[LMSTUDIO].embeddingModel
-
-        log.display(
-            """
-            ℹ️  Using LMStudio for embeddings
-               • LMStudio URL: $baseUrl
-               • Embedding model: $modelName
-               • Configure in askimo.yml: models.lmstudio.embedding_model
-            """.trimIndent(),
-        )
-
-        ensureLocalEmbeddingModelAvailable(LMSTUDIO, baseUrl, modelName)
-
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-
-        return OpenAiEmbeddingModelBuilder()
-            .apiKey("not-needed")
-            .baseUrl(baseUrl)
-            .modelName(modelName)
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .build()
-    }
-
-    override fun getEmbeddingTokenLimit(settings: LmStudioSettings): Int = LocalEmbeddingTokenLimits.resolve(AppConfig.models[LMSTUDIO].embeddingModel)
+        builder: OpenAiEmbeddingModelBuilder,
+    ): OpenAiEmbeddingModelBuilder = builder.httpClientBuilder(createHttpClientBuilder(settings.baseUrl))
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiModelFactory.kt
@@ -4,156 +4,18 @@
  */
 package io.askimo.core.providers.localai
 
-import dev.langchain4j.http.client.jdk.JdkHttpClient
-import dev.langchain4j.memory.ChatMemory
-import dev.langchain4j.model.chat.ChatModel
-import dev.langchain4j.model.chat.StreamingChatModel
-import dev.langchain4j.model.embedding.EmbeddingModel
-import dev.langchain4j.model.image.ImageModel
-import dev.langchain4j.model.openai.OpenAiChatModel
-import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
-import dev.langchain4j.model.openai.OpenAiImageModel
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import dev.langchain4j.rag.content.retriever.ContentRetriever
-import dev.langchain4j.service.AiServices
-import dev.langchain4j.service.tool.ToolProvider
-import io.askimo.core.config.AppConfig
-import io.askimo.core.context.AppContext
-import io.askimo.core.context.ExecutionMode
-import io.askimo.core.logging.display
-import io.askimo.core.logging.logger
-import io.askimo.core.providers.AiServiceBuilder
-import io.askimo.core.providers.ChatClient
-import io.askimo.core.providers.ChatModelFactory
-import io.askimo.core.providers.LocalEmbeddingTokenLimits
-import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ModelProvider.LOCALAI
-import io.askimo.core.providers.ProviderModelUtils.fetchModels
+import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.providers.ensureLocalEmbeddingModelAvailable
-import io.askimo.core.telemetry.TelemetryChatModelListener
-import io.askimo.core.util.ProxyUtil
-import java.net.http.HttpClient
-import java.time.Duration
 
-class LocalAiModelFactory : ChatModelFactory<LocalAiSettings> {
-
-    private val log = logger<LocalAiModelFactory>()
+class LocalAiModelFactory : OpenAiCompatibleChatModelFactory<LocalAiSettings>() {
 
     override fun getProvider(): ModelProvider = LOCALAI
 
-    override fun availableModels(settings: LocalAiSettings): List<ModelDTO> {
-        val baseUrl = settings.baseUrl.takeIf { it.isNotBlank() } ?: return emptyList()
-        return fetchModels(apiKey = "not-needed", url = "$baseUrl/models", providerName = LOCALAI)
-            .map { ModelDTO.of(LOCALAI, it) }
-    }
-
     override fun defaultSettings(): LocalAiSettings = LocalAiSettings()
 
-    override fun create(
-        sessionId: String?,
-        settings: LocalAiSettings,
-        toolProvider: ToolProvider?,
-        retriever: ContentRetriever?,
-        executionMode: ExecutionMode,
-        chatMemory: ChatMemory?,
-    ): ChatClient = AiServiceBuilder.buildChatClient(
-        sessionId = sessionId,
-        settings = settings,
-        provider = LOCALAI,
-        chatModel = createStreamingModel(settings),
-        secondaryChatModel = createSecondaryModel(settings),
-        chatMemory = chatMemory,
-        toolProvider = toolProvider,
-        retriever = retriever,
-        executionMode = executionMode,
-    )
+    override fun canFetchModels(settings: LocalAiSettings): Boolean = settings.baseUrl.isNotBlank()
 
-    override fun createImageModel(
-        settings: LocalAiSettings,
-    ): ImageModel = OpenAiImageModel.builder()
-        .apiKey("localai")
-        .baseUrl(settings.baseUrl)
-        .modelName(AppConfig.models[LOCALAI].imageModel)
-        .logger(log)
-        .logRequests(log.isDebugEnabled)
-        .logResponses(log.isTraceEnabled)
-        .build()
-
-    override fun createStreamingModel(settings: LocalAiSettings): StreamingChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiStreamingChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey("localai")
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, LOCALAI.name.lowercase())))
-            .build()
-    }
-
-    override fun createSecondaryModel(settings: LocalAiSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey("localai")
-            .modelName(AppConfig.models[LOCALAI].utilityModel.ifBlank { settings.defaultModel })
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
-            .build()
-    }
-
-    override fun createModel(settings: LocalAiSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey("localai")
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .listeners(listOf(TelemetryChatModelListener(telemetry, LOCALAI.name.lowercase())))
-            .build()
-    }
-
-    override fun createUtilityClient(
-        settings: LocalAiSettings,
-    ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryModel(settings))
-        .build()
-
-    override fun supportsEmbedding(): Boolean = true
-
-    override fun createEmbeddingModel(settings: LocalAiSettings): EmbeddingModel {
-        val baseUrl = settings.baseUrl.removeSuffix("/")
-        val modelName = AppConfig.models[LOCALAI].embeddingModel
-
-        log.display(
-            """
-            ℹ️  Using LocalAI for embeddings
-               • LocalAI URL: $baseUrl
-               • Embedding model: $modelName
-               • Configure in askimo.yml: models.localai.embedding_model
-            """.trimIndent(),
-        )
-
-        ensureLocalEmbeddingModelAvailable(LOCALAI, baseUrl, modelName)
-
-        return OpenAiEmbeddingModelBuilder()
-            .apiKey("not-needed")
-            .baseUrl(baseUrl)
-            .modelName(modelName)
-            .build()
-    }
-
-    override fun getEmbeddingTokenLimit(settings: LocalAiSettings): Int = LocalEmbeddingTokenLimits.resolve(AppConfig.models[LOCALAI].embeddingModel)
+    override fun checkEmbeddingAvailability(baseUrl: String, modelName: String) = ensureLocalEmbeddingModelAvailable(getProvider(), baseUrl, modelName)
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaModelFactory.kt
@@ -4,48 +4,19 @@
  */
 package io.askimo.core.providers.ollama
 
-import dev.langchain4j.http.client.jdk.JdkHttpClient
-import dev.langchain4j.memory.ChatMemory
-import dev.langchain4j.model.chat.ChatModel
-import dev.langchain4j.model.chat.StreamingChatModel
-import dev.langchain4j.model.embedding.EmbeddingModel
-import dev.langchain4j.model.image.ImageModel
-import dev.langchain4j.model.openai.OpenAiChatModel
-import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
-import dev.langchain4j.model.openai.OpenAiImageModel
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import dev.langchain4j.rag.content.retriever.ContentRetriever
-import dev.langchain4j.service.AiServices
-import dev.langchain4j.service.tool.ToolProvider
-import io.askimo.core.config.AppConfig
-import io.askimo.core.context.AppContext
-import io.askimo.core.context.ExecutionMode
-import io.askimo.core.logging.logger
-import io.askimo.core.providers.AiServiceBuilder
-import io.askimo.core.providers.ChatClient
-import io.askimo.core.providers.ChatModelFactory
-import io.askimo.core.providers.LocalEmbeddingTokenLimits
-import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
-import io.askimo.core.providers.ProviderModelUtils.fetchModels
+import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.providers.ensureLocalEmbeddingModelAvailable
-import io.askimo.core.telemetry.TelemetryChatModelListener
-import io.askimo.core.util.ProxyUtil
-import java.net.http.HttpClient
-import java.time.Duration
 
-class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
-    private val log = logger<OllamaModelFactory>()
+class OllamaModelFactory : OpenAiCompatibleChatModelFactory<OllamaSettings>() {
 
     override fun getProvider(): ModelProvider = ModelProvider.OLLAMA
 
-    override fun availableModels(settings: OllamaSettings): List<ModelDTO> {
-        val baseUrl = settings.baseUrl.takeIf { it.isNotBlank() } ?: return emptyList()
-        return fetchModels(apiKey = "not-needed", url = "$baseUrl/models", providerName = ModelProvider.OLLAMA)
-            .map { ModelDTO.of(ModelProvider.OLLAMA, it) }
-    }
-
     override fun defaultSettings(): OllamaSettings = OllamaSettings()
+
+    override fun canFetchModels(settings: OllamaSettings): Boolean = settings.baseUrl.isNotBlank()
+
+    override fun checkEmbeddingAvailability(baseUrl: String, modelName: String) = ensureLocalEmbeddingModelAvailable(getProvider(), baseUrl, modelName)
 
     override fun getNoModelsHelpText(): String = """
         You may not have any models installed yet.
@@ -55,104 +26,4 @@ class OllamaModelFactory : ChatModelFactory<OllamaSettings> {
 
         Example: ollama pull llama3
     """.trimIndent()
-
-    override fun create(
-        sessionId: String?,
-        settings: OllamaSettings,
-        toolProvider: ToolProvider?,
-        retriever: ContentRetriever?,
-        executionMode: ExecutionMode,
-        chatMemory: ChatMemory?,
-    ): ChatClient = AiServiceBuilder.buildChatClient(
-        sessionId = sessionId,
-        settings = settings,
-        provider = ModelProvider.OLLAMA,
-        chatModel = createStreamingModel(settings),
-        secondaryChatModel = createSecondaryModel(settings),
-        chatMemory = chatMemory,
-        toolProvider = toolProvider,
-        retriever = retriever,
-        executionMode = executionMode,
-    )
-
-    override fun createImageModel(
-        settings: OllamaSettings,
-    ): ImageModel = OpenAiImageModel.builder()
-        .apiKey("ollama")
-        .baseUrl(settings.baseUrl)
-        .modelName(AppConfig.models[ModelProvider.OLLAMA].imageModel)
-        .logger(log)
-        .logRequests(log.isDebugEnabled)
-        .logResponses(log.isTraceEnabled)
-        .build()
-
-    override fun createStreamingModel(settings: OllamaSettings): StreamingChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiStreamingChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OLLAMA.name.lowercase())))
-            .build()
-    }
-
-    override fun createSecondaryModel(settings: OllamaSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey("ollama")
-            .modelName(AppConfig.models[ModelProvider.OLLAMA].utilityModel.ifBlank { settings.defaultModel })
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .build()
-    }
-
-    override fun createModel(settings: OllamaSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder(), settings.baseUrl)
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey("ollama")
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OLLAMA.name.lowercase())))
-            .build()
-    }
-
-    override fun createUtilityClient(
-        settings: OllamaSettings,
-    ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryModel(settings))
-        .build()
-
-    override fun supportsEmbedding(): Boolean = true
-
-    override fun createEmbeddingModel(settings: OllamaSettings): EmbeddingModel {
-        val baseUrl = settings.baseUrl.removeSuffix("/")
-        val modelName = AppConfig.models[ModelProvider.OLLAMA].embeddingModel
-        ensureLocalEmbeddingModelAvailable(ModelProvider.OLLAMA, baseUrl, modelName)
-        return OpenAiEmbeddingModelBuilder()
-            .apiKey("not-needed")
-            .baseUrl(baseUrl)
-            .modelName(modelName)
-            .build()
-    }
-
-    override fun getEmbeddingTokenLimit(settings: OllamaSettings): Int = LocalEmbeddingTokenLimits.resolve(AppConfig.models[ModelProvider.OLLAMA].embeddingModel)
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
@@ -4,54 +4,24 @@
  */
 package io.askimo.core.providers.openaicompatible
 
-import dev.langchain4j.http.client.jdk.JdkHttpClient
-import dev.langchain4j.memory.ChatMemory
-import dev.langchain4j.model.chat.ChatModel
-import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
-import dev.langchain4j.model.image.ImageModel
-import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
-import dev.langchain4j.model.openai.OpenAiImageModel
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import dev.langchain4j.rag.content.retriever.ContentRetriever
-import dev.langchain4j.service.AiServices
-import dev.langchain4j.service.tool.ToolProvider
 import io.askimo.core.config.AppConfig
-import io.askimo.core.context.AppContext
-import io.askimo.core.context.ExecutionMode
-import io.askimo.core.logging.logger
-import io.askimo.core.providers.AiServiceBuilder
-import io.askimo.core.providers.ChatClient
-import io.askimo.core.providers.ChatModelFactory
-import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
-import io.askimo.core.providers.ProviderModelUtils.fetchModels
-import io.askimo.core.telemetry.TelemetryChatModelListener
+import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.util.ApiKeyUtils.safeApiKey
-import io.askimo.core.util.ProxyUtil
-import java.net.http.HttpClient
-import java.time.Duration
 
-class OpenAiCompatibleModelFactory : ChatModelFactory<OpenAiCompatibleSettings> {
-    private val log = logger<OpenAiCompatibleModelFactory>()
+class OpenAiCompatibleModelFactory : OpenAiCompatibleChatModelFactory<OpenAiCompatibleSettings>() {
 
     override fun getProvider(): ModelProvider = ModelProvider.OPENAI_COMPATIBLE
 
-    private fun createHttpClientBuilder(baseUrl: String) = JdkHttpClient.builder().httpClientBuilder(
-        ProxyUtil.configureProxy(
-            HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1),
-            baseUrl,
-        ),
-    )
-
-    override fun availableModels(settings: OpenAiCompatibleSettings): List<ModelDTO> = fetchModels(
-        apiKey = settings.apiKey.ifBlank { "not-needed" },
-        url = "${settings.baseUrl.removeSuffix("/")}/models",
-        providerName = ModelProvider.OPENAI_COMPATIBLE,
-    ).map { ModelDTO.of(ModelProvider.OPENAI_COMPATIBLE, it) }
-
     override fun defaultSettings(): OpenAiCompatibleSettings = OpenAiCompatibleSettings()
+
+    /**
+     * Real key from settings; falls back to "not-needed" for servers that don't require auth.
+     * Wrapped in [safeApiKey] to guarantee a non-blank value for the HTTP client.
+     */
+    override fun resolveApiKey(settings: OpenAiCompatibleSettings): String = safeApiKey(settings.apiKey.ifBlank { "not-needed" })
 
     override fun getNoModelsHelpText(): String = """
         One possible reason is that your server URL or API key is not configured.
@@ -60,96 +30,15 @@ class OpenAiCompatibleModelFactory : ChatModelFactory<OpenAiCompatibleSettings> 
         2. Add an API key if your server requires it
     """.trimIndent()
 
-    override fun create(
-        sessionId: String?,
-        settings: OpenAiCompatibleSettings,
-        toolProvider: ToolProvider?,
-        retriever: ContentRetriever?,
-        executionMode: ExecutionMode,
-        chatMemory: ChatMemory?,
-    ): ChatClient = AiServiceBuilder.buildChatClient(
-        sessionId = sessionId,
-        settings = settings,
-        provider = ModelProvider.OPENAI_COMPATIBLE,
-        chatModel = createStreamingModel(settings),
-        secondaryChatModel = createSecondaryModel(settings),
-        chatMemory = chatMemory,
-        toolProvider = toolProvider,
-        retriever = retriever,
-        executionMode = executionMode,
-    )
-
-    override fun createImageModel(settings: OpenAiCompatibleSettings): ImageModel {
-        val apiKey = settings.apiKey.ifBlank { "not-needed" }
-        return OpenAiImageModel.builder()
-            .baseUrl(settings.baseUrl)
-            .apiKey(safeApiKey(apiKey))
-            .modelName(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].imageModel)
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .build()
-    }
-
-    override fun createStreamingModel(settings: OpenAiCompatibleSettings): StreamingChatModel {
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-        val apiKey = settings.apiKey.ifBlank { "not-needed" }
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiStreamingChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey(safeApiKey(apiKey))
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OPENAI_COMPATIBLE.providerKey())))
-            .build()
-    }
-
-    override fun createSecondaryModel(settings: OpenAiCompatibleSettings): ChatModel {
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-        val apiKey = settings.apiKey.ifBlank { "not-needed" }
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey(safeApiKey(apiKey))
-            .modelName(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].utilityModel.ifBlank { settings.defaultModel })
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
-            .build()
-    }
-
-    override fun createModel(settings: OpenAiCompatibleSettings): ChatModel {
-        val jdkHttpClientBuilder = createHttpClientBuilder(settings.baseUrl)
-        val apiKey = settings.apiKey.ifBlank { "not-needed" }
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey(safeApiKey(apiKey))
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.OPENAI_COMPATIBLE.providerKey())))
-            .build()
-    }
-
-    override fun createUtilityClient(settings: OpenAiCompatibleSettings): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryModel(settings))
+    /**
+     * OpenAI-compatible servers can be remote — skip the local model availability check.
+     * Also uses the settings API key (via [resolveApiKey]) for the embedding request itself.
+     */
+    override fun createEmbeddingModel(settings: OpenAiCompatibleSettings): EmbeddingModel = OpenAiEmbeddingModelBuilder()
+        .baseUrl(settings.baseUrl)
+        .apiKey(resolveApiKey(settings))
+        .modelName(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel)
         .build()
-
-    override fun supportsEmbedding(): Boolean = true
-
-    override fun createEmbeddingModel(settings: OpenAiCompatibleSettings): EmbeddingModel {
-        val apiKey = settings.apiKey.ifBlank { "not-needed" }
-        return OpenAiEmbeddingModelBuilder()
-            .baseUrl(settings.baseUrl)
-            .apiKey(safeApiKey(apiKey))
-            .modelName(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel)
-            .build()
-    }
 
     override fun getEmbeddingTokenLimit(settings: OpenAiCompatibleSettings): Int {
         val modelName = AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel.lowercase()

--- a/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiModelFactory.kt
@@ -4,126 +4,33 @@
  */
 package io.askimo.core.providers.xai
 
-import dev.langchain4j.http.client.jdk.JdkHttpClient
-import dev.langchain4j.memory.ChatMemory
-import dev.langchain4j.model.chat.ChatModel
-import dev.langchain4j.model.chat.StreamingChatModel
-import dev.langchain4j.model.image.ImageModel
-import dev.langchain4j.model.openai.OpenAiChatModel
-import dev.langchain4j.model.openai.OpenAiImageModel
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import dev.langchain4j.rag.content.retriever.ContentRetriever
-import dev.langchain4j.service.AiServices
-import dev.langchain4j.service.tool.ToolProvider
-import io.askimo.core.config.AppConfig
-import io.askimo.core.context.AppContext
-import io.askimo.core.context.ExecutionMode
-import io.askimo.core.logging.logger
-import io.askimo.core.providers.AiServiceBuilder
-import io.askimo.core.providers.ChatClient
-import io.askimo.core.providers.ChatModelFactory
+import dev.langchain4j.model.embedding.EmbeddingModel
 import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ModelProvider.XAI
+import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.providers.ProviderModelUtils.fetchModels
-import io.askimo.core.telemetry.TelemetryChatModelListener
 import io.askimo.core.util.ApiKeyUtils.safeApiKey
-import io.askimo.core.util.ProxyUtil
-import java.net.http.HttpClient
-import java.time.Duration
 
-class XAiModelFactory : ChatModelFactory<XAiSettings> {
-    private val log = logger<XAiModelFactory>()
+class XAiModelFactory : OpenAiCompatibleChatModelFactory<XAiSettings>() {
 
     override fun getProvider(): ModelProvider = XAI
 
+    override fun defaultSettings(): XAiSettings = XAiSettings()
+
+    override fun resolveApiKey(settings: XAiSettings): String = safeApiKey(settings.apiKey)
+
     override fun availableModels(settings: XAiSettings): List<ModelDTO> {
         val apiKey = settings.apiKey.takeIf { it.isNotBlank() } ?: return emptyList()
-        val url = "${settings.baseUrl.trimEnd('/')}/models"
-        return fetchModels(apiKey = apiKey, url = url, providerName = XAI)
+        return fetchModels(apiKey = apiKey, url = "${settings.baseUrl.trimEnd('/')}/models", providerName = XAI)
             .map { ModelDTO.of(XAI, it) }
     }
 
-    override fun defaultSettings(): XAiSettings = XAiSettings()
+    /** xAI does not offer an embedding endpoint. */
+    override fun supportsEmbedding(): Boolean = false
 
-    override fun create(
-        sessionId: String?,
-        settings: XAiSettings,
-        toolProvider: ToolProvider?,
-        retriever: ContentRetriever?,
-        executionMode: ExecutionMode,
-        chatMemory: ChatMemory?,
-    ): ChatClient = AiServiceBuilder.buildChatClient(
-        sessionId = sessionId,
-        settings = settings,
-        provider = XAI,
-        chatModel = createStreamingModel(settings),
-        secondaryChatModel = createSecondaryModel(settings),
-        chatMemory = chatMemory,
-        toolProvider = toolProvider,
-        retriever = retriever,
-        executionMode = executionMode,
+    override fun createEmbeddingModel(settings: XAiSettings): EmbeddingModel = throw UnsupportedOperationException(
+        "${getProvider().name} does not support embedding models. " +
+            "Please switch to a provider that supports embeddings (OpenAI, Ollama, etc.) to use RAG features.",
     )
-
-    override fun createImageModel(
-        settings: XAiSettings,
-    ): ImageModel = OpenAiImageModel.builder()
-        .baseUrl(settings.baseUrl)
-        .apiKey(safeApiKey(settings.apiKey))
-        .modelName(AppConfig.models[XAI].imageModel)
-        .logger(log)
-        .logRequests(log.isDebugEnabled)
-        .logResponses(log.isTraceEnabled)
-        .build()
-
-    override fun createStreamingModel(settings: XAiSettings): StreamingChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiStreamingChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .apiKey(safeApiKey(settings.apiKey))
-            .baseUrl(settings.baseUrl)
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, XAI.name.lowercase())))
-            .build()
-    }
-
-    override fun createSecondaryModel(settings: XAiSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey(safeApiKey(settings.apiKey))
-            .modelName(AppConfig.models[XAI].utilityModel.ifBlank { settings.defaultModel })
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
-            .build()
-    }
-
-    override fun createModel(settings: XAiSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .baseUrl(settings.baseUrl)
-            .apiKey(safeApiKey(settings.apiKey))
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .listeners(listOf(TelemetryChatModelListener(telemetry, XAI.name.lowercase())))
-            .build()
-    }
-
-    override fun createUtilityClient(
-        settings: XAiSettings,
-    ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryModel(settings))
-        .build()
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiSettings.kt
@@ -5,6 +5,7 @@
 package io.askimo.core.providers.xai
 
 import io.askimo.core.providers.HasApiKey
+import io.askimo.core.providers.HasBaseUrl
 import io.askimo.core.providers.ProviderConfigField
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.providers.SettingField
@@ -12,11 +13,12 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class XAiSettings(
-    val baseUrl: String = "https://api.x.ai/v1",
+    override var baseUrl: String = "https://api.x.ai/v1",
     override var apiKey: String = "",
     override val defaultModel: String = "",
 ) : ProviderSettings,
-    HasApiKey {
+    HasApiKey,
+    HasBaseUrl {
     override fun describe(): List<String> = listOf(
         "apiKey:  ${maskApiKey()}",
         "baseUrl: $baseUrl",


### PR DESCRIPTION
- Introduce `OpenAiCompatibleChatModelFactory` to deduplicate model creation logic.
- Remove redundant boilerplate and imports across multiple model factory implementations.
- Refactor `XAiSettings` to implement `HasBaseUrl` interface.
- Update GraalVM reflection configuration for native image support.