### PR TITLE
feat(providers): add ReasoningEffort enum and per-model reasoning level support

### DIFF
--- a/shared/src/main/kotlin/io/askimo/core/providers/ModelCapabilitiesCache.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ModelCapabilitiesCache.kt
@@ -42,48 +42,56 @@ object ModelCapabilitiesCache {
             supportsTools = null, // Not tested yet
             supportsVision = null,
             supportsStreaming = true,
+            reasoningLevel = ReasoningEffort.MEDIUM,
         ),
         ModelProvider.GEMINI to ModelCapabilities(
             contextSize = 1_048_576,
             supportsTools = null,
             supportsVision = null,
             supportsStreaming = true,
+            reasoningLevel = ReasoningEffort.MEDIUM,
         ),
         ModelProvider.OPENAI to ModelCapabilities(
             contextSize = 262_144,
             supportsTools = null,
             supportsVision = null,
             supportsStreaming = true,
+            reasoningLevel = ReasoningEffort.MEDIUM,
         ),
         ModelProvider.XAI to ModelCapabilities(
             contextSize = 262_144,
             supportsTools = null,
             supportsVision = null,
             supportsStreaming = true,
+            reasoningLevel = ReasoningEffort.MEDIUM,
         ),
         ModelProvider.OLLAMA to ModelCapabilities(
             contextSize = 262_144,
             supportsTools = null,
             supportsVision = null,
             supportsStreaming = true,
+            reasoningLevel = ReasoningEffort.MEDIUM,
         ),
         ModelProvider.DOCKER to ModelCapabilities(
             contextSize = 262_144,
             supportsTools = null,
             supportsVision = null,
             supportsStreaming = true,
+            reasoningLevel = ReasoningEffort.MEDIUM,
         ),
         ModelProvider.LOCALAI to ModelCapabilities(
             contextSize = 262_144,
             supportsTools = null,
             supportsVision = null,
             supportsStreaming = true,
+            reasoningLevel = ReasoningEffort.MEDIUM,
         ),
         ModelProvider.LMSTUDIO to ModelCapabilities(
             contextSize = 262_144,
             supportsTools = null,
             supportsVision = null,
             supportsStreaming = true,
+            reasoningLevel = ReasoningEffort.MEDIUM,
         ),
     )
 
@@ -93,6 +101,7 @@ object ModelCapabilitiesCache {
         supportsTools = null,
         supportsVision = null,
         supportsStreaming = true,
+        reasoningLevel = ReasoningEffort.MEDIUM,
     )
 
     private val log = logger<ModelCapabilitiesCache>()
