### PR TITLE
refactor(memory): Improve memory context tracking and token budget

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
@@ -35,6 +35,10 @@ import java.time.Instant
  * Tests cover:
  * - Basic message storage and retrieval
  * - Token-aware summarization triggering
+ * - Protected recent turns (last 6 messages always kept verbatim)
+ * - Summarization prune fraction (65% of candidates pruned per cycle)
+ * - keyFacts cap (MAX_KEY_FACTS = 30) with LRU-by-relevance eviction
+ * - mainTopics cap (MAX_MAIN_TOPICS = 15)
  * - Async summarization behavior
  * - Memory persistence (import/export)
  * - Database integration
@@ -53,20 +57,16 @@ class TokenAwareSummarizingMemoryTest {
 
     @BeforeEach
     fun setup() {
-        // Create mocks
         mockAppContext = mock()
         mockChatClient = mock()
         mockRepository = mock()
         mockParams = mock()
 
-        // Setup default AppContext behavior
         whenever(mockAppContext.createUtilityClient()).thenReturn(mockChatClient)
         whenever(mockAppContext.getActiveProvider()).thenReturn(io.askimo.core.providers.ModelProvider.OPENAI)
         whenever(mockAppContext.params).thenReturn(mockParams)
         whenever(mockParams.model).thenReturn("gpt-4")
         whenever(mockAppContext.buildUserMemoryPrefix()).thenReturn("")
-
-        // Mock repository to return null (no existing memory)
         whenever(mockRepository.getBySessionId(any())).thenReturn(null)
     }
 
@@ -77,18 +77,17 @@ class TokenAwareSummarizingMemoryTest {
         }
     }
 
