### PR TITLE
feat(core): improve analytics telemetry and model timeouts

### DIFF
--- a/shared/src/main/kotlin/io/askimo/core/analytics/Analytics.kt
+++ b/shared/src/main/kotlin/io/askimo/core/analytics/Analytics.kt
@@ -15,12 +15,6 @@ import java.nio.file.Files
 /**
  * Business analytics singleton — tracks anonymous feature usage for Askimo.t.
  *
- * ## Privacy contract
- * - Default: **disabled**. Zero data leaves the device until the user explicitly opts in.
- * - Opt-in is presented once via [io.askimo.ui.shell.analyticsConsentDialog].
- * - Opt-out immediately stops collection, clears the queue, and deletes the disk file.
- * - No conversation content, prompts, responses, file paths, or API keys — ever.
- *
  * ## Usage
  * ```kotlin
  * Analytics.initialize(AppConfig.analytics)
@@ -90,7 +84,7 @@ object Analytics {
 
     /**
      * Fires [AnalyticsEvent.RETURNING_USER] when [launchCount] hits a retention milestone
-     * (2nd, 7th, or 30th launch). No-op for other counts or when analytics is disabled.
+     * (2nd, 7th, or 30th launch). No-op for other counts.
      *
      * @param launchCount The current launch count returned by `ApplicationPreferences.incrementLaunchCount()`.
      */
@@ -101,7 +95,11 @@ object Analytics {
             30 -> "30"
             else -> return
         }
-        track(AnalyticsEvent.RETURNING_USER, mapOf("launch_count_bucket" to bucket))
+        if (enabled && initialized) {
+            track(AnalyticsEvent.RETURNING_USER, mapOf("launch_count_bucket" to bucket))
+        } else {
+            sendRetentionPingDirect(bucket)
+        }
     }
 
     fun sendInstallPingIfNeeded() {
@@ -135,11 +133,41 @@ object Analytics {
     }
 
     private fun buildInstallPingPayload(): String {
-        val os = System.getProperty("os.name", "unknown")
-            .replace("\\", "\\\\").replace("\"", "\\\"")
-        val version = VersionInfo.version
-            .replace("\\", "\\\\").replace("\"", "\\\"")
+        val (os, version) = osAndVersion()
         return """[{"event":"${AnalyticsEvent.INSTALL_PING.eventName}","appVersion":"$version","os":"$os"}]"""
+    }
+
+    private fun sendRetentionPingDirect(bucket: String) {
+        val endpoint = runCatching { AppConfig.analytics.endpoint }.getOrNull() ?: return
+        val payload = buildRetentionPingPayload(bucket)
+        Thread({
+            runCatching {
+                val (status, _) = httpPost(
+                    url = endpoint,
+                    body = payload,
+                    connectTimeoutMs = 10_000,
+                    readTimeoutMs = 15_000,
+                    httpVersion = HttpClient.Version.HTTP_2,
+                )
+                if (status in 200..299) {
+                    log.debug("Retention ping sent (bucket=$bucket, HTTP $status)")
+                } else {
+                    log.trace("Retention ping HTTP $status — will retry on next matching launch")
+                }
+            }.onFailure { log.trace("Retention ping failed: ${it.message} — will retry on next matching launch") }
+        }, "askimo-retention-ping").also { it.isDaemon = true }.start()
+    }
+
+    private fun buildRetentionPingPayload(bucket: String): String {
+        val (os, version) = osAndVersion()
+        val installId = AnalyticsDeviceInfo.installId
+            .replace("\\", "\\\\").replace("\"", "\\\"")
+        return """[{"event":"${AnalyticsEvent.RETURNING_USER.eventName}","appVersion":"$version","os":"$os","installId":"$installId","properties":{"launch_count_bucket":"$bucket"}}]"""
+    }
+
+    private fun osAndVersion(): Pair<String, String> {
+        fun String.jsonSafe() = replace("\\", "\\\\").replace("\"", "\\\"")
+        return System.getProperty("os.name", "unknown").jsonSafe() to VersionInfo.version.jsonSafe()
     }
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/analytics/AnalyticsEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/analytics/AnalyticsEvent.kt
@@ -5,9 +5,11 @@
 package io.askimo.core.analytics
 
 import io.askimo.core.VersionInfo
-import io.askimo.core.util.MachineId
+import io.askimo.core.util.AskimoHome
 import kotlinx.serialization.Serializable
+import java.nio.file.Files
 import java.util.Locale
+import java.util.UUID
 
 /**
  * Wire payload sent to the Askimo ingest endpoint.
@@ -44,9 +46,11 @@ data class AnalyticsEventPayload(
      */
     val timestampMs: Long = System.currentTimeMillis(),
     /**
-     * Stable anonymous device identifier derived from hardware via [MachineId].
-     * Used by the ingest endpoint to deduplicate feature-first-use events across
-     * sessions — no local tracking file is needed.
+     * Anonymous install-scoped identifier — a random UUID v4 persisted in
+     * [AnalyticsDeviceInfo.INSTALL_ID_FILE] (`~/.askimo/personal/.install_id`).
+     * Generated once on first access, stable across sessions for the same installation,
+     * regenerated on reinstall. No hardware signal, no PII.
+     * Used by the ingest endpoint to deduplicate events across sessions.
      */
     val installId: String = AnalyticsDeviceInfo.installId,
 )
