### PR TITLE
Fix: Code blocks lose syntax highlighting when AI includes a filename in the language tag

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -4,7 +4,10 @@
  */
 package io.askimo.ui.chat
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.ScrollbarStyle
+import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -14,13 +17,17 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile
@@ -950,13 +957,15 @@ private fun fileAttachmentChip(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun aiMessageEditDialog(
     message: ChatMessageDTO,
     onDismiss: () -> Unit,
     onSave: (String) -> Unit,
 ) {
-    var editedContent by remember { mutableStateOf(message.content) }
+    val textFieldState = rememberTextFieldState(message.content)
+    val textScrollState = rememberScrollState()
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -982,17 +991,39 @@ fun aiMessageEditDialog(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 
-                // Scrollable content field with consistent styling
-                OutlinedTextField(
-                    value = editedContent,
-                    onValueChange = { editedContent = it },
+                // Scrollable content field with visible scrollbar
+                Box(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(600.dp),
-                    textStyle = MaterialTheme.typography.bodyMedium,
-                    colors = AppComponents.outlinedTextFieldColors(),
-                    label = { Text(stringResource("message.ai.edit.content.label")) },
-                )
+                ) {
+                    OutlinedTextField(
+                        state = textFieldState,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .padding(end = 12.dp), // room for the scrollbar
+                        textStyle = MaterialTheme.typography.bodyMedium,
+                        colors = AppComponents.outlinedTextFieldColors(),
+                        label = { Text(stringResource("message.ai.edit.content.label")) },
+                        scrollState = textScrollState,
+                    )
+
+                    VerticalScrollbar(
+                        modifier = Modifier
+                            .align(Alignment.CenterEnd)
+                            .fillMaxHeight(),
+                        adapter = rememberScrollbarAdapter(textScrollState),
+                        style = ScrollbarStyle(
+                            minimalHeight = 16.dp,
+                            thickness = 8.dp,
+                            shape = MaterialTheme.shapes.small,
+                            hoverDurationMillis = 300,
+                            unhoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                            hoverColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                        ),
+                    )
+                }
 
                 // Action buttons
                 Row(
@@ -1010,7 +1041,7 @@ fun aiMessageEditDialog(
 
                     primaryButton(
                         onClick = {
-                            onSave(editedContent)
+                            onSave(textFieldState.text.toString())
                             onDismiss()
                         },
                     ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
@@ -740,7 +740,10 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
     val blockIsStreaming = rawInfo.endsWith("|streaming")
     // Strip the sentinel before any downstream use
     val cleanInfo = if (blockIsStreaming) rawInfo.removeSuffix("|streaming") else rawInfo
-    val language = cleanInfo.takeIf { it.isNotBlank() }
+    val language = cleanInfo
+        .substringBefore(':') // strip ":filename" suffix if present (e.g. "xml:pom.xml" → "xml")
+        .trim()
+        .takeIf { it.isNotBlank() }
     val code = codeBlock.literal
 
     // Show partial code while the code block is still being received


### PR DESCRIPTION
Some AI assistants (e.g. Claude, Cursor-style models) annotate code blocks with both a language and a filename:
```xml:pom.xml```
```java:src/main/java/com/example/userservice/model/User.java``` 
When these responses were rendered in Askimo, the code blocks appeared as plain text with no syntax highlighting,  because the entire string xml:pom.xml or java:src/main/… was treated as the language name, which nothing recognises. Fix
Extract only the language part (before the :) from the info string, so highlighting works regardless of whether a filename is appended. Before / After

Before: A Java code block from an AI response that includes a file path renders as unstyled plain text, indistinguishable from a regular paragraph. After: The same code block renders with full Java syntax highlighting, copy button, and run button,  exactly as if the AI had written ```java alone