+    // ── Basic storage ────────────────────────────────────────────────────────
+
     @Test
     fun `should initialize empty memory`() {
         memory = createMemory()
-
-        val messages = memory.messages()
-        assertEquals(0, messages.size, "Memory should be empty on initialization")
+        assertEquals(0, memory.messages().size, "Memory should be empty on initialization")
     }
 
     @Test
     fun `should add messages to memory`() {
         memory = createMemory()
-
         memory.add(UserMessage.from("Hello"))
         memory.add(AiMessage.from("Hi there!"))
 
@@ -102,140 +101,269 @@ class TokenAwareSummarizingMemoryTest {
     fun `should estimate tokens correctly with default estimator`() {
         memory = createMemory()
 
-        // Add a message with known word count
-        val testMessage = UserMessage.from("one two three four five") // 5 words
+        // Default estimator: words × 1.75 — "one two three four five" = 5 words → 8 tokens
+        val testMessage = UserMessage.from("one two three four five")
         memory.add(testMessage)
 
-        // Default estimator: words * 1.3 = 5 * 1.3 = 6.5 -> 6 tokens
-        val messages = memory.messages()
-        assertEquals(1, messages.size)
+        assertEquals(1, memory.messages().size)
     }
 
     @Test
-    fun `should not trigger summarization below threshold`() {
-        memory = createMemory(
-            summarizationThreshold = 0.9,
-            asyncSummarization = false,
-        )
+    fun `default token estimator uses 1_75 multiplier`() {
+        val estimator = TokenAwareSummarizingMemory.defaultTokenEstimator()
+        val msg = UserMessage.from("one two three four") // 4 words × 1.75 = 7
+        assertEquals(7, estimator(msg))
+    }
 
-        // Add a few messages (should be below 90% threshold)
+    // ── Summarization threshold ──────────────────────────────────────────────
+
+    @Test
+    fun `should not trigger summarization below threshold`() {
+        memory = createMemory(summarizationThreshold = 0.9, asyncSummarization = false)
+
         memory.add(UserMessage.from("Short message"))
         memory.add(AiMessage.from("Another short response"))
 
-        // Verify no summarization occurred
-        val messages = memory.messages()
-        assertFalse(messages.any { it is SystemMessage }, "No summary should be generated below threshold")
+        assertFalse(
+            memory.messages().any { it is SystemMessage },
+            "No summary should be generated below threshold",
+        )
     }
 
     @Test
     fun `should trigger summarization above threshold`() {
-        // Use synchronous summarization for predictable testing
-        // Set very low threshold (1%) to trigger easily
-        memory = createMemory(
-            summarizationThreshold = 0.01,
-            asyncSummarization = false,
-        )
+        memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false)
 
-        // Mock the summarization response
         whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """
-            {
-                "keyFacts": {"topic": "testing"},
-                "mainTopics": ["memory", "summarization"],
-                "recentContext": "Testing summarization feature"
-            }
-            """.trimIndent(),
+            """{"keyFacts":{"topic":"testing"},"mainTopics":["memory"],"recentContext":"test"}""",
         )
 
-        // Add many messages with long content to ensure we exceed even 1% of token budget
-        // Default estimator: words * 1.3, so each message ~65 tokens
         repeat(100) { i ->
-            memory.add(UserMessage.from("Test message number $i with some additional content to increase the token count significantly " + "word ".repeat(30)))
-            memory.add(AiMessage.from("Response to message $i with additional content and more words " + "word ".repeat(30)))
+            memory.add(UserMessage.from("Test message $i " + "word ".repeat(30)))
+            memory.add(AiMessage.from("Response $i " + "word ".repeat(30)))
         }
 
-        // Wait for async operations to complete (even with asyncSummarization=false, it uses executor)
         Thread.sleep(2000)
-
-        // Close memory to ensure all async operations complete
         memory.close()
 
-        // Verify summarization was triggered at least once
         verify(mockChatClient, atLeastOnce()).sendMessage(any())
     }
 
+    // ── Protected recent turns ───────────────────────────────────────────────
+
+    @Test
+    fun `should not summarize when all messages are within protected window`() {
+        // PROTECTED_RECENT_TURNS = 6; with ≤ 6 messages there are 0 candidates → skip
+        memory = createMemory(summarizationThreshold = 0.0001, asyncSummarization = false)
+
+        whenever(mockChatClient.sendMessage(any())).thenReturn(
+            """{"keyFacts":{},"mainTopics":[],"recentContext":""}""",
+        )
+
+        // Add exactly 6 messages — all protected, nothing to prune
+        repeat(6) { i -> memory.add(UserMessage.from("msg $i " + "word ".repeat(50))) }
+
+        Thread.sleep(500)
+        memory.close()
+
+        // All 6 messages should remain because the summarizer exits early when
+        // messagesToSummarizeCount == 0
+        val remaining = memory.messages().filterIsInstance<UserMessage>()
+        assertEquals(6, remaining.size, "All 6 protected messages should remain unpruned")
+    }
+
+    @Test
+    fun `should prune only non-protected messages`() {
+        // Use a fixed token estimator so we control exactly when the trigger fires
+        var messageCount = 0
+        val countingEstimator: (ChatMessage) -> Int = { _ ->
+            messageCount++
+            1000 // each message = 1000 tokens, triggers immediately
+        }
+
+        memory = createMemory(
+            summarizationThreshold = 0.001,
+            asyncSummarization = false,
+            tokenEstimator = countingEstimator,
+        )
+
+        whenever(mockChatClient.sendMessage(any())).thenReturn(
+            """{"keyFacts":{},"mainTopics":[],"recentContext":""}""",
+        )
+
+        // Add 12 messages: 6 are protected, 6 are candidates → 65% of 6 ≈ 3 pruned
+        repeat(12) { i -> memory.add(UserMessage.from("msg $i")) }
+
+        Thread.sleep(1000)
+        memory.close()
+
+        // After pruning, at least 6 protected messages should survive
+        val remaining = memory.messages().filterIsInstance<UserMessage>()
+        assertTrue(remaining.size >= 6, "At least 6 protected messages must survive; got ${remaining.size}")
+    }
+
+    // ── keyFacts cap + LRU eviction ──────────────────────────────────────────
+
+    @Test
+    fun `mergeWithExistingSummary caps keyFacts at MAX_KEY_FACTS`() {
+        // Use a high token estimator so each message immediately blows past the threshold
+        memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false, tokenEstimator = { _ -> 10_000 })
+
+        // Build a summary with 30 facts (fills the cap exactly)
+        val initialFacts = (1..30).associate { "fact$it" to "value$it" }
+        val initialSummary = SessionConversationSummary(keyFacts = initialFacts, mainTopics = emptyList(), recentContext = "")
+        memory.importState(TokenAwareSummarizingMemory.MemoryState(messages = emptyList(), summary = initialSummary))
+
+        // Simulate a new summarization that adds 5 more facts (should evict oldest)
+        whenever(mockChatClient.sendMessage(any())).thenReturn(
+            """{"keyFacts":{"fact31":"v31","fact32":"v32","fact33":"v33","fact34":"v34","fact35":"v35"},"mainTopics":[],"recentContext":"new"}""",
+        )
+
+        repeat(50) { i -> memory.add(UserMessage.from("msg $i " + "word ".repeat(30))) }
+
+        Thread.sleep(2000)
+        memory.close()
+
+        val state = memory.exportState()
+        val facts = state.summary?.keyFacts ?: emptyMap()
+        assertTrue(facts.size <= 30, "keyFacts must not exceed MAX_KEY_FACTS=30; got ${facts.size}")
+        // New facts should be present (they were refreshed most recently)
+        assertTrue(facts.containsKey("fact31") || facts.containsKey("fact35"), "New facts should survive the cap")
+        // Oldest facts (1–5) should have been evicted
+        assertFalse(facts.containsKey("fact1"), "Oldest fact should have been evicted")
+    }
+
+    @Test
+    fun `mergeWithExistingSummary refreshes position of updated key`() {
+        // Use a high token estimator so messages immediately exceed the threshold and
+        // force summarization — without it the token count never reaches the trigger point.
+        memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false, tokenEstimator = { _ -> 10_000 })
+
+        // Initial summary with 30 facts — fact1 is oldest
+        val initialFacts = (1..30).associate { "fact$it" to "value$it" }
+        val initialSummary = SessionConversationSummary(keyFacts = initialFacts, mainTopics = emptyList(), recentContext = "")
+        memory.importState(TokenAwareSummarizingMemory.MemoryState(messages = emptyList(), summary = initialSummary))
+
+        // Simulate a new cycle that updates fact1 (refreshes it) and adds 5 new facts
+        whenever(mockChatClient.sendMessage(any())).thenReturn(
+            """{"keyFacts":{"fact1":"updated","fact31":"v31","fact32":"v32","fact33":"v33","fact34":"v34","fact35":"v35"},"mainTopics":[],"recentContext":"ctx"}""",
+        )
+
+        repeat(50) { i -> memory.add(UserMessage.from("msg $i " + "word ".repeat(30))) }
+
+        Thread.sleep(2000)
+        memory.close()
+
+        val facts = memory.exportState().summary?.keyFacts ?: emptyMap()
+        assertTrue(facts.size <= 30, "Cap must hold at 30")
+        // fact1 was re-inserted (updated) so it should survive; fact2 should be evicted
+        assertTrue(facts.containsKey("fact1"), "Updated fact1 should have been refreshed and kept")
+        assertFalse(facts.containsKey("fact2"), "fact2 was not refreshed and should have been evicted")
+    }
+
+    // ── mainTopics cap ───────────────────────────────────────────────────────
+
+    @Test
+    fun `mergeWithExistingSummary caps mainTopics at MAX_MAIN_TOPICS`() {
+        memory = createMemory()
+
+        // Initial summary with 15 topics
+        val initialTopics = (1..15).map { "topic$it" }
+        val initialSummary = SessionConversationSummary(keyFacts = emptyMap(), mainTopics = initialTopics, recentContext = "")
+        memory.importState(TokenAwareSummarizingMemory.MemoryState(messages = emptyList(), summary = initialSummary))
+
+        // New cycle adds 5 more distinct topics
+        whenever(mockChatClient.sendMessage(any())).thenReturn(
+            """{"keyFacts":{},"mainTopics":["topic16","topic17","topic18","topic19","topic20"],"recentContext":"ctx"}""",
+        )
+
+        repeat(50) { i -> memory.add(UserMessage.from("msg $i " + "word ".repeat(30))) }
+
+        Thread.sleep(2000)
+        memory.close()
+
+        val topics = memory.exportState().summary?.mainTopics ?: emptyList()
+        assertTrue(topics.size <= 15, "mainTopics must not exceed MAX_MAIN_TOPICS=15; got ${topics.size}")
+        // takeLast keeps most recent — new topics should be present
+        assertTrue(
+            topics.any { it.startsWith("topic1") && it.length > 6 },
+            "Recent topics (16–20) should be present",
+        )
+    }
+
+    // ── Summary merge ────────────────────────────────────────────────────────
+
+    @Test
+    fun `should merge summaries when multiple summarizations occur`() {
+        memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false)
+
+        whenever(mockChatClient.sendMessage(any())).thenReturn(
+            """{"keyFacts":{"fact1":"value1"},"mainTopics":["topic1"],"recentContext":"First context"}""",
+        )
+        repeat(100) { i -> memory.add(UserMessage.from("Batch 1 msg $i " + "word ".repeat(30))) }
+        Thread.sleep(2000)
+
+        whenever(mockChatClient.sendMessage(any())).thenReturn(
+            """{"keyFacts":{"fact2":"value2"},"mainTopics":["topic2"],"recentContext":"Second context"}""",
+        )
+        repeat(100) { i -> memory.add(UserMessage.from("Batch 2 msg $i " + "word ".repeat(30))) }
+        Thread.sleep(2000)
+        memory.close()
+
+        val facts = memory.exportState().summary?.keyFacts ?: emptyMap()
+        assertNotNull(memory.exportState().summary)
+        assertTrue(
+            facts.containsKey("fact1") || facts.containsKey("fact2"),
+            "Merged summary should contain facts from both summarizations",
+        )
+    }
+
+    // ── System message preservation ──────────────────────────────────────────
+
     @Test
     fun `should preserve system messages during summarization`() {
-        memory = createMemory(
-            summarizationThreshold = 0.01,
-            asyncSummarization = false,
-        )
+        memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false)
 
