### PR TITLE
feat(ui): display full timestamp in message tooltip

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -76,6 +76,7 @@ import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.RunCodeEvent
 import io.askimo.core.event.internal.parseFilePreviewRequestEvent
 import io.askimo.core.i18n.LocalizationManager
+import io.askimo.core.util.TimeUtil
 import io.askimo.core.util.formatFileSize
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
@@ -551,11 +552,13 @@ private fun userMessageBubble(
                                 // Timestamp — visible on hover, right side of action bar
                                 message.timestamp?.let { ts ->
                                     Spacer(modifier = Modifier.width(Spacing.small))
-                                    Text(
-                                        text = formatMessageTime(ts),
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                                    )
+                                    themedTooltip(text = TimeUtil.formatFullDateTime(ts, LocalizationManager.getCurrentLocale())) {
+                                        Text(
+                                            text = formatMessageTime(ts),
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -927,11 +930,13 @@ private fun aiMessageBubble(
                 message.timestamp?.let { ts ->
                     Spacer(modifier = Modifier.width(Spacing.small))
                     val timestampPrefix = if (total != null && total > 0) "· " else ""
-                    Text(
-                        text = "$timestampPrefix${formatMessageTime(ts)}",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                    )
+                    themedTooltip(text = TimeUtil.formatFullDateTime(ts, LocalizationManager.getCurrentLocale())) {
+                        Text(
+                            text = "$timestampPrefix${formatMessageTime(ts)}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                        )
+                    }
                 }
             }
         }

--- a/shared/src/main/kotlin/io/askimo/core/util/TimeUtil.kt
+++ b/shared/src/main/kotlin/io/askimo/core/util/TimeUtil.kt
@@ -5,15 +5,13 @@
 package io.askimo.core.util
 
 import java.time.Instant
-import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.Locale
 
 object TimeUtil {
     private val instantDisplayFmt = DateTimeFormatter.ofPattern("MMM dd, HH:mm:ss")
-
-    fun stamp(): String = OffsetDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
     /**
      * Formats an Instant with the standard display format for the given locale,
@@ -86,5 +84,20 @@ object TimeUtil {
             if (hours > 0 || minutes > 0) append("${minutes}$minuteLabel ")
             append("${seconds}$secondLabel")
         }.trim()
+    }
+
+    /**
+     * Formats an [Instant] as a full locale-aware date and time string suitable for tooltips.
+     * Example: "Saturday, June 21, 2026 at 3:45:00 PM"
+     *
+     * @param instant The Instant to format
+     * @param locale  The locale to use for formatting (defaults to system locale)
+     * @return The formatted date-time string in the user's local timezone
+     */
+    fun formatFullDateTime(instant: Instant, locale: Locale = Locale.getDefault()): String {
+        val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.MEDIUM)
+            .withLocale(locale)
+            .withZone(ZoneId.systemDefault())
+        return formatter.format(instant)
     }
 }


### PR DESCRIPTION
- Introduce formatFullDateTime in TimeUtil for locale-aware date formatting.
- Wrap chat message timestamps in a tooltip to reveal the full date and time on hover.