@@ -54,13 +58,30 @@ data class AnalyticsEventPayload(
 /** Cached device-level facts resolved once at class-load time. */
 internal object AnalyticsDeviceInfo {
     /**
-     * Stable anonymous device identifier derived from hardware via [MachineId].
-     * The raw hardware value is SHA-256 hashed inside [MachineId] — nothing
-     * identifiable is ever stored or transmitted. Falls back to `"unknown"` only
-     * when every platform strategy fails (extremely unlikely).
+     * File name (relative to [AskimoHome.base()]) storing the anonymous install-scoped UUID.
+     * Generated once as a random UUID v4 on first access and reused for all subsequent sessions.
+     * No hardware data is ever read or stored — no MAC address, no CPU serial, nothing.
+     */
+    internal const val INSTALL_ID_FILE = ".install_id"
+
+    /**
+     * Anonymous install-scoped identifier — a random UUID v4 persisted in [INSTALL_ID_FILE].
+     * Stable across app sessions for the same installation; regenerated on reinstall.
+     * Falls back to `"unknown"` only when the home directory is completely inaccessible.
      */
     val installId: String by lazy {
-        MachineId.resolve() ?: "unknown"
+        val path = runCatching { AskimoHome.base().resolve(INSTALL_ID_FILE) }.getOrNull()
+            ?: return@lazy "unknown"
+        if (Files.exists(path)) {
+            val existing = runCatching { Files.readString(path).trim() }.getOrNull()
+            if (!existing.isNullOrBlank()) return@lazy existing
+        }
+        val id = UUID.randomUUID().toString()
+        runCatching {
+            Files.createDirectories(path.parent)
+            Files.writeString(path, id)
+        }
+        id
     }
 
     /** `"native"` when running under GraalVM substrate, otherwise the JVM major version. */

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -297,7 +297,7 @@ data class ProviderModelConfig(
  *   accommodate slow local models and cloud reasoning models with extended thinking.
  */
 data class ModelTimeoutsConfig(
-    @field:JsonAlias("utilityModelTimeoutSeconds") val utilityModelTimeoutSeconds: Long = 45,
+    @field:JsonAlias("utilityModelTimeoutSeconds") val utilityModelTimeoutSeconds: Long = 300,
     @field:JsonAlias("defaultModelTimeoutSeconds") val defaultModelTimeoutSeconds: Long = 300,
 )
 


### PR DESCRIPTION
- Escape JSON strings for OS, version, and install ID to prevent malformed telemetry payloads.
- Persist analytics installation ID to disk to ensure stable returning user tracking.
- Increase utility model timeout from 45 to 300 seconds to prevent premature request failures on slower models.