-        // Mock the summarization response
         whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """
-            {
-                "keyFacts": {},
-                "mainTopics": [],
-                "recentContext": "test"
-            }
-            """.trimIndent(),
+            """{"keyFacts":{},"mainTopics":[],"recentContext":"test"}""",
         )
 
-        // Add system message
-        val systemMessage = SystemMessage.from("You are a helpful assistant")
-        memory.add(systemMessage)
-
-        // Add many user/AI messages to trigger summarization
+        memory.add(SystemMessage.from("You are a helpful assistant"))
         repeat(100) { i ->
             memory.add(UserMessage.from("Message $i " + "word ".repeat(30)))
             memory.add(AiMessage.from("Response $i " + "word ".repeat(30)))
         }
 
-        // Wait for summarization and close to ensure completion
         Thread.sleep(2000)
         memory.close()
 
-        val messages = memory.messages()
-        val systemMessages = messages.filterIsInstance<SystemMessage>()
-
-        // Should have at least the original system message preserved (not removed during pruning)
-        // Note: System messages from summarization may also be present
-        assertTrue(systemMessages.isNotEmpty(), "System messages should be preserved")
+        assertTrue(memory.messages().filterIsInstance<SystemMessage>().isNotEmpty(), "System messages should be preserved")
     }
+
+    // ── Clear / export / import ──────────────────────────────────────────────
 
     @Test
     fun `should clear all messages and summary`() {
         memory = createMemory()
-
         memory.add(UserMessage.from("Test"))
         memory.add(AiMessage.from("Response"))
-
         memory.clear()
-
-        val messages = memory.messages()
-        assertEquals(0, messages.size, "All messages should be cleared")
+        assertEquals(0, memory.messages().size)
     }
 
     @Test
     fun `should export and import memory state`() {
         memory = createMemory()
-
-        // Add messages
         memory.add(UserMessage.from("Question 1"))
         memory.add(AiMessage.from("Answer 1"))
         memory.add(UserMessage.from("Question 2"))
 
-        // Export state
         val state = memory.exportState()
-
-        // Create new memory and import state
         memory.clear()
         assertEquals(0, memory.messages().size)
 
         memory.importState(state)
 
-        // Verify imported state
         val messages = memory.messages()
         assertEquals(3, messages.size)
         assertEquals("Question 1", (messages[0] as UserMessage).singleText())
@@ -243,18 +371,32 @@ class TokenAwareSummarizingMemoryTest {
     }
 
     @Test
+    fun `should serialize and deserialize memory state correctly`() {
+        memory = createMemory()
+        memory.add(UserMessage.from("User question"))
+        memory.add(AiMessage.from("AI answer"))
+        memory.add(SystemMessage.from("System instruction"))
+
+        val state = memory.exportState()
+        assertEquals(3, state.messages.size)
+        assertNull(state.summary, "No summary should exist yet")
+
+        memory.clear()
+        memory.importState(state)
+        assertEquals(3, memory.messages().size)
+    }
+
+    // ── Persistence ──────────────────────────────────────────────────────────
+
+    @Test
     fun `should persist to database when adding messages`() {
         memory = createMemory()
-
         memory.add(UserMessage.from("Test message"))
-
-        // Verify saveMemory was called
         verify(mockRepository, times(1)).saveMemory(any())
     }
 
     @Test
     fun `should load from database on initialization`() {
-        // Setup repository to return existing memory
         val existingMemory = SessionMemory(
             sessionId = sessionId,
             memorySummary = null,
@@ -268,7 +410,6 @@ class TokenAwareSummarizingMemoryTest {
         )
         whenever(mockRepository.getBySessionId(sessionId)).thenReturn(existingMemory)
 
-        // Create memory - should load from DB
         memory = createMemory()
 
         val messages = memory.messages()
@@ -278,133 +419,84 @@ class TokenAwareSummarizingMemoryTest {
     }
 
     @Test
+    fun `should handle database load failure gracefully`() {
+        whenever(mockRepository.getBySessionId(any())).thenThrow(RuntimeException("Database error"))
+        memory = createMemory()
+        assertEquals(0, memory.messages().size, "Should start with empty memory on load failure")
+    }
+
+    @Test
+    fun `should handle database save failure gracefully`() {
+        whenever(mockRepository.saveMemory(any())).thenThrow(RuntimeException("Database error"))
+        memory = createMemory()
+        memory.add(UserMessage.from("Test"))
+        assertEquals(1, memory.messages().size, "Message should still be in memory despite save failure")
+    }
+
+    // ── Error handling ───────────────────────────────────────────────────────
+
+    @Test
+    fun `should handle summarization failure gracefully with fallback`() {
+        memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false)
+        whenever(mockChatClient.sendMessage(any())).thenThrow(RuntimeException("API Error"))
+
+        repeat(100) { i -> memory.add(UserMessage.from("Message $i " + "word ".repeat(30))) }
+
+        Thread.sleep(2000)
+        memory.close()
+
+        assertNotNull(memory.messages(), "Memory should continue functioning despite summarization failure")
+    }
+
+    @Test
     fun `should handle empty conversation gracefully`() {
         memory = createMemory()
-
         val messages = memory.messages()
         assertNotNull(messages)
         assertEquals(0, messages.size)
     }
+
+    // ── Custom token estimator ───────────────────────────────────────────────
 
     @Test
     fun `should use custom token estimator when provided`() {
         var estimatorCalled = false
         val customEstimator: (ChatMessage) -> Int = { _ ->
             estimatorCalled = true
-            100 // Always return 100 tokens
+            100
         }
 
         memory = createMemory(tokenEstimator = customEstimator)
-
         memory.add(UserMessage.from("Test"))
-
         assertTrue(estimatorCalled, "Custom token estimator should be called")
     }
 
-    @Test
-    fun `should merge summaries when multiple summarizations occur`() {
-        memory = createMemory(
-            summarizationThreshold = 0.01,
-            asyncSummarization = false,
-        )
-
-        // First summarization
-        whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """
-            {
-                "keyFacts": {"fact1": "value1"},
-                "mainTopics": ["topic1"],
-                "recentContext": "First context"
-            }
-            """.trimIndent(),
-        )
-
-        repeat(100) { i ->
-            memory.add(UserMessage.from("Message batch 1 - $i " + "word ".repeat(30)))
-        }
-
-        Thread.sleep(2000)
-
-        // Second summarization with different facts
-        whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """
-            {
-                "keyFacts": {"fact2": "value2"},
-                "mainTopics": ["topic2"],
-                "recentContext": "Second context"
-            }
-            """.trimIndent(),
-        )
-
-        repeat(100) { i ->
-            memory.add(UserMessage.from("Message batch 2 - $i " + "word ".repeat(30)))
-        }
-
-        Thread.sleep(2000)
-        memory.close()
-
-        // Verify both facts are preserved in summary
-        val state = memory.exportState()
-        assertNotNull(state.summary)
-        assertTrue(
-            state.summary?.keyFacts?.containsKey("fact1") == true || state.summary?.keyFacts?.containsKey("fact2") == true,
-            "Merged summary should contain facts from both summarizations",
-        )
-    }
-
-    @Test
-    fun `should handle summarization failure gracefully with fallback`() {
-        memory = createMemory(
-            summarizationThreshold = 0.01,
-            asyncSummarization = false,
-        )
-
-        // Mock summarization to throw exception
-        whenever(mockChatClient.sendMessage(any())).thenThrow(RuntimeException("API Error"))
-
-        repeat(100) { i ->
-            memory.add(UserMessage.from("Message $i " + "word ".repeat(30)))
-        }
-
-        Thread.sleep(2000)
-        memory.close()
-
-        // Memory should still function with basic summary fallback
-        val messages = memory.messages()
-        assertNotNull(messages, "Memory should continue functioning despite summarization failure")
-    }
+    // ── Concurrency ──────────────────────────────────────────────────────────
 
     @Test
     fun `should handle concurrent message additions safely`() {
         memory = createMemory()
 
         val threads = (1..10).map { threadId ->
-            Thread {
-                repeat(10) { i ->
-                    memory.add(UserMessage.from("Thread $threadId - Message $i"))
-                }
-            }
+            Thread { repeat(10) { i -> memory.add(UserMessage.from("Thread $threadId - Message $i")) } }
         }
-
         threads.forEach { it.start() }
         threads.forEach { it.join() }
 
-        val messages = memory.messages()
-        assertEquals(100, messages.size, "All concurrent messages should be added")
+        assertEquals(100, memory.messages().size, "All concurrent messages should be added")
     }
