### PR TITLE
fix(docker-ai): update Docker AI model factory to use legacy OpenAI API

### DIFF
--- a/.github/workflows/shared-tests.yml
+++ b/.github/workflows/shared-tests.yml
@@ -1,13 +1,21 @@
-name: Shared Tests
+name: Tests
 
 on:
   pull_request:
   workflow_dispatch:
 
 jobs:
-  shared-test:
-    name: shared-test
-    runs-on: ubuntu-latest
+  test:
+    name: test-${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: linux
+          - os: windows-latest
+            name: windows
 
     steps:
       - name: Checkout
@@ -24,14 +32,22 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Run shared tests
-        run: ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx2g" :shared:test
+      - name: Run tests (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: ./gradlew --no-daemon -Dorg.gradle.jvmargs="-Xmx2g" test
 
-      - name: Upload test report
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          DISABLE_DOCKER_TESTS: 'true'
+        run: .\gradlew.bat --no-daemon "-Dorg.gradle.jvmargs=-Xmx2g" -PDISABLE_DOCKER_TESTS=true test
+
+      - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: shared-test-report-attempt${{ github.run_attempt }}
-          path: shared/build/reports/tests/test
+          name: test-reports-${{ matrix.name }}-attempt${{ github.run_attempt }}
+          path: "**/build/reports/tests/test"
           retention-days: 7
 

--- a/cli/src/main/kotlin/io/askimo/cli/recipes/RecipeExecutor.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/recipes/RecipeExecutor.kt
@@ -89,12 +89,12 @@ class RecipeExecutor(
         val output =
             appContext
                 .getStatelessChatClient()
-                .sendStreamingMessageWithCallback(null, UserMessage(prompt)) { _ ->
+                .sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
                     if (firstTokenSeen.compareAndSet(false, true)) {
                         indicator?.stopWithElapsed()
                         opts.terminal?.flush()
                     }
-                }.trim()
+                }).trim()
 
         // If no tokens ever arrived, still print a nice “done” line
         if (!firstTokenSeen.get()) {

--- a/cli/src/test/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactoryTest.kt
@@ -58,7 +58,7 @@ class AnthropicModelFactoryTest {
             )
 
         val prompt = "Reply with a single short word."
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt)) { _ -> }.trim()
+        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ -> }).trim()
 
         assertTrue(output.isNotBlank(), "Expected a non-empty response from Anthropic, but got blank: '$output'")
     }

--- a/cli/src/test/kotlin/io/askimo/core/providers/gemini/GeminiModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/gemini/GeminiModelFactoryTest.kt
@@ -51,9 +51,9 @@ class GeminiModelFactoryTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt)) { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
             print(".") // Show progress without overwhelming output
-        }.trim()
+        }).trim()
 
         println("\nFinal output: '$output'")
         return output

--- a/cli/src/test/kotlin/io/askimo/core/providers/ollama/OllamaModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/ollama/OllamaModelFactoryTest.kt
@@ -65,9 +65,9 @@ class OllamaModelFactoryTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt)) { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
             print(".")
-        }.trim()
+        }).trim()
 
         println("\nFinal output: '$output'")
         return output

--- a/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryProxyTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryProxyTest.kt
@@ -94,9 +94,9 @@ class OpenAiModelFactoryProxyTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt with proxy config: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt)) { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
             print(".")
-        }.trim()
+        }).trim()
 
         println("\nReceived response (length: ${output.length})")
         return output

--- a/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryTest.kt
@@ -51,9 +51,9 @@ class OpenAiModelFactoryTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt)) { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
             print(".")
-        }.trim()
+        }).trim()
 
         println("\nFinal output: '$output'")
         return output

--- a/cli/src/test/kotlin/io/askimo/core/providers/xai/XAiModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/xai/XAiModelFactoryTest.kt
@@ -52,9 +52,9 @@ class XAiModelFactoryTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt)) { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
             print(".")
-        }.trim()
+        }).trim()
 
         println("\nFinal output: '$output'")
         return output

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1054,6 +1054,7 @@ mermaid.button.expand=Mở rộng
 mermaid.button.zoom.in=Phóng to
 mermaid.button.zoom.out=Thu nhỏ
 mermaid.button.reset.zoom=Đặt lại thu phóng
+mermaid.button.retry=Thử lại
 mermaid.feedback.copied=Đã sao chép!
 
 # Reference Material

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -4,11 +4,20 @@
  */
 package io.askimo.core.providers.docker
 
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
+import dev.langchain4j.model.openai.OpenAiChatModel
+import dev.langchain4j.model.openai.OpenAiResponsesChatModel
+import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel
+import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
+import io.askimo.core.providers.ModelCapabilitiesCache
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ModelProvider.DOCKER
 import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.providers.ensureLocalEmbeddingModelAvailable
+import io.askimo.core.telemetry.TelemetryChatModelListener
 import java.net.http.HttpClient
 
 class DockerAiModelFactory : OpenAiCompatibleChatModelFactory<DockerAiSettings>() {
@@ -19,6 +28,34 @@ class DockerAiModelFactory : OpenAiCompatibleChatModelFactory<DockerAiSettings>(
 
     /** Docker AI does not support HTTP/2. */
     override fun httpVersion(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+
+    override fun createStreamingModel(settings: DockerAiSettings): StreamingChatModel {
+        val telemetry = AppContext.getInstance().telemetry
+        val supportsThinking = ModelCapabilitiesCache.supportsThinking(getProvider(), settings.defaultModel)
+        return OpenAiStreamingChatModel.builder()
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl))
+            .baseUrl(settings.baseUrl)
+            .apiKey(resolveApiKey(settings))
+            .modelName(settings.defaultModel)
+            .apply {
+                val reasoningLevel = ModelCapabilitiesCache.getReasoningLevel(getProvider(), settings.defaultModel)
+                if (supportsThinking && reasoningLevel.isEnabled) {
+                    reasoningEffort(reasoningLevel.value)
+                }
+            }
+            .logRequests(log.isDebugEnabled)
+            .logResponses(log.isDebugEnabled)
+            .listeners(listOf(TelemetryChatModelListener(telemetry, getProvider().providerKey())))
+            .build()
+    }
+
+    override fun createSecondaryModel(settings: DockerAiSettings): ChatModel = OpenAiChatModel.builder()
+        .httpClientBuilder(createHttpClientBuilder(settings.baseUrl))
+        .baseUrl(settings.baseUrl)
+        .apiKey(resolveApiKey(settings))
+        .modelName(AppConfig.models[getProvider()].utilityModel.ifBlank { utilityModelFallback(settings) })
+        .logRequests(log.isDebugEnabled)
+        .build()
 
     /**
      * When no explicit utility model is configured, fall back to whichever model is currently

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -7,8 +7,6 @@ package io.askimo.core.providers.docker
 import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.openai.OpenAiChatModel
-import dev.langchain4j.model.openai.OpenAiResponsesChatModel
-import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext


### PR DESCRIPTION
- DockerModelFactory uses the legacy OpenAI api
- Update workflow to rename job, set DISABLE_DOCKER_TESTS env, adjust Gradle command, and correct test reports path