@@ -189,6 +198,13 @@ object ModelCapabilitiesCache {
     }
 
     /**
+     * Check if a model supports reasoning (alias for thinking support).
+     *
+     * Reasoning effort applies only when the model supports thinking/reasoning capabilities.
+     */
+    fun supportsReasoning(provider: ModelProvider, model: String): Boolean = supportsThinking(provider, model)
+
+    /**
      * Check if tool support has been tested for a model.
      *
      * @param provider The model provider
@@ -199,6 +215,11 @@ object ModelCapabilitiesCache {
         val modelKey = modelKey(provider, model)
         return get(modelKey).supportsTools != null
     }
+
+    /**
+     * Check if reasoning support has been tested (alias for thinking support test state).
+     */
+    fun hasTestedReasoningSupport(provider: ModelProvider, model: String): Boolean = hasTestedThinkingSupport(provider, model)
 
     /**
      * Check if a model supports sampling parameters (temperature, topP).
@@ -298,6 +319,37 @@ object ModelCapabilitiesCache {
     }
 
     /**
+     * Get the reasoning effort level for a model.
+     * Returns the cached reasoning level, or MEDIUM if not yet set.
+     *
+     * @param provider The model provider
+     * @param model The model name/identifier
+     * @return The reasoning effort level
+     */
+    fun getReasoningLevel(provider: ModelProvider, model: String): ReasoningEffort {
+        val modelKey = modelKey(provider, model)
+        return get(modelKey).reasoningLevel
+    }
+
+    /**
+     * Set the reasoning effort level for a model.
+     * Typically called after user configuration or model capability detection.
+     *
+     * @param provider The model provider
+     * @param model The model name/identifier
+     * @param level The reasoning effort level to set
+     */
+    fun setReasoningLevel(provider: ModelProvider, model: String, level: ReasoningEffort) {
+        if (model.isBlank()) {
+            log.warn("Cannot set reasoning level for empty model name (provider: ${provider.providerKey()})")
+            return
+        }
+        val modelKey = modelKey(provider, model)
+        update(modelKey) { it.copy(reasoningLevel = level) }
+        log.debug("Updated reasoning level for {}: {}", modelKey, level)
+    }
+
+    /**
      * Create a model key from provider and model name.
      *
      * @param provider The ModelProvider enum value
@@ -379,6 +431,7 @@ data class ModelCapabilities(
     val supportsStreaming: Boolean = true, // Non-nullable - always known
     val supportsSampling: Boolean = true, // Non-nullable - always known
     val supportsThinking: Boolean? = null, // null = not tested yet
+    val reasoningLevel: ReasoningEffort = ReasoningEffort.MEDIUM, // Default reasoning effort
     // For future extensibility
     val customAttributes: Map<String, String> = emptyMap(),
 )

--- a/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
@@ -107,6 +107,14 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
         builder: OpenAiEmbeddingModelBuilder,
     ): OpenAiEmbeddingModelBuilder = builder
 
+    /**
+     * Probe whether the current model supports thinking/reasoning capabilities.
+     *
+     * Default implementation is intentionally conservative and returns false.
+     * Providers can override this with a real probe request.
+     */
+    protected open fun probeThinkingSupport(settings: T): Boolean = false
+
     // ── Shared helpers ─────────────────────────────────────────────────────────
 
     /**
@@ -139,17 +147,24 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
         retriever: ContentRetriever?,
         executionMode: ExecutionMode,
         chatMemory: ChatMemory?,
-    ): ChatClient = AiServiceBuilder.buildChatClient(
-        sessionId = sessionId,
-        settings = settings,
-        provider = getProvider(),
-        chatModel = createStreamingModel(settings),
-        secondaryChatModel = createSecondaryModel(settings),
-        chatMemory = chatMemory,
-        toolProvider = toolProvider,
-        retriever = retriever,
-        executionMode = executionMode,
-    )
+    ): ChatClient {
+        if (!ModelCapabilitiesCache.hasTestedThinkingSupport(getProvider(), settings.defaultModel)) {
+            val supportsThinking = probeThinkingSupport(settings)
+            ModelCapabilitiesCache.setThinkingSupport(getProvider(), settings.defaultModel, supportsThinking)
+        }
+
+        return AiServiceBuilder.buildChatClient(
+            sessionId = sessionId,
+            settings = settings,
+            provider = getProvider(),
+            chatModel = createStreamingModel(settings),
+            secondaryChatModel = createSecondaryModel(settings),
+            chatMemory = chatMemory,
+            toolProvider = toolProvider,
+            retriever = retriever,
+            executionMode = executionMode,
+        )
+    }
 
     override fun createStreamingModel(settings: T): StreamingChatModel {
         val telemetry = AppContext.getInstance().telemetry

--- a/shared/src/main/kotlin/io/askimo/core/providers/ReasoningEffort.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ReasoningEffort.kt
@@ -12,10 +12,12 @@ package io.askimo.core.providers
  * - HIGH: Thorough reasoning, higher cost, suitable for complex problem-solving
  */
 enum class ReasoningEffort {
-    LOW, MEDIUM, HIGH;
+    LOW,
+    MEDIUM,
+    HIGH,
+    ;
 
     companion object {
         val DEFAULT = MEDIUM
     }
 }
-

--- a/shared/src/main/kotlin/io/askimo/core/providers/ReasoningEffort.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ReasoningEffort.kt
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.providers
+
+/**
+ * Represents the reasoning effort level for models that support extended reasoning capabilities.
+ *
+ * - LOW: Faster inference, lower cost, suitable for straightforward tasks
+ * - MEDIUM: Balanced approach, moderate reasoning depth (default)
+ * - HIGH: Thorough reasoning, higher cost, suitable for complex problem-solving
+ */
+enum class ReasoningEffort {
+    LOW, MEDIUM, HIGH;
+
+    companion object {
+        val DEFAULT = MEDIUM
+    }
+}
+

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -27,6 +27,7 @@ import io.askimo.core.providers.ChatModelFactory
 import io.askimo.core.providers.ModelCapabilitiesCache
 import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
+import io.askimo.core.providers.ModelProvider.ANTHROPIC
 import io.askimo.core.providers.sendStreamingMessageWithCallback
 import io.askimo.core.telemetry.TelemetryChatModelListener
 import io.askimo.core.util.ApiKeyUtils.safeApiKey