+
+    // ── Misc ─────────────────────────────────────────────────────────────────
 
     @Test
     fun `should extract text content from different message types`() {
         memory = createMemory()
-
         memory.add(UserMessage.from("User text"))
         memory.add(AiMessage.from("AI text"))
         memory.add(SystemMessage.from("System text"))
 
         val messages = memory.messages()
         assertEquals(3, messages.size)
-
-        // Verify each message type is stored correctly
         assertTrue(messages[0] is UserMessage)
         assertTrue(messages[1] is AiMessage)
         assertTrue(messages[2] is SystemMessage)
@@ -413,82 +505,21 @@ class TokenAwareSummarizingMemoryTest {
     @Test
     fun `should close executor service properly`() {
         memory = createMemory()
-
         memory.add(UserMessage.from("Test"))
-
-        // Close should not hang
-        memory.close()
-
-        // Attempting to use after close is implementation-defined
-        // but close itself should complete
-    }
-
-    @Test
-    fun `should handle database load failure gracefully`() {
-        // Mock repository to throw exception
-        whenever(mockRepository.getBySessionId(any())).thenThrow(RuntimeException("Database error"))
-
-        // Should not crash on initialization
-        memory = createMemory()
-
-        val messages = memory.messages()
-        assertEquals(0, messages.size, "Should start with empty memory on load failure")
-    }
-
-    @Test
-    fun `should handle database save failure gracefully`() {
-        // Mock repository to throw exception on save
-        whenever(mockRepository.saveMemory(any())).thenThrow(RuntimeException("Database error"))
-
-        memory = createMemory()
-
-        // Should not crash when adding messages
-        memory.add(UserMessage.from("Test"))
-
-        val messages = memory.messages()
-        assertEquals(1, messages.size, "Message should still be in memory despite save failure")
+        memory.close() // Should not hang
     }
 
     @Test
     fun `should calculate maxTokens based on model context size`() {
-        // This is a behavioral test - memory should adapt to model context size
         memory = createMemory()
-
-        // Add messages - the memory should use appropriate limits based on model
         memory.add(UserMessage.from("Test message"))
-
-        val messages = memory.messages()
-        assertNotNull(messages, "Memory should function with dynamic token calculation")
-    }
-
-    @Test
-    fun `should serialize and deserialize memory state correctly`() {
-        memory = createMemory()
-
-        // Add various message types
-        memory.add(UserMessage.from("User question"))
-        memory.add(AiMessage.from("AI answer"))
-        memory.add(SystemMessage.from("System instruction"))
-
-        // Export and verify serialization
-        val state = memory.exportState()
-
-        assertEquals(3, state.messages.size)
-        assertNull(state.summary, "No summary should exist yet")
-
-        // Import into new memory
-        memory.clear()
-        memory.importState(state)
-
-        val restoredMessages = memory.messages()
-        assertEquals(3, restoredMessages.size)
+        assertNotNull(memory.messages(), "Memory should function with dynamic token calculation")
     }
 
     @Test
     fun `should handle very long messages`() {
         memory = createMemory()
-
-        val longText = "word ".repeat(10000) // Very long message
+        val longText = "word ".repeat(10000)
         memory.add(UserMessage.from(longText))
 
         val messages = memory.messages()
@@ -499,24 +530,19 @@ class TokenAwareSummarizingMemoryTest {
     @Test
     fun `should maintain message order`() {
         memory = createMemory()
-
-        val messageTexts = (1..10).map { "Message $it" }
-        messageTexts.forEach { text ->
-            memory.add(UserMessage.from(text))
-        }
+        (1..10).forEach { i -> memory.add(UserMessage.from("Message $i")) }
 
         val messages = memory.messages()
         assertEquals(10, messages.size)
-
-        // Verify order is preserved
         messages.forEachIndexed { index, message ->
             assertEquals("Message ${index + 1}", (message as UserMessage).singleText())
         }
     }
 
-    // Helper function to create memory instance with default settings
+    // ── Helper ───────────────────────────────────────────────────────────────
+
     private fun createMemory(
-        summarizationThreshold: Double = 0.6,
+        summarizationThreshold: Double = 0.4, // matches updated default
         asyncSummarization: Boolean = true,
         tokenEstimator: (ChatMessage) -> Int = TokenAwareSummarizingMemory.defaultTokenEstimator(),
         summarizationTimeoutSeconds: Long = 30,

--- a/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
@@ -86,23 +86,62 @@ data class UserMemorySummary(
 }
 
 /**
- * This memory keeps recent messages in full detail while creating either a structured
- * AI-powered summary or a simple extractive summary of older messages to preserve
- * context without exceeding token limits.
+ * Token-aware summarizing memory that keeps recent messages verbatim while compressing
+ * older history into a structured summary to stay within model context limits.
  *
- * Memory persistence is mandatory - sessionId and sessionMemoryRepository are required.
- * The memory automatically loads from database on creation and saves after every change.
+ * ## Memory budget
  *
- * The maximum tokens for memory is dynamically calculated as 40% of the model's context
- * window size, ensuring optimal utilization regardless of which model is active.
+ * The total context window is split into three fixed allocations:
+ *
+ * ```
+ * ┌─────────────────────────────────────────────────────────┐
+ * │  Context window  (e.g. 128 000 tokens)                  │
+ * ├──────────────────┬──────────────────┬───────────────────┤
+ * │  History memory  │  Current request │  AI response      │
+ * │  40 %  (51 200)  │  40 %  (51 200)  │  20 %  (25 600)   │
+ * └──────────────────┴──────────────────┴───────────────────┘
+ * ```
+ *
+ * ## Summarization trigger
+ *
+ * Summarization fires when the in-memory token estimate exceeds
+ * `maxTokens × summarizationThreshold` (default **0.4** = 16 % of the full
+ * context window). Firing at 40 % of the memory budget keeps the usage curve
+ * flat and avoids large spikes just before each summarization cycle.
+ *
+ * ## What gets summarized
+ *
+ * The last [PROTECTED_RECENT_TURNS] messages are always kept verbatim so the AI
+ * always sees full-fidelity context for the most recent exchanges. Of the
+ * remaining candidates, [SUMMARIZATION_PRUNE_FRACTION] (65 %) are compressed
+ * and pruned oldest-first each cycle, creating generous breathing room before
+ * the next trigger fires.
+ *
+ * Example with 20 messages:
+ * ```
+ * Messages:  1  2  3  4  5  6  7  8  9 | 10 11 12 13 14 | 15 16 17 18 19 20
+ *            ←──── pruned this cycle ───→  ←── deferred ──→  ←── protected ──→
+ * ```
+ * - Protected (always verbatim): messages 15–20  (last 6)
+ * - Candidates (eligible for pruning): messages 1–14  (20 − 6)
+ * - Pruned this cycle: messages 1–9  (65 % of 14 ≈ 9, oldest first)
+ * - Deferred to next cycle: messages 10–14  (the remaining 35 % of candidates
+ *   that the 65 % fraction did not reach — they will be first in line next time)
+ *
+ * ## Token estimator
+ *
+ * Uses `word_count × 1.75` — a conservative multiplier that accounts for code
+ * blocks, JSON, URLs, and non-ASCII content which tokenize at much higher ratios
+ * than plain prose. Overshooting slightly is safe; undershooting silently exceeds
+ * the budget.
  *
  * @param appContext The application context for accessing model information
  * @param sessionId The session ID this memory belongs to (required for persistence)
  * @param sessionMemoryRepository Repository for persisting memory state (required)
- * @param tokenEstimator Function to estimate token count for a message (default: words * 1.3)
- * @param summarizationThreshold Percentage (0.0-1.0) of maxTokens at which to trigger summarization, default 0.6
- * @param asyncSummarization Whether to run summarization asynchronously, default true
- * @param summarizationTimeoutSeconds Timeout for summarization operations in seconds, default 300
+ * @param tokenEstimator Function to estimate token count for a message (default: words × 1.75)
+ * @param summarizationThreshold Fraction (0.0–1.0) of maxTokens at which summarization fires (default 0.4)
+ * @param asyncSummarization Whether to run summarization asynchronously (default true)
+ * @param summarizationTimeoutSeconds Timeout for summarization operations in seconds (default 300)
  */
 class TokenAwareSummarizingMemory(
     private val appContext: AppContext,
@@ -110,7 +149,7 @@ class TokenAwareSummarizingMemory(
     private val sessionMemoryRepository: SessionMemoryRepository,
     private val userMemoryRepository: UserMemoryRepository? = null,
     private val tokenEstimator: (ChatMessage) -> Int = defaultTokenEstimator(),
-    private val summarizationThreshold: Double = 0.6,
+    private val summarizationThreshold: Double = 0.4,
     asyncSummarization: Boolean = true,
     private val summarizationTimeoutSeconds: Long = 300,
 ) : ChatMemory,
@@ -359,7 +398,8 @@ class TokenAwareSummarizingMemory(
                         messages.filterNot { it.type() == ChatMessageType.SYSTEM }
                     }
                     if (conversationMessages.isNotEmpty()) {
-                        val messagesToSummarizeCount = (conversationMessages.size * 0.45).toInt().coerceAtLeast(1)
+                        val summarizableCandidates = (conversationMessages.size - PROTECTED_RECENT_TURNS).coerceAtLeast(0)
+                        val messagesToSummarizeCount = (summarizableCandidates * SUMMARIZATION_PRUNE_FRACTION).toInt().coerceAtLeast(if (summarizableCandidates > 0) 1 else conversationMessages.size)
                         val messagesToSummarize = conversationMessages.take(messagesToSummarizeCount)
                         generateBasicSummary(messagesToSummarize)
                         pruneMessages(messagesToSummarize)
@@ -395,12 +435,23 @@ class TokenAwareSummarizingMemory(
 
         if (conversationMessages.isEmpty()) return
 
-        val messagesToSummarizeCount = (conversationMessages.size * 0.45).toInt().coerceAtLeast(1)
+        // Always protect the most recent turns verbatim. Summarize 65% of the
+        // remaining candidates (oldest first) so each cycle creates significant
+        // breathing room before the next trigger fires.
+        val summarizableCandidates = (conversationMessages.size - PROTECTED_RECENT_TURNS).coerceAtLeast(0)
+        val messagesToSummarizeCount = (summarizableCandidates * SUMMARIZATION_PRUNE_FRACTION).toInt().coerceAtLeast(
+            if (summarizableCandidates > 0) 1 else 0,
+        )
+
+        if (messagesToSummarizeCount == 0) {
+            log.debug("Not enough non-protected messages to summarize yet (total: ${conversationMessages.size}, protected: $PROTECTED_RECENT_TURNS)")
+            return
+        }
 
         // Copy messages to avoid holding lock during AI call
         val messagesToSummarize = conversationMessages.take(messagesToSummarizeCount)
 
-        log.info("Summarizing $messagesToSummarizeCount out of ${conversationMessages.size} conversation messages (excluding system messages)")
+        log.info("Summarizing $messagesToSummarizeCount out of ${conversationMessages.size} conversation messages (protected last $PROTECTED_RECENT_TURNS)")
 
         try {
             generateStructuredSummary(messagesToSummarize)
@@ -462,16 +513,37 @@ class TokenAwareSummarizingMemory(
     }
 
     private fun mergeWithExistingSummary(newSummary: SessionConversationSummary): SessionConversationSummary {
-        val existing = structuredSummary
-        return if (existing != null) {
-            SessionConversationSummary(
-                keyFacts = existing.keyFacts + newSummary.keyFacts,
-                mainTopics = (existing.mainTopics + newSummary.mainTopics).distinct(),
-                recentContext = newSummary.recentContext,
-            )
-        } else {
-            newSummary
+        val existing = structuredSummary ?: return newSummary
+
+        // Merge keyFacts using LRU-by-relevance: existing facts come first, then new
+        // facts are re-inserted at the end (removing the old entry first so that
+        // updating an existing key refreshes its "recency" position). When the total
+        // exceeds MAX_KEY_FACTS the oldest entries at the front are dropped — these are
+        // facts that have not appeared in any recent summarization cycle and are
+        // therefore the least likely to still be relevant.
+        val mergedFacts = LinkedHashMap<String, String>(existing.keyFacts)
+        newSummary.keyFacts.forEach { (k, v) ->
+            mergedFacts.remove(k) // reset insertion order so updated keys move to back
+            mergedFacts[k] = v
         }
+        val cappedFacts = if (mergedFacts.size > MAX_KEY_FACTS) {
+            mergedFacts.entries
+                .drop(mergedFacts.size - MAX_KEY_FACTS)
+                .associate { it.toPair() }
+        } else {
+            mergedFacts.toMap()
+        }
+
+        // Cap mainTopics — takeLast keeps the most recently observed topics.
+        val mergedTopics = (existing.mainTopics + newSummary.mainTopics)
+            .distinct()
+            .takeLast(MAX_MAIN_TOPICS)
+
+        return SessionConversationSummary(
+            keyFacts = cappedFacts,
+            mainTopics = mergedTopics,
+            recentContext = newSummary.recentContext,
+        )
     }
 
     /**
@@ -661,7 +733,42 @@ class TokenAwareSummarizingMemory(
         private const val MAX_SUMMARY_LENGTH = 2000
 
         /**
-         * Default token estimator that approximates token count as word count * 1.3
+         * Number of most-recent conversation messages always kept verbatim.
+         * These are never included in a summarization batch, ensuring the AI
+         * always sees full-fidelity context for the latest exchanges.
+         */
+        private const val PROTECTED_RECENT_TURNS = 6
+
+        /**
+         * Fraction of the summarizable (non-protected) messages to compress
+         * and prune each summarization cycle. 0.65 means 65% of candidates are
+         * removed, leaving more breathing room before the next cycle fires.
+         */
+        private const val SUMMARIZATION_PRUNE_FRACTION = 0.65
+
+        /**
+         * Maximum number of key facts retained in the merged structured summary.
+         * Uses LRU-by-relevance eviction: facts that appear in recent summarization
+         * cycles are refreshed to the back of the map; facts not seen recently drift
+         * to the front and are dropped when this cap is exceeded.
+         */
+        private const val MAX_KEY_FACTS = 30
+
+        /**
+         * Maximum number of distinct main topics retained across summary merges.
+         * The most recently observed topics are kept (takeLast semantics).
+         */
+        private const val MAX_MAIN_TOPICS = 15
+
+        /**
+         * Default token estimator: word count × 1.75.
+         *
+         * The 1.75 multiplier is intentionally conservative to account for
+         * code blocks, JSON payloads, URLs, and non-ASCII text that tokenize
+         * at much higher ratios than plain English prose. Overshooting slightly
+         * means summarization fires a little earlier than strictly necessary —
+         * which is safe. Undershooting would allow the actual token budget to be
+         * silently exceeded.
          */
         fun defaultTokenEstimator(): (ChatMessage) -> Int = { message ->
             val text = when (message) {
@@ -670,7 +777,7 @@ class TokenAwareSummarizingMemory(
                 is SystemMessage -> message.text() ?: ""
                 else -> ""
             }
-            (text.split("\\s+".toRegex()).size * 1.3).toInt()
+            (text.split("\\s+".toRegex()).size * 1.75).toInt()
         }
     }
 }


### PR DESCRIPTION
- Adjust the token estimation multiplier to 1.75 in the core service layer to ensure a conservative buffer against unforeseen data types (like code or JSON) exceeding the calculated token budget.
- Enhanced documentation for memory storage, clarifying that recent messages are kept verbatim while older history is compressed into structure summaries.
- Updated internal test constants and thresholds to reflect improved memory boundaries and summarization logic defaults.