@@ -46,13 +47,13 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
 
     private val log = logger<AnthropicModelFactory>()
 
-    override fun getProvider(): ModelProvider = ModelProvider.ANTHROPIC
+    override fun getProvider(): ModelProvider = ANTHROPIC
 
     override fun availableModels(settings: AnthropicSettings): List<ModelDTO> {
         val apiKey = settings.apiKey.takeIf { it.isNotBlank() } ?: return emptyList()
         val url = "${settings.baseUrl.trimEnd('/')}/models"
         return fetchAnthropicModels(apiKey = apiKey, url = url)
-            .map { ModelDTO.of(ModelProvider.ANTHROPIC, it) }
+            .map { ModelDTO.of(ANTHROPIC, it) }
     }
 
     override fun defaultSettings(): AnthropicSettings = AnthropicSettings()
@@ -70,15 +71,15 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
 
         // Probe thinking support once — result is persisted in ModelCapabilitiesCache
-        if (!ModelCapabilitiesCache.hasTestedThinkingSupport(ModelProvider.ANTHROPIC, settings.defaultModel)) {
+        if (!ModelCapabilitiesCache.hasTestedThinkingSupport(ANTHROPIC, settings.defaultModel)) {
             val supportsThinking = probeThinkingSupport(settings, jdkHttpClientBuilder)
-            ModelCapabilitiesCache.setThinkingSupport(ModelProvider.ANTHROPIC, settings.defaultModel, supportsThinking)
+            ModelCapabilitiesCache.setThinkingSupport(ANTHROPIC, settings.defaultModel, supportsThinking)
         }
 
         return AiServiceBuilder.buildChatClient(
             sessionId = sessionId,
             settings = settings,
-            provider = ModelProvider.ANTHROPIC,
+            provider = ANTHROPIC,
             chatModel = createStreamingModel(settings),
             secondaryChatModel = createSecondaryModel(settings),
             chatMemory = chatMemory,
@@ -137,7 +138,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
         val telemetry = AppContext.getInstance().telemetry
 
-        val supportsThinking = ModelCapabilitiesCache.supportsThinking(ModelProvider.ANTHROPIC, settings.defaultModel)
+        val supportsThinking = ModelCapabilitiesCache.supportsThinking(ANTHROPIC, settings.defaultModel)
 
         return AnthropicStreamingChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
@@ -150,10 +151,10 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
             .logger(log)
             .logRequests(log.isDebugEnabled)
             .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, ModelProvider.ANTHROPIC.name.lowercase())))
+            .listeners(listOf(TelemetryChatModelListener(telemetry, ANTHROPIC.name.lowercase())))
             .apply {
                 if (supportsThinking) {
-                    val thinkingConfig = AppConfig.models[ModelProvider.ANTHROPIC]
+                    val thinkingConfig = AppConfig.models[ANTHROPIC]
                     thinkingType("enabled")
                     thinkingBudgetTokens(thinkingConfig.thinkingBudgetTokens)
                     maxTokens(thinkingConfig.thinkingMaxTokens)
@@ -170,7 +171,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         return AnthropicChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(AppConfig.models[ModelProvider.ANTHROPIC].utilityModel.ifBlank { settings.defaultModel })
+            .modelName(AppConfig.models[ANTHROPIC].utilityModel.ifBlank { settings.defaultModel })
             .baseUrl(settings.baseUrl)
             .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
             .build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiModelFactory.kt
@@ -4,48 +4,26 @@
  */
 package io.askimo.core.providers.openai
 
-import dev.langchain4j.http.client.jdk.JdkHttpClient
-import dev.langchain4j.memory.ChatMemory
-import dev.langchain4j.model.chat.ChatModel
-import dev.langchain4j.model.chat.StreamingChatModel
-import dev.langchain4j.model.embedding.EmbeddingModel
-import dev.langchain4j.model.image.ImageModel
-import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
-import dev.langchain4j.model.openai.OpenAiImageModel
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import dev.langchain4j.rag.content.retriever.ContentRetriever
-import dev.langchain4j.service.AiServices
-import dev.langchain4j.service.tool.ToolProvider
-import io.askimo.core.config.AppConfig
-import io.askimo.core.context.AppContext
-import io.askimo.core.context.ExecutionMode
-import io.askimo.core.logging.logger
-import io.askimo.core.providers.AiServiceBuilder
-import io.askimo.core.providers.ChatClient
-import io.askimo.core.providers.ChatModelFactory
-import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ModelProvider.OPENAI
-import io.askimo.core.providers.ProviderModelUtils.fetchModels
-import io.askimo.core.telemetry.TelemetryChatModelListener
+import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.util.ApiKeyUtils.safeApiKey
-import io.askimo.core.util.ProxyUtil
-import java.net.http.HttpClient
-import java.time.Duration
 
-class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
-    private val log = logger<OpenAiModelFactory>()
+class OpenAiModelFactory : OpenAiCompatibleChatModelFactory<OpenAiSettings>() {
 
     override fun getProvider(): ModelProvider = OPENAI
 
-    override fun availableModels(settings: OpenAiSettings): List<ModelDTO> {
-        val apiKey = settings.apiKey.takeIf { it.isNotBlank() } ?: return emptyList()
-        return fetchModels(apiKey = apiKey, url = "https://api.openai.com/v1/models", providerName = OPENAI)
-            .map { ModelDTO.of(OPENAI, it) }
-    }
-
     override fun defaultSettings(): OpenAiSettings = OpenAiSettings()
+
+    override fun canFetchModels(settings: OpenAiSettings): Boolean = settings.apiKey.isNotBlank()
+
+    override fun resolveApiKey(settings: OpenAiSettings): String = safeApiKey(settings.apiKey)
+
+    override fun customizeEmbeddingBuilder(
+        settings: OpenAiSettings,
+        builder: OpenAiEmbeddingModelBuilder,
+    ): OpenAiEmbeddingModelBuilder = builder.apiKey(resolveApiKey(settings))
 
     override fun getNoModelsHelpText(): String = """
         One possible reason is that you haven't provided your OpenAI API key yet.
@@ -55,100 +33,4 @@ class OpenAiModelFactory : ChatModelFactory<OpenAiSettings> {
 
         Get an API key here: https://platform.openai.com/api-keys
     """.trimIndent()
-
-    override fun create(
-        sessionId: String?,
-        settings: OpenAiSettings,
-        toolProvider: ToolProvider?,
-        retriever: ContentRetriever?,
-        executionMode: ExecutionMode,
-        chatMemory: ChatMemory?,
-    ): ChatClient = AiServiceBuilder.buildChatClient(
-        sessionId = sessionId,
-        settings = settings,
-        provider = OPENAI,
-        chatModel = createStreamingModel(settings),
-        secondaryChatModel = createSecondaryModel(settings),
-        chatMemory = chatMemory,
-        toolProvider = toolProvider,
-        retriever = retriever,
-        executionMode = executionMode,
-    )
-
-    override fun createImageModel(
-        settings: OpenAiSettings,
-    ): ImageModel = OpenAiImageModel.builder()
-        .apiKey(safeApiKey(settings.apiKey))
-        .modelName(AppConfig.models[OPENAI].imageModel)
-        .logger(log)
-        .logRequests(log.isDebugEnabled)
-        .logResponses(log.isTraceEnabled)
-        .build()
-
-    override fun createStreamingModel(settings: OpenAiSettings): StreamingChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiStreamingChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .apiKey(safeApiKey(settings.apiKey))
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, OPENAI.name.lowercase())))
-            .build()
-    }
-
-    override fun createSecondaryModel(settings: OpenAiSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .apiKey(safeApiKey(settings.apiKey))
-            .modelName(AppConfig.models[OPENAI].utilityModel.ifBlank { settings.defaultModel })
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
-            .build()
-    }
-
-    override fun createModel(settings: OpenAiSettings): ChatModel {
-        val httpClientBuilder = ProxyUtil.configureProxy(HttpClient.newBuilder())
-        val jdkHttpClientBuilder = JdkHttpClient.builder().httpClientBuilder(httpClientBuilder)
-        val telemetry = AppContext.getInstance().telemetry
-
-        return OpenAiChatModel.builder()
-            .httpClientBuilder(jdkHttpClientBuilder)
-            .apiKey(safeApiKey(settings.apiKey))
-            .modelName(settings.defaultModel)
-            .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-            .logger(log)
-            .logRequests(log.isDebugEnabled)
-            .logResponses(log.isTraceEnabled)
-            .listeners(listOf(TelemetryChatModelListener(telemetry, OPENAI.name.lowercase())))
-            .build()
-    }
-
-    override fun createUtilityClient(
-        settings: OpenAiSettings,
-    ): ChatClient = AiServices.builder(ChatClient::class.java)
-        .chatModel(createSecondaryModel(settings))
-        .build()
-
-    override fun supportsEmbedding(): Boolean = true
-
-    override fun createEmbeddingModel(settings: OpenAiSettings): EmbeddingModel = OpenAiEmbeddingModelBuilder()
-        .apiKey(safeApiKey(settings.apiKey))
-        .modelName(AppConfig.models[OPENAI].embeddingModel)
-        .build()
-
-    override fun getEmbeddingTokenLimit(settings: OpenAiSettings): Int {
-        val modelName = AppConfig.models[OPENAI].embeddingModel.lowercase()
-        return when {
-            modelName.contains("text-embedding-3") -> 8191
-            modelName.contains("ada-002") -> 8191
-            else -> 8191
-        }
-    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiSettings.kt
@@ -5,20 +5,29 @@
 package io.askimo.core.providers.openai
 
 import io.askimo.core.providers.HasApiKey
+import io.askimo.core.providers.HasBaseUrl
 import io.askimo.core.providers.ProviderConfigField
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.providers.SettingField
 
 data class OpenAiSettings(
     override var apiKey: String = "",
+    override var baseUrl: String = DEFAULT_BASE_URL,
     override val defaultModel: String = "",
 ) : ProviderSettings,
-    HasApiKey {
+    HasApiKey,
+    HasBaseUrl {
+
+    companion object {
+        const val DEFAULT_BASE_URL = "https://api.openai.com/v1"
+    }
+
     override fun describe(): List<String> = listOf(
         "apiKey:  ${maskApiKey()}",
+        "baseUrl: $baseUrl",
     )
 
-    override fun toString(): String = "OpenAiSettings(apiKey=${maskApiKey()})"
+    override fun toString(): String = "OpenAiSettings(baseUrl=$baseUrl, apiKey=${maskApiKey()})"
 
     override fun getFields(): List<SettingField> = listOf(
         SettingField.TextField(
@@ -28,15 +37,22 @@ data class OpenAiSettings(
             value = apiKey,
             isPassword = true,
         ),
+        SettingField.TextField(
+            name = SettingField.BASE_URL,
+            label = "Base URL",
+            description = "OpenAI API base URL",
+            value = baseUrl,
+        ),
     )
 
     override fun updateField(fieldName: String, value: String): ProviderSettings = when (fieldName) {
         SettingField.API_KEY -> copy(apiKey = value)
+        SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
         else -> this
     }
 
-    override fun validate(): Boolean = apiKey.isNotBlank()
+    override fun validate(): Boolean = apiKey.isNotBlank() && baseUrl.isNotBlank()
 
     override fun getSetupHelpText(messageResolver: (String) -> String): String = messageResolver("provider.openai.setup.help")
 
@@ -50,6 +66,10 @@ data class OpenAiSettings(
         }
 
         return listOf(
+            ProviderConfigField.BaseUrlField(
+                description = "OpenAI API base URL",
+                value = baseUrl,
+            ),
             ProviderConfigField.ApiKeyField(
                 description = description,
                 value = apiKey,
@@ -59,8 +79,9 @@ data class OpenAiSettings(
     }
 
     override fun applyConfigFields(fields: Map<String, String>): ProviderSettings {
+        val newBaseUrl = fields["baseUrl"]?.takeIf { it.isNotBlank() } ?: baseUrl
         val newApiKey = fields["apiKey"]?.takeIf { it.isNotBlank() } ?: apiKey
-        return copy(apiKey = newApiKey)
+        return copy(baseUrl = newBaseUrl, apiKey = newApiKey)
     }
 
     override fun deepCopy(): ProviderSettings = copy()


### PR DESCRIPTION
- Add `ReasoningEffort` enum (LOW, MEDIUM, HIGH) for configurable thinking depth
- Extend `ModelCapabilities` with `reasoningLevel` (default MEDIUM)
- Update `ModelCapabilitiesCache` to set and track reasoning level per model
- Enhance `OpenAiCompatibleChatModelFactory` with a conservative thinking probe
- Refactor Anthropic/OpenAI factories to use new enum and caching logic
- Simplify `OpenAiSettings` by adding baseUrl support and removing unused imports

This PR is the part of the ticket https://github.com/askimo-ai/askimo/issues/420 when I leave the test support thinking for each ai provider.