### PR TITLE
feat(web-search): add built-in web search backend support

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -113,6 +113,7 @@ import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.common.ui.util.FileDialogUtils
 import io.askimo.ui.util.Platform
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.java.KoinJavaComponent
@@ -124,6 +125,7 @@ import kotlin.collections.minus
 import kotlin.collections.plus
 import kotlin.math.ceil
 import kotlin.ranges.coerceIn
+import kotlin.time.Duration.Companion.milliseconds
 
 private val log = currentFileLogger()
 
@@ -313,6 +315,32 @@ fun chatInputField(
 
     val selectFileTitle = stringResource("chat.select.file")
     val scope = rememberCoroutineScope()
+
+    // ── Rotating placeholder hints ─────────────────────────────────────────────
+    // Cycles through discoverability hints (web search, URL, attach) only while
+    // the input is empty and the AI is not responding.
+    val placeholderHints = listOf(
+        placeholder,
+        stringResource("chat.input.placeholder.hint.search"),
+        placeholder,
+        stringResource("chat.input.placeholder.hint.attach", Platform.modifierKey),
+    )
+    var placeholderIndex by remember { mutableStateOf(0) }
+    val activePlaceholder = if (inputText.text.isEmpty() && !isLoading && !isThinking) {
+        placeholderHints[placeholderIndex]
+    } else {
+        placeholder
+    }
+    LaunchedEffect(inputText.text, isLoading, isThinking) {
+        if (inputText.text.isEmpty() && !isLoading && !isThinking) {
+            while (true) {
+                delay(5_000L.milliseconds)
+                placeholderIndex = (placeholderIndex + 1) % placeholderHints.size
+            }
+        } else {
+            placeholderIndex = 0
+        }
+    }
     val openFileDialog = {
         scope.launch {
             val paths = FileDialogUtils.pickFilePaths(selectFileTitle)
@@ -550,7 +578,7 @@ fun chatInputField(
                                     else -> false
                                 }
                             },
-                        placeholder = { Text(placeholder) },
+                        placeholder = { Text(activePlaceholder) },
                         maxLines = maxVisibleInputLines,
                         interactionSource = interactionSource,
                         // Border is provided by the outer container; keep OutlinedTextField's own border transparent.

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -12,9 +12,13 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.ButtonColors
@@ -23,6 +27,8 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -37,7 +43,9 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -45,10 +53,13 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
+import io.askimo.ui.common.i18n.stringResource
 
 object AppComponents {
 
@@ -234,6 +245,59 @@ object AppComponents {
             maxLines = maxLines,
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
+            colors = outlinedTextFieldColors(),
+        )
+    }
+
+    /**
+     * A themed [OutlinedTextField] for secret values (API keys, passwords).
+     *
+     * Renders as a password field by default and provides an inline eye-icon toggle
+     * so the user can reveal the actual value they typed. Visibility state is local
+     * to each call site and resets whenever the composable leaves the composition.
+     *
+     * All other behaviour (colors, debounce, etc.) is left to the caller.
+     */
+    @Composable
+    fun appSecretTextField(
+        value: String,
+        onValueChange: (String) -> Unit,
+        modifier: Modifier = Modifier,
+        label: (@Composable () -> Unit)? = null,
+        placeholder: (@Composable () -> Unit)? = null,
+        supportingText: (@Composable () -> Unit)? = null,
+        isError: Boolean = false,
+        enabled: Boolean = true,
+        singleLine: Boolean = true,
+    ) {
+        var showSecret by remember { mutableStateOf(false) }
+
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier,
+            label = label,
+            placeholder = placeholder,
+            supportingText = supportingText,
+            isError = isError,
+            enabled = enabled,
+            singleLine = singleLine,
+            visualTransformation = if (showSecret) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                IconButton(
+                    onClick = { showSecret = !showSecret },
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Icon(
+                        imageVector = if (showSecret) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                        contentDescription = stringResource(
+                            if (showSecret) "mcp.instance.password.hide" else "mcp.instance.password.show",
+                        ),
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
             colors = outlinedTextFieldColors(),
         )
     }

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -403,6 +403,31 @@ settings.proxy.password.placeholder=Optional
 settings.proxy.system.info=ℹ️ Using system proxy settings from your operating system configuration
 settings.proxy.socks5.no.auth.info=ℹ️ SOCKS5 authentication is not currently supported. Use SOCKS5 proxy without authentication, or create an issue on GitHub if you need this feature.
 
+# Web Search Settings
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key ↗
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=✅ Search is working
+settings.web_search.test.fail=❌ {0}
+
 # User Profile
 user.profile.default_name=Guest User
 user.profile.menu=User Profile Menu
@@ -642,6 +667,8 @@ chat.reasoning.effort.medium.description=Balanced depth and speed. Suitable for 
 chat.reasoning.effort.high=High
 chat.reasoning.effort.high.description=Thorough reasoning, higher cost. Best for complex problem-solving.
 chat.input.placeholder=Type your message... (Enter to send, Shift+Enter for new line)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here
 chat.select.file=Select File(s)
 chat.attachment.remove=Remove attachment
 chat.attachment.preview.loading=Loading preview\u2026

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1499,3 +1499,31 @@ persona.developer=💻 Code schreiben und überprüfen
 persona.researcher=🔬 Recherchieren und analysieren
 persona.manager=📋 Schreiben und organisieren
 persona.everything=⚡ Ich mache eine Mischung aus Dingen
+# Web Search Settings (stub — pending translation)
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key \u2197
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=\u2705 Search is working
+settings.web_search.test.fail=\u274c {0}
+
+# Chat input placeholder hints (stub — pending translation)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1495,3 +1495,31 @@ persona.developer=💻 Escribir y revisar código
 persona.researcher=🔬 Investigar y analizar
 persona.manager=📋 Escribir y organizar
 persona.everything=⚡ Hago una mezcla de cosas
+# Web Search Settings (stub — pending translation)
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key \u2197
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=\u2705 Search is working
+settings.web_search.test.fail=\u274c {0}
+
+# Chat input placeholder hints (stub — pending translation)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1498,3 +1498,32 @@ persona.developer=💻 Écrire et réviser du code
 persona.researcher=🔬 Rechercher et analyser
 persona.manager=📋 Écrire et organiser
 persona.everything=⚡ Je fais un mélange de choses
+
+# Web Search Settings (stub — pending translation)
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key \u2197
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=\u2705 Search is working
+settings.web_search.test.fail=\u274c {0}
+
+# Chat input placeholder hints (stub — pending translation)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1497,3 +1497,32 @@ persona.developer=💻 コードの作成とレビュー
 persona.researcher=🔬 調査と分析
 persona.manager=📋 作成と整理
 persona.everything=⚡ 色々なことを組み合わせています
+
+# Web Search Settings (stub — pending translation)
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key \u2197
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=\u2705 Search is working
+settings.web_search.test.fail=\u274c {0}
+
+# Chat input placeholder hints (stub — pending translation)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1495,3 +1495,32 @@ persona.developer=💻 코드 작성 및 검토
 persona.researcher=🔬 조사 및 분석
 persona.manager=📋 작성 및 정리
 persona.everything=⚡ 여러 가지 작업을 혼합하여 합니다
+
+# Web Search Settings (stub — pending translation)
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key \u2197
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=\u2705 Search is working
+settings.web_search.test.fail=\u274c {0}
+
+# Chat input placeholder hints (stub — pending translation)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1497,3 +1497,31 @@ persona.developer=💻 Escrever e revisar código
 persona.researcher=🔬 Pesquisar e analisar
 persona.manager=📋 Escrever e organizar
 persona.everything=⚡ Eu faço uma mistura de coisas
+# Web Search Settings (stub — pending translation)
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key \u2197
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=\u2705 Search is working
+settings.web_search.test.fail=\u274c {0}
+
+# Chat input placeholder hints (stub — pending translation)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1496,3 +1496,31 @@ persona.developer=💻 Viết và đánh giá mã
 persona.researcher=🔬 Nghiên cứu và phân tích
 persona.manager=📋 Viết và tổ chức
 persona.everything=⚡ Tôi làm nhiều việc kết hợp
+# Web Search Settings (stub — pending translation)
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key \u2197
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=\u2705 Search is working
+settings.web_search.test.fail=\u274c {0}
+
+# Chat input placeholder hints (stub — pending translation)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1498,3 +1498,31 @@ persona.developer=💻 编写和审查代码
 persona.researcher=🔬 研究和分析
 persona.manager=📋 撰写和组织
 persona.everything=⚡ 我做各种混合的工作
+# Web Search Settings (stub — pending translation)
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key \u2197
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=\u2705 Search is working
+settings.web_search.test.fail=\u274c {0}
+
+# Chat input placeholder hints (stub — pending translation)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1499,3 +1499,32 @@ persona.developer=💻 編寫和審查程式碼
 persona.researcher=🔬 研究和分析
 persona.manager=📋 撰寫和組織
 persona.everything=⚡ 我做各種混合的工作
+
+# Web Search Settings (stub — pending translation)
+settings.web_search=Web Search
+settings.web_search.description=Enable built-in web search so the AI can look up current information without any API key. DuckDuckGo works out of the box — upgrade to Brave or Tavily for higher quality results.
+settings.web_search.title=Web Search Configuration
+settings.web_search.enabled=Enabled
+settings.web_search.zero_config_note=DuckDuckGo works with no setup. Select a different backend below only if you want higher-quality or higher-volume results and have an API key for that service.
+settings.web_search.backend=Search Backend
+settings.web_search.backend.duckduckgo=DuckDuckGo
+settings.web_search.backend.duckduckgo.description=Free, no API key required. Privacy-respecting default.
+settings.web_search.backend.brave=Brave Search
+settings.web_search.backend.brave.description=Fast, independent index. Requires a free Brave Search API key.
+settings.web_search.backend.tavily=Tavily
+settings.web_search.backend.tavily.description=AI-optimised results with optional answer extraction. Requires a Tavily API key.
+settings.web_search.backend.searxng=SearxNG
+settings.web_search.backend.searxng.description=Privacy-respecting meta-search via your own SearxNG instance. No API key needed.
+settings.web_search.api_key=API Key
+settings.web_search.api_key.placeholder=Paste your API key here
+settings.web_search.get_api_key=Get a free API key \u2197
+settings.web_search.endpoint=SearxNG Instance URL
+settings.web_search.endpoint.placeholder=https://search.example.com
+settings.web_search.test=Test Search
+settings.web_search.test.running=Testing...
+settings.web_search.test.success=\u2705 Search is working
+settings.web_search.test.fail=\u274c {0}
+
+# Chat input placeholder hints (stub — pending translation)
+chat.input.placeholder.hint.search=Try: "search the web for…" or paste a URL to read any page
+chat.input.placeholder.hint.attach=Attach files with {0}+A, or drag and drop them here

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsView.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.outlined.Cable
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.Keyboard
 import androidx.compose.material.icons.outlined.NetworkCheck
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -69,6 +70,7 @@ enum class SettingsSection {
     AI_PROVIDER,
     APPEARANCE,
     NETWORK,
+    WEB_SEARCH,
     SHORTCUTS,
     MCP_SERVERS,
     SKILLS,
@@ -198,6 +200,12 @@ fun settingsViewWithSidebar(
                         onClick = { onSectionChange(SettingsSection.NETWORK) },
                     )
                     settingsSidebarItem(
+                        title = stringResource("settings.web_search"),
+                        icon = Icons.Outlined.Search,
+                        isSelected = selectedSection == SettingsSection.WEB_SEARCH,
+                        onClick = { onSectionChange(SettingsSection.WEB_SEARCH) },
+                    )
+                    settingsSidebarItem(
                         title = stringResource("settings.shortcuts"),
                         icon = Icons.Outlined.Keyboard,
                         isSelected = selectedSection == SettingsSection.SHORTCUTS,
@@ -279,6 +287,7 @@ fun settingsViewWithSidebar(
                         SettingsSection.AI_PROVIDER -> aiProviderSettingsSection(settingsViewModel)
                         SettingsSection.APPEARANCE -> appearanceSettingsSection()
                         SettingsSection.NETWORK -> networkSettingsSection()
+                        SettingsSection.WEB_SEARCH -> webSearchSettingsSection()
                         SettingsSection.SHORTCUTS -> shortcutsSettingsSection()
                         SettingsSection.MCP_SERVERS -> mcpServerTemplatesSection()
                         SettingsSection.SKILLS -> skillsSettingsSection()

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/WebSearchSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/WebSearchSettingsSection.kt
@@ -1,0 +1,483 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.desktop.settings
+
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.unit.dp
+import io.askimo.core.config.AppConfig
+import io.askimo.core.config.WebSearchBackend
+import io.askimo.core.config.WebSearchConfig
+import io.askimo.tools.web.WebSearchDispatcher
+import io.askimo.ui.common.components.linkButton
+import io.askimo.ui.common.components.primaryButton
+import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.Spacing
+import io.askimo.ui.common.theme.ThemePreferences
+import io.askimo.ui.common.ui.clickableCard
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration.Companion.milliseconds
+import java.awt.Desktop
+import java.net.URI
+
+@Composable
+fun webSearchSettingsSection() {
+    val scrollState = rememberScrollState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Column(
+                modifier = Modifier
+                    .widthIn(max = ThemePreferences.CONTENT_MAX_WIDTH)
+                    .fillMaxWidth()
+                    .padding(start = Spacing.extraLarge, top = Spacing.extraLarge, bottom = Spacing.extraLarge, end = 36.dp),
+                verticalArrangement = Arrangement.spacedBy(Spacing.large),
+            ) {
+                Text(
+                    text = stringResource("settings.web_search"),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.padding(bottom = Spacing.small),
+                )
+
+                Text(
+                    text = stringResource("settings.web_search.description"),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                )
+
+                webSearchConfigCard()
+            }
+        }
+
+        VerticalScrollbar(
+            adapter = rememberScrollbarAdapter(scrollState),
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .fillMaxHeight(),
+            style = AppComponents.scrollbarStyle(),
+        )
+    }
+}
+
+@Composable
+private fun webSearchConfigCard() {
+    val raw = AppConfig.rawWebSearch
+    var backend by remember { mutableStateOf(raw.backend) }
+    var enabled by remember { mutableStateOf(raw.enabled) }
+    var searxngEndpoint by remember { mutableStateOf(raw.searxngEndpoint) }
+    // API keys loaded async from keychain — start blank
+    var braveApiKey by remember { mutableStateOf("") }
+    var tavilyApiKey by remember { mutableStateOf("") }
+    var backendDropdownExpanded by remember { mutableStateOf(false) }
+
+    var testStatus by remember { mutableStateOf<TestStatus?>(null) }
+    var isTesting by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    // Load secured API keys off UI thread — same pattern as proxy password
+    LaunchedEffect(Unit) {
+        val resolved = withContext(Dispatchers.IO) { AppConfig.webSearch }
+        braveApiKey = if (WebSearchConfig.isActualKey(resolved.braveApiKey)) resolved.braveApiKey else ""
+        tavilyApiKey = if (WebSearchConfig.isActualKey(resolved.tavilyApiKey)) resolved.tavilyApiKey else ""
+    }
+
+    // ── Debounced saves for typed fields (keychain I/O — must NOT block the UI thread) ──
+    // Local state updates instantly on every keystroke; the actual persist fires 500 ms
+    // after the user stops typing, on Dispatchers.IO.
+    LaunchedEffect(braveApiKey) {
+        delay(500.milliseconds)
+        withContext(Dispatchers.IO) { AppConfig.updateField("webSearch.braveApiKey", braveApiKey) }
+    }
+    LaunchedEffect(tavilyApiKey) {
+        delay(500.milliseconds)
+        withContext(Dispatchers.IO) { AppConfig.updateField("webSearch.tavilyApiKey", tavilyApiKey) }
+    }
+    LaunchedEffect(searxngEndpoint) {
+        delay(500.milliseconds)
+        withContext(Dispatchers.IO) { AppConfig.updateField("webSearch.searxngEndpoint", searxngEndpoint) }
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = AppComponents.bannerCardColors(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.medium),
+        ) {
+            // ── Header row: title + enabled toggle ───────────────────────────────
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource("settings.web_search.title"),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.weight(1f),
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                ) {
+                    Text(
+                        text = stringResource("settings.web_search.enabled"),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                    )
+                    Switch(
+                        checked = enabled,
+                        onCheckedChange = { newValue ->
+                            enabled = newValue
+                            AppConfig.updateField("webSearch.enabled", newValue)
+                        },
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    )
+                }
+            }
+
+            Text(
+                text = stringResource("settings.web_search.description"),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+            )
+
+            // ── Zero-config info banner ───────────────────────────────────────────
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f),
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            ) {
+                Row(
+                    modifier = Modifier.padding(Spacing.medium),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    Icon(
+                        Icons.Default.Info,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp).padding(top = 2.dp),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                    Text(
+                        text = stringResource("settings.web_search.zero_config_note"),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+            }
+
+            HorizontalDivider()
+
+            // ── Backend selector ──────────────────────────────────────────────────
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+                Text(
+                    text = stringResource("settings.web_search.backend"),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickableCard { backendDropdownExpanded = true },
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surface,
+                        ),
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(12.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource("settings.web_search.backend.${backend.name.lowercase()}"),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                                Text(
+                                    text = stringResource("settings.web_search.backend.${backend.name.lowercase()}.description"),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                                )
+                            }
+                            Icon(
+                                Icons.Default.Edit,
+                                contentDescription = "Change backend",
+                                tint = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+                    }
+
+                    AppComponents.dropdownMenu(
+                        expanded = backendDropdownExpanded,
+                        onDismissRequest = { backendDropdownExpanded = false },
+                    ) {
+                        WebSearchBackend.entries.forEach { b ->
+                            DropdownMenuItem(
+                                text = {
+                                    Column(verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall)) {
+                                        Text(
+                                            text = stringResource("settings.web_search.backend.${b.name.lowercase()}"),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                        )
+                                        Text(
+                                            text = stringResource("settings.web_search.backend.${b.name.lowercase()}.description"),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                },
+                                onClick = {
+                                    backend = b
+                                    AppConfig.updateField("webSearch.backend", b)
+                                    backendDropdownExpanded = false
+                                    testStatus = null
+                                },
+                                leadingIcon = if (b == backend) {
+                                    { Icon(Icons.Default.Check, contentDescription = "Selected", tint = MaterialTheme.colorScheme.onSurface) }
+                                } else null,
+                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                            )
+                        }
+                    }
+                }
+            }
+
+            // ── Conditional fields by backend ─────────────────────────────────────
+            when (backend) {
+                WebSearchBackend.BRAVE -> {
+                    HorizontalDivider()
+                    braveApiKeyField(
+                        value = braveApiKey,
+                        onValueChange = { newValue ->
+                            braveApiKey = newValue
+                            testStatus = null
+                        },
+                    )
+                }
+
+                WebSearchBackend.TAVILY -> {
+                    HorizontalDivider()
+                    tavilyApiKeyField(
+                        value = tavilyApiKey,
+                        onValueChange = { newValue ->
+                            tavilyApiKey = newValue
+                            testStatus = null
+                        },
+                    )
+                }
+
+                WebSearchBackend.SEARXNG -> {
+                    HorizontalDivider()
+                    searxngEndpointField(
+                        value = searxngEndpoint,
+                        onValueChange = { newValue ->
+                            searxngEndpoint = newValue
+                            testStatus = null
+                        },
+                    )
+                }
+
+                WebSearchBackend.DUCKDUCKGO -> { /* no extra fields */ }
+            }
+
+            HorizontalDivider()
+
+            // ── Test button + result ──────────────────────────────────────────────
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.medium),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                primaryButton(
+                    onClick = {
+                        isTesting = true
+                        testStatus = null
+                        scope.launch {
+                            val result = withContext(Dispatchers.IO) {
+                                WebSearchDispatcher.testBackend(AppConfig.webSearch)
+                            }
+                            isTesting = false
+                            testStatus = if (result.isSuccess) {
+                                TestStatus.Success(result.getOrThrow())
+                            } else {
+                                TestStatus.Failure(result.exceptionOrNull()?.message ?: "Unknown error")
+                            }
+                        }
+                    },
+                    enabled = enabled && !isTesting,
+                ) {
+                    Text(
+                        if (isTesting) {
+                            stringResource("settings.web_search.test.running")
+                        } else {
+                            stringResource("settings.web_search.test")
+                        },
+                    )
+                }
+
+                testStatus?.let { status ->
+                    Text(
+                        text = when (status) {
+                            is TestStatus.Success -> stringResource("settings.web_search.test.success")
+                            is TestStatus.Failure -> stringResource("settings.web_search.test.fail")
+                                .replace("{0}", status.message)
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = when (status) {
+                            is TestStatus.Success -> MaterialTheme.colorScheme.primary
+                            is TestStatus.Failure -> MaterialTheme.colorScheme.error
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Conditional field composables ─────────────────────────────────────────────
+
+@Composable
+private fun braveApiKeyField(
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+        AppComponents.appSecretTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(stringResource("settings.web_search.api_key")) },
+            placeholder = { Text(stringResource("settings.web_search.api_key.placeholder")) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        linkButton(
+            onClick = {
+                runCatching {
+                    if (Desktop.isDesktopSupported()) {
+                        Desktop.getDesktop().browse(URI("https://brave.com/search/api/"))
+                    }
+                }
+            },
+        ) {
+            Icon(Icons.Default.Info, contentDescription = null, modifier = Modifier.size(14.dp))
+            Text(
+                text = stringResource("settings.web_search.get_api_key"),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 4.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun tavilyApiKeyField(
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+        AppComponents.appSecretTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(stringResource("settings.web_search.api_key")) },
+            placeholder = { Text(stringResource("settings.web_search.api_key.placeholder")) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        linkButton(
+            onClick = {
+                runCatching {
+                    if (Desktop.isDesktopSupported()) {
+                        Desktop.getDesktop().browse(URI("https://app.tavily.com"))
+                    }
+                }
+            },
+        ) {
+            Icon(Icons.Default.Info, contentDescription = null, modifier = Modifier.size(14.dp))
+            Text(
+                text = stringResource("settings.web_search.get_api_key"),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 4.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun searxngEndpointField(
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(stringResource("settings.web_search.endpoint")) },
+        placeholder = { Text(stringResource("settings.web_search.endpoint.placeholder")) },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+    )
+}
+
+// ── Internal state ─────────────────────────────────────────────────────────────
+
+private sealed interface TestStatus {
+    data class Success(val message: String) : TestStatus
+    data class Failure(val message: String) : TestStatus
+}
+

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/WebSearchSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/WebSearchSettingsSection.kt
@@ -58,9 +58,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.time.Duration.Companion.milliseconds
 import java.awt.Desktop
 import java.net.URI
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun webSearchSettingsSection() {
@@ -293,7 +293,9 @@ private fun webSearchConfigCard() {
                                 },
                                 leadingIcon = if (b == backend) {
                                     { Icon(Icons.Default.Check, contentDescription = "Selected", tint = MaterialTheme.colorScheme.onSurface) }
-                                } else null,
+                                } else {
+                                    null
+                                },
                                 modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                             )
                         }
@@ -378,6 +380,7 @@ private fun webSearchConfigCard() {
                     Text(
                         text = when (status) {
                             is TestStatus.Success -> stringResource("settings.web_search.test.success")
+
                             is TestStatus.Failure -> stringResource("settings.web_search.test.fail")
                                 .replace("{0}", status.message)
                         },
@@ -480,4 +483,3 @@ private sealed interface TestStatus {
     data class Success(val message: String) : TestStatus
     data class Failure(val message: String) : TestStatus
 }
-

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -349,6 +349,58 @@ data class AnalyticsConfig(
     val endpoint: String = "https://analytics.$DOMAIN/ingest",
 )
 
+/**
+ * Supported web search backends.
+ * Resolution order: user-configured backend → DuckDuckGo fallback (zero-config).
+ */
+enum class WebSearchBackend {
+    DUCKDUCKGO,
+    SEARXNG,
+    BRAVE,
+    TAVILY,
+}
+
+private const val WEB_SEARCH_KEY_BRAVE = "websearch.brave.key"
+private const val WEB_SEARCH_KEY_TAVILY = "websearch.tavily.key"
+private const val WEB_SEARCH_KEY_PLACEHOLDER = "***keychain***"
+
+/**
+ * Configuration for the built-in web search feature.
+ * Lives under the `web_search:` key in askimo.yml.
+ *
+ * API keys are stored securely via [SecureKeyManager] — the YAML holds a
+ * `***keychain***` placeholder, never the raw key value.
+ */
+data class WebSearchConfig(
+    val backend: WebSearchBackend = WebSearchBackend.DUCKDUCKGO,
+    val searxngEndpoint: String = "https://searx.be",
+    val enabled: Boolean = true,
+    /** Raw field — may be blank or `***keychain***`. Use [AppConfig.webSearch] resolved accessors. */
+    val braveApiKey: String = "",
+    /** Raw field — may be blank or `***keychain***`. Use [AppConfig.webSearch] resolved accessors. */
+    val tavilyApiKey: String = "",
+) {
+    companion object {
+        fun isKeyPlaceholder(value: String): Boolean = value == WEB_SEARCH_KEY_PLACEHOLDER
+        fun isActualKey(value: String): Boolean = value.isNotBlank() && !isKeyPlaceholder(value)
+        fun getSecureBraveKey(): String? = SecureKeyManager.retrieveSecretKey(WEB_SEARCH_KEY_BRAVE)
+        fun getSecureTavilyKey(): String? = SecureKeyManager.retrieveSecretKey(WEB_SEARCH_KEY_TAVILY)
+        fun setSecureBraveKey(key: String): SecureKeyManager.StorageResult = if (key.isEmpty()) {
+            SecureKeyManager.removeSecretKey(WEB_SEARCH_KEY_BRAVE)
+            SecureKeyManager.StorageResult(success = true, method = SecureKeyManager.StorageMethod.KEYCHAIN)
+        } else {
+            SecureKeyManager.storeSecuredKey(WEB_SEARCH_KEY_BRAVE, key)
+        }
+        fun setSecureTavilyKey(key: String): SecureKeyManager.StorageResult = if (key.isEmpty()) {
+            SecureKeyManager.removeSecretKey(WEB_SEARCH_KEY_TAVILY)
+            SecureKeyManager.StorageResult(success = true, method = SecureKeyManager.StorageMethod.KEYCHAIN)
+        } else {
+            SecureKeyManager.storeSecuredKey(WEB_SEARCH_KEY_TAVILY, key)
+        }
+        fun getKeyPlaceholder(): String = WEB_SEARCH_KEY_PLACEHOLDER
+    }
+}
+
 data class AppConfigData(
     val embedding: EmbeddingConfig = EmbeddingConfig(),
     val retry: RetryConfig = RetryConfig(),
@@ -360,6 +412,7 @@ data class AppConfigData(
     val models: ModelsConfig = ModelsConfig(),
     val proxy: ProxyConfig = ProxyConfig(),
     val analytics: AnalyticsConfig = AnalyticsConfig(),
+    val webSearch: WebSearchConfig = WebSearchConfig(),
     val context: AppContextParams = AppContextParams.noOp(),
     @field:JsonAlias("current_locale") val currentLocale: String? = null,
 )
@@ -374,6 +427,36 @@ object AppConfig {
     val models: ModelsConfig get() = delegate.models
     val context: AppContextParams get() = delegate.context
     val analytics: AnalyticsConfig get() = delegate.analytics
+
+    /**
+     * Raw web search configuration **without** keychain lookup.
+     * API key fields may be blank or `***keychain***`.
+     */
+    val rawWebSearch: WebSearchConfig get() = delegate.webSearch
+
+    /**
+     * Web search configuration with API keys resolved from secure storage.
+     * Safe to pass directly to backends.
+     */
+    val webSearch: WebSearchConfig
+        get() {
+            val config = delegate.webSearch
+            val braveKey = if (!WebSearchConfig.isActualKey(config.braveApiKey)) {
+                WebSearchConfig.getSecureBraveKey() ?: ""
+            } else {
+                config.braveApiKey
+            }
+            val tavilyKey = if (!WebSearchConfig.isActualKey(config.tavilyApiKey)) {
+                WebSearchConfig.getSecureTavilyKey() ?: ""
+            } else {
+                config.tavilyApiKey
+            }
+            return if (braveKey != config.braveApiKey || tavilyKey != config.tavilyApiKey) {
+                config.copy(braveApiKey = braveKey, tavilyApiKey = tavilyKey)
+            } else {
+                config
+            }
+        }
 
     /**
      * BCP-47 language tag of the user's selected UI locale (e.g. "ja-JP", "zh-CN").
@@ -578,6 +661,13 @@ object AppConfig {
         analytics:
           opted_in: ${'$'}{ASKIMO_ANALYTICS_OPTED_IN:false}
           endpoint: ${'$'}{ASKIMO_ANALYTICS_ENDPOINT:https://analytics.askimo.chat/ingest}
+
+        web_search:
+          backend:          ${'$'}{ASKIMO_WEB_SEARCH_BACKEND:DUCKDUCKGO}
+          searxng_endpoint: ${'$'}{ASKIMO_SEARXNG_ENDPOINT:https://searx.be}
+          brave_api_key:    ${'$'}{BRAVE_SEARCH_API_KEY:}
+          tavily_api_key:   ${'$'}{TAVILY_API_KEY:}
+          enabled:          ${'$'}{ASKIMO_WEB_SEARCH_ENABLED:true}
 
         context:
           current_provider: ${'$'}{ASKIMO_CONTEXT_CURRENT_PROVIDER:UNKNOWN}
@@ -1028,7 +1118,17 @@ object AppConfig {
                 password = env("ASKIMO_PROXY_PASSWORD", ""),
             )
 
-        return AppConfigData(emb, r, t, idx, dev, chat, rag, models, proxy)
+        val webSearch = WebSearchConfig(
+            backend = System.getenv("ASKIMO_WEB_SEARCH_BACKEND")
+                ?.let { runCatching { WebSearchBackend.valueOf(it) }.getOrNull() }
+                ?: WebSearchBackend.DUCKDUCKGO,
+            searxngEndpoint = env("ASKIMO_SEARXNG_ENDPOINT", "https://searx.be"),
+            braveApiKey = env("BRAVE_SEARCH_API_KEY", ""),
+            tavilyApiKey = env("TAVILY_API_KEY", ""),
+            enabled = System.getenv("ASKIMO_WEB_SEARCH_ENABLED")?.toBoolean() ?: true,
+        )
+
+        return AppConfigData(emb, r, t, idx, dev, chat, rag, models, proxy, webSearch = webSearch)
     }
 
     /**
@@ -1138,6 +1238,8 @@ object AppConfig {
                 "analytics" -> current.copy(analytics = updateAnalyticsField(current.analytics, field, value))
 
                 "indexing" -> current.copy(indexing = updateIndexingField(current.indexing, field, value))
+
+                "webSearch" -> current.copy(webSearch = updateWebSearchField(current.webSearch, field, value))
 
                 else -> {
                     log.displayError("Unknown config section: $section", null)
@@ -1319,5 +1421,57 @@ object AppConfig {
         "excludeFileNames" -> config.copy(excludeFileNames = value as Set<String>)
         "binaryExtensions" -> config.copy(binaryExtensions = value as Set<String>)
         else -> config
+    }
+
+    private fun updateWebSearchField(config: WebSearchConfig, field: String, value: Any): WebSearchConfig = when (field) {
+        "backend" -> config.copy(
+            backend = if (value is WebSearchBackend) value
+            else runCatching { WebSearchBackend.valueOf(value.toString()) }.getOrElse { config.backend },
+        )
+
+        "searxngEndpoint" -> config.copy(searxngEndpoint = value as String)
+
+        "enabled" -> config.copy(enabled = value as Boolean)
+
+        "braveApiKey" -> {
+            val key = value as String
+            if (WebSearchConfig.isActualKey(key)) {
+                val result = WebSearchConfig.setSecureBraveKey(key)
+                when (result.method) {
+                    SecureKeyManager.StorageMethod.KEYCHAIN ->
+                        log.debug("Brave Search API key stored securely in keychain")
+                    SecureKeyManager.StorageMethod.ENCRYPTED ->
+                        log.warn("Brave Search API key stored with encryption ({})", result.warningMessage)
+                    SecureKeyManager.StorageMethod.INSECURE_FALLBACK ->
+                        log.warn("⚠️ Brave Search API key storage: {}", result.warningMessage)
+                }
+                config.copy(braveApiKey = WebSearchConfig.getKeyPlaceholder())
+            } else {
+                config.copy(braveApiKey = key)
+            }
+        }
+
+        "tavilyApiKey" -> {
+            val key = value as String
+            if (WebSearchConfig.isActualKey(key)) {
+                val result = WebSearchConfig.setSecureTavilyKey(key)
+                when (result.method) {
+                    SecureKeyManager.StorageMethod.KEYCHAIN ->
+                        log.debug("Tavily API key stored securely in keychain")
+                    SecureKeyManager.StorageMethod.ENCRYPTED ->
+                        log.warn("Tavily API key stored with encryption ({})", result.warningMessage)
+                    SecureKeyManager.StorageMethod.INSECURE_FALLBACK ->
+                        log.warn("⚠️ Tavily API key storage: {}", result.warningMessage)
+                }
+                config.copy(tavilyApiKey = WebSearchConfig.getKeyPlaceholder())
+            } else {
+                config.copy(tavilyApiKey = key)
+            }
+        }
+
+        else -> {
+            log.displayError("Unknown webSearch field: $field", null)
+            config
+        }
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -1425,8 +1425,11 @@ object AppConfig {
 
     private fun updateWebSearchField(config: WebSearchConfig, field: String, value: Any): WebSearchConfig = when (field) {
         "backend" -> config.copy(
-            backend = if (value is WebSearchBackend) value
-            else runCatching { WebSearchBackend.valueOf(value.toString()) }.getOrElse { config.backend },
+            backend = if (value is WebSearchBackend) {
+                value
+            } else {
+                runCatching { WebSearchBackend.valueOf(value.toString()) }.getOrElse { config.backend }
+            },
         )
 
         "searxngEndpoint" -> config.copy(searxngEndpoint = value as String)
@@ -1440,8 +1443,10 @@ object AppConfig {
                 when (result.method) {
                     SecureKeyManager.StorageMethod.KEYCHAIN ->
                         log.debug("Brave Search API key stored securely in keychain")
+
                     SecureKeyManager.StorageMethod.ENCRYPTED ->
                         log.warn("Brave Search API key stored with encryption ({})", result.warningMessage)
+
                     SecureKeyManager.StorageMethod.INSECURE_FALLBACK ->
                         log.warn("⚠️ Brave Search API key storage: {}", result.warningMessage)
                 }
@@ -1458,8 +1463,10 @@ object AppConfig {
                 when (result.method) {
                     SecureKeyManager.StorageMethod.KEYCHAIN ->
                         log.debug("Tavily API key stored securely in keychain")
+
                     SecureKeyManager.StorageMethod.ENCRYPTED ->
                         log.warn("Tavily API key stored with encryption ({})", result.warningMessage)
+
                     SecureKeyManager.StorageMethod.INSECURE_FALLBACK ->
                         log.warn("⚠️ Tavily API key storage: {}", result.warningMessage)
                 }

--- a/shared/src/main/kotlin/io/askimo/tools/web/BraveBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/BraveBackend.kt
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.tools.web
+
+import io.askimo.core.logging.logger
+import io.askimo.core.util.httpGet
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Web search backend using the Brave Search API.
+ *
+ * Docs: https://api.search.brave.com/app/documentation/web-search/get-started
+ * Requires a free or paid API key from https://brave.com/search/api/
+ */
+class BraveBackend(private val apiKey: String) : SearchBackend {
+
+    override val name: String = "Brave Search"
+
+    private val log = logger<BraveBackend>()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    companion object {
+        private const val BASE_URL = "https://api.search.brave.com/res/v1/web/search"
+        private const val TIMEOUT_MS = 15_000L
+    }
+
+    override fun search(query: String, maxResults: Int): List<SearchResult> {
+        val encoded = URLEncoder.encode(query.trim(), StandardCharsets.UTF_8)
+        val url = "$BASE_URL?q=$encoded&count=$maxResults"
+
+        log.debug("Brave Search: query='{}', count={}", query, maxResults)
+
+        val (status, body) = httpGet(
+            url = url,
+            headers = mapOf(
+                "X-Subscription-Token" to apiKey,
+                "Accept" to "application/json",
+                "Accept-Encoding" to "gzip",
+            ),
+            readTimeoutMs = TIMEOUT_MS,
+        )
+
+        if (status != 200) {
+            log.warn("Brave Search returned HTTP {}: {}", status, body.take(200))
+            error("Brave Search API returned HTTP $status")
+        }
+
+        return parseResults(body, maxResults)
+    }
+
+    private fun parseResults(body: String, maxResults: Int): List<SearchResult> = try {
+        val root = json.parseToJsonElement(body).jsonObject
+        val webResults = root["web"]?.jsonObject
+            ?.get("results")?.jsonArray
+            ?: return emptyList()
+
+        webResults.take(maxResults).mapNotNull { element ->
+            val obj = element.jsonObject
+            val title = obj["title"]?.jsonPrimitive?.contentOrNull?.trim() ?: return@mapNotNull null
+            val url = obj["url"]?.jsonPrimitive?.contentOrNull?.trim() ?: return@mapNotNull null
+            val snippet = obj["description"]?.jsonPrimitive?.contentOrNull?.trim() ?: ""
+            SearchResult(title = title, url = url, snippet = snippet)
+        }
+    } catch (e: Exception) {
+        log.warn("Failed to parse Brave Search response: {}", e.message)
+        emptyList()
+    }
+}
+

--- a/shared/src/main/kotlin/io/askimo/tools/web/BraveBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/BraveBackend.kt
@@ -74,4 +74,3 @@ class BraveBackend(private val apiKey: String) : SearchBackend {
         emptyList()
     }
 }
-

--- a/shared/src/main/kotlin/io/askimo/tools/web/DuckDuckGoBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/DuckDuckGoBackend.kt
@@ -113,4 +113,3 @@ class DuckDuckGoBackend : SearchBackend {
         }
     }
 }
-

--- a/shared/src/main/kotlin/io/askimo/tools/web/DuckDuckGoBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/DuckDuckGoBackend.kt
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.tools.web
+
+import io.askimo.core.AppConstants.DOMAIN
+import io.askimo.core.logging.logger
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Zero-config web search backend using DuckDuckGo's HTML endpoint.
+ *
+ * - No API key required.
+ * - Uses the `/html/` endpoint which returns a plain HTML page with results.
+ * - Real destination URLs are encoded in DDG's redirect parameter `uddg=`.
+ * - Ad / promoted results (class `result--ad`) are filtered out automatically.
+ */
+class DuckDuckGoBackend : SearchBackend {
+
+    override val name: String = "DuckDuckGo"
+
+    private val log = logger<DuckDuckGoBackend>()
+
+    companion object {
+        private const val SEARCH_URL = "https://html.duckduckgo.com/html/"
+        private const val TIMEOUT_MS = 15_000
+        private const val USER_AGENT = "Mozilla/5.0 (compatible; Askimo/1.0; +https://$DOMAIN)"
+    }
+
+    override fun search(query: String, maxResults: Int): List<SearchResult> {
+        val encoded = URLEncoder.encode(query.trim(), StandardCharsets.UTF_8)
+        val url = "$SEARCH_URL?q=$encoded"
+
+        log.debug("DuckDuckGo search: query='{}', url='{}'", query, url)
+
+        val doc: Document = Jsoup.connect(url)
+            .userAgent(USER_AGENT)
+            .timeout(TIMEOUT_MS)
+            // DDG requires these headers to return proper HTML results
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .header("Accept", "text/html,application/xhtml+xml")
+            // POST with the query for more reliable results
+            .data("q", query.trim())
+            .post()
+
+        val results = mutableListOf<SearchResult>()
+
+        // Each organic result is wrapped in a <div class="result ...">
+        // Ad results have class "result--ad" — skip them
+        val resultDivs = doc.select("div.result:not(.result--ad)")
+
+        for (div in resultDivs) {
+            if (results.size >= maxResults) break
+
+            // Title and raw (redirected) href
+            val titleEl = div.selectFirst("a.result__a") ?: continue
+            val rawHref = titleEl.attr("href")
+            val title = titleEl.text().trim()
+            if (title.isBlank()) continue
+
+            // Decode the actual destination URL from DDG's redirect wrapper
+            val destinationUrl = extractRealUrl(rawHref) ?: continue
+
+            // Skip DDG-internal or empty links
+            if (destinationUrl.contains("duckduckgo.com") || destinationUrl.isBlank()) continue
+
+            // Snippet text
+            val snippet = div.selectFirst("a.result__snippet")?.text()?.trim()
+                ?: div.selectFirst(".result__snippet")?.text()?.trim()
+                ?: ""
+
+            results += SearchResult(
+                title = title,
+                url = destinationUrl,
+                snippet = snippet,
+            )
+        }
+
+        log.debug("DuckDuckGo returned {} results for '{}'", results.size, query)
+        return results
+    }
+
+    /**
+     * DDG wraps destination URLs as: `//duckduckgo.com/l/?uddg=<encoded_url>&...`
+     * This extracts and decodes the real URL from the `uddg` parameter.
+     * Falls back to returning the raw href if it already looks like a real URL.
+     */
+    private fun extractRealUrl(href: String): String? {
+        if (href.isBlank()) return null
+
+        // Already a proper URL (unlikely from DDG HTML but defensive)
+        if (href.startsWith("http://") || href.startsWith("https://")) return href
+
+        // DDG redirect pattern: /l/?uddg=<encoded>&rut=...
+        val normalized = if (href.startsWith("//")) "https:$href" else href
+        return try {
+            val uri = java.net.URI(normalized)
+            val query = uri.rawQuery ?: return null
+            val uddg = query.split("&")
+                .firstOrNull { it.startsWith("uddg=") }
+                ?.removePrefix("uddg=")
+                ?: return null
+            URLDecoder.decode(uddg, StandardCharsets.UTF_8)
+                .takeIf { it.startsWith("http://") || it.startsWith("https://") }
+        } catch (e: Exception) {
+            log.trace("Could not parse DDG redirect href '{}': {}", href, e.message)
+            null
+        }
+    }
+}
+

--- a/shared/src/main/kotlin/io/askimo/tools/web/SearchBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/SearchBackend.kt
@@ -27,4 +27,3 @@ interface SearchBackend {
      */
     fun search(query: String, maxResults: Int = 5): List<SearchResult>
 }
-

--- a/shared/src/main/kotlin/io/askimo/tools/web/SearchBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/SearchBackend.kt
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.tools.web
+
+/**
+ * Common interface for all web search backends.
+ *
+ * Implementations:
+ * - [DuckDuckGoBackend]  — scraping-based, zero-config, no API key required
+ * - [BraveBackend]       — Brave Search API, requires `BRAVE_SEARCH_API_KEY`
+ * - [TavilyBackend]      — Tavily API, requires `TAVILY_API_KEY`
+ * - [SearxNGBackend]     — self-hosted SearxNG instance, configurable endpoint
+ */
+interface SearchBackend {
+    /** Human-readable name of this backend, used in tool output and logs. */
+    val name: String
+
+    /**
+     * Perform a web search and return up to [maxResults] results.
+     *
+     * @param query     The search query string.
+     * @param maxResults Maximum number of results to return (callers coerce to 1–10).
+     * @return List of [SearchResult]s, may be empty if nothing is found.
+     * @throws Exception on network or parse failure — callers should handle.
+     */
+    fun search(query: String, maxResults: Int = 5): List<SearchResult>
+}
+

--- a/shared/src/main/kotlin/io/askimo/tools/web/SearchResult.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/SearchResult.kt
@@ -15,4 +15,3 @@ data class SearchResult(
     /** Short snippet / description extracted from the result. */
     val snippet: String,
 )
-

--- a/shared/src/main/kotlin/io/askimo/tools/web/SearchResult.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/SearchResult.kt
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.tools.web
+
+/**
+ * A single web search result returned by any [SearchBackend].
+ */
+data class SearchResult(
+    /** Page title. */
+    val title: String,
+    /** Canonical URL of the result. */
+    val url: String,
+    /** Short snippet / description extracted from the result. */
+    val snippet: String,
+)
+

--- a/shared/src/main/kotlin/io/askimo/tools/web/SearxNGBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/SearxNGBackend.kt
@@ -76,4 +76,3 @@ class SearxNGBackend(private val endpoint: String) : SearchBackend {
         emptyList()
     }
 }
-

--- a/shared/src/main/kotlin/io/askimo/tools/web/SearxNGBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/SearxNGBackend.kt
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.tools.web
+
+import io.askimo.core.AppConstants.DOMAIN
+import io.askimo.core.logging.logger
+import io.askimo.core.util.httpGet
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Web search backend using a self-hosted (or public) SearxNG instance.
+ *
+ * SearxNG is a free, open-source, privacy-respecting metasearch engine.
+ * Users can run their own instance or point to a public one (e.g. https://searx.be).
+ *
+ * Docs: https://docs.searxng.org/dev/search_api.html
+ * No API key required — just a running SearxNG endpoint.
+ */
+class SearxNGBackend(private val endpoint: String) : SearchBackend {
+
+    override val name: String = "SearxNG"
+
+    private val log = logger<SearxNGBackend>()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    companion object {
+        private const val TIMEOUT_MS = 15_000L
+        private const val USER_AGENT = "Mozilla/5.0 (compatible; Askimo/1.0; +https://$DOMAIN)"
+    }
+
+    override fun search(query: String, maxResults: Int): List<SearchResult> {
+        val base = endpoint.trimEnd('/')
+        val encoded = URLEncoder.encode(query.trim(), StandardCharsets.UTF_8)
+        val url = "$base/search?q=$encoded&format=json&categories=general&language=en"
+
+        log.debug("SearxNG search: query='{}', endpoint='{}'", query, base)
+
+        val (status, body) = httpGet(
+            url = url,
+            headers = mapOf(
+                "User-Agent" to USER_AGENT,
+                "Accept" to "application/json",
+            ),
+            readTimeoutMs = TIMEOUT_MS,
+        )
+
+        if (status != 200) {
+            log.warn("SearxNG returned HTTP {}: {}", status, body.take(200))
+            error("SearxNG returned HTTP $status — check the endpoint URL in Settings → Web Search")
+        }
+
+        return parseResults(body, maxResults)
+    }
+
+    private fun parseResults(body: String, maxResults: Int): List<SearchResult> = try {
+        val root = json.parseToJsonElement(body).jsonObject
+        val results = root["results"]?.jsonArray ?: return emptyList()
+
+        results.take(maxResults).mapNotNull { element ->
+            val obj = element.jsonObject
+            val title = obj["title"]?.jsonPrimitive?.contentOrNull?.trim() ?: return@mapNotNull null
+            val url = obj["url"]?.jsonPrimitive?.contentOrNull?.trim() ?: return@mapNotNull null
+            val snippet = obj["content"]?.jsonPrimitive?.contentOrNull?.trim() ?: ""
+            SearchResult(title = title, url = url, snippet = snippet)
+        }
+    } catch (e: Exception) {
+        log.warn("Failed to parse SearxNG response: {}", e.message)
+        emptyList()
+    }
+}
+

--- a/shared/src/main/kotlin/io/askimo/tools/web/TavilyBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/TavilyBackend.kt
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.tools.web
+
+import io.askimo.core.logging.logger
+import io.askimo.core.util.httpPost
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * Web search backend using the Tavily Search API.
+ *
+ * Docs: https://docs.tavily.com/docs/tavily-api/rest_api
+ * Requires a free or paid API key from https://app.tavily.com
+ *
+ * Uses a POST request with a JSON body — Tavily's standard search endpoint.
+ */
+class TavilyBackend(private val apiKey: String) : SearchBackend {
+
+    override val name: String = "Tavily"
+
+    private val log = logger<TavilyBackend>()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    companion object {
+        private const val BASE_URL = "https://api.tavily.com/search"
+        private const val TIMEOUT_MS = 20_000L
+    }
+
+    override fun search(query: String, maxResults: Int): List<SearchResult> {
+        log.debug("Tavily search: query='{}', maxResults={}", query, maxResults)
+
+        val requestBody = buildJsonObject {
+            put("query", query.trim())
+            put("max_results", maxResults)
+            put("search_depth", "basic")
+            put("include_answer", false)
+            put("api_key", apiKey)
+        }.toString()
+
+        val (status, body) = httpPost(
+            url = BASE_URL,
+            body = requestBody,
+            headers = mapOf("Content-Type" to "application/json"),
+            readTimeoutMs = TIMEOUT_MS,
+        )
+
+        if (status != 200) {
+            log.warn("Tavily returned HTTP {}: {}", status, body.take(200))
+            error("Tavily API returned HTTP $status")
+        }
+
+        return parseResults(body, maxResults)
+    }
+
+    private fun parseResults(body: String, maxResults: Int): List<SearchResult> = try {
+        val root = json.parseToJsonElement(body).jsonObject
+        val results = root["results"]?.jsonArray ?: return emptyList()
+
+        results.take(maxResults).mapNotNull { element ->
+            val obj = element.jsonObject
+            val title = obj["title"]?.jsonPrimitive?.contentOrNull?.trim() ?: return@mapNotNull null
+            val url = obj["url"]?.jsonPrimitive?.contentOrNull?.trim() ?: return@mapNotNull null
+            // Tavily returns `content` (full snippet) or `raw_content`
+            val snippet = obj["content"]?.jsonPrimitive?.contentOrNull?.trim()
+                ?: obj["raw_content"]?.jsonPrimitive?.contentOrNull?.trim()
+                ?: ""
+            SearchResult(title = title, url = url, snippet = snippet.take(300))
+        }
+    } catch (e: Exception) {
+        log.warn("Failed to parse Tavily response: {}", e.message)
+        emptyList()
+    }
+}
+

--- a/shared/src/main/kotlin/io/askimo/tools/web/TavilyBackend.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/TavilyBackend.kt
@@ -79,4 +79,3 @@ class TavilyBackend(private val apiKey: String) : SearchBackend {
         emptyList()
     }
 }
-

--- a/shared/src/main/kotlin/io/askimo/tools/web/WebSearchDispatcher.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/WebSearchDispatcher.kt
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.tools.web
+
+import io.askimo.core.config.WebSearchBackend
+import io.askimo.core.config.WebSearchConfig
+import io.askimo.core.logging.logger
+
+
+/**
+ * Selects the active [SearchBackend] based on the current [WebSearchConfig].
+ *
+ * Resolution order:
+ * 1. User-configured backend (if it has a valid API key / endpoint)
+ * 2. DuckDuckGo fallback (zero-config, always available)
+ */
+object WebSearchDispatcher {
+
+    private val log = logger<WebSearchDispatcher>()
+
+    /**
+     * Returns the active [SearchBackend] for the given config.
+     * Falls back to [DuckDuckGoBackend] if the configured backend has no valid credentials.
+     */
+    fun activeBackend(config: WebSearchConfig): SearchBackend {
+        val backend = when (config.backend) {
+            WebSearchBackend.BRAVE -> {
+                if (config.braveApiKey.isNotBlank()) {
+                    log.debug("Using Brave Search backend")
+                    BraveBackend(config.braveApiKey)
+                } else {
+                    log.debug("Brave backend selected but no API key — falling back to DuckDuckGo")
+                    null
+                }
+            }
+
+            WebSearchBackend.TAVILY -> {
+                if (config.tavilyApiKey.isNotBlank()) {
+                    log.debug("Using Tavily backend")
+                    TavilyBackend(config.tavilyApiKey)
+                } else {
+                    log.debug("Tavily backend selected but no API key — falling back to DuckDuckGo")
+                    null
+                }
+            }
+
+            WebSearchBackend.SEARXNG -> {
+                log.debug("Using SearxNG backend: {}", config.searxngEndpoint)
+                SearxNGBackend(config.searxngEndpoint)
+            }
+
+            WebSearchBackend.DUCKDUCKGO -> null
+        }
+
+        return backend ?: DuckDuckGoBackend().also {
+            if (config.backend != WebSearchBackend.DUCKDUCKGO) {
+                log.debug("Resolved backend: DuckDuckGo (fallback)")
+            } else {
+                log.debug("Using DuckDuckGo backend")
+            }
+        }
+    }
+
+    /**
+     * Tests the active backend with a simple query.
+     * Returns [Result.success] with a short status string, or [Result.failure] on error.
+     */
+    fun testBackend(config: WebSearchConfig): Result<String> = runCatching {
+        val backend = activeBackend(config)
+        val results = backend.search("Askimo AI", maxResults = 1)
+        if (results.isEmpty()) {
+            error("No results returned from ${backend.name}")
+        }
+        "OK · ${backend.name} · \"${results.first().title}\""
+    }
+}
+

--- a/shared/src/main/kotlin/io/askimo/tools/web/WebSearchDispatcher.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/WebSearchDispatcher.kt
@@ -8,7 +8,6 @@ import io.askimo.core.config.WebSearchBackend
 import io.askimo.core.config.WebSearchConfig
 import io.askimo.core.logging.logger
 
-
 /**
  * Selects the active [SearchBackend] based on the current [WebSearchConfig].
  *
@@ -76,4 +75,3 @@ object WebSearchDispatcher {
         "OK · ${backend.name} · \"${results.first().title}\""
     }
 }
-

--- a/shared/src/main/kotlin/io/askimo/tools/web/WebSearchTools.kt
+++ b/shared/src/main/kotlin/io/askimo/tools/web/WebSearchTools.kt
@@ -7,6 +7,8 @@ package io.askimo.tools.web
 import dev.langchain4j.agent.tool.P
 import dev.langchain4j.agent.tool.Tool
 import io.askimo.core.AppConstants.DOMAIN
+import io.askimo.core.config.AppConfig
+import io.askimo.core.logging.logger
 import io.askimo.tools.ToolResponseBuilder
 import org.jsoup.HttpStatusException
 import org.jsoup.Jsoup
@@ -24,6 +26,89 @@ object WebSearchTools {
     private const val PAGE_TIMEOUT_MS = 15_000
     private const val USER_AGENT =
         "Mozilla/5.0 (compatible; Askimo/1.0; +https://$DOMAIN)"
+
+    private val log = logger<WebSearchTools>()
+
+    /**
+     * Search the web for current information using the configured backend.
+     *
+     * @param query      The search query string.
+     * @param maxResults Maximum number of results to return (1–10, default 5).
+     * @return JSON with a list of results (title, url, snippet) and the backend used.
+     */
+    @Tool(
+        """Search the web for current information, recent news, or any topic that needs up-to-date data.
+
+Use this tool when the user asks about:
+- Recent events, news, or anything that may have changed recently
+- Current prices, statistics, or live data
+- Topics the AI might not have knowledge about
+- Finding specific websites, products, people, or organisations
+
+WORKFLOW:
+1. Call searchWeb() with a concise, targeted query.
+2. Review the returned titles and snippets.
+3. Call readWebPage() on the most relevant URL(s) to get full content if needed.
+4. Summarise the findings directly to the user.
+
+OUTPUT FORMAT:
+Present results as a numbered list with title, URL, and a brief note about each.
+Always cite the source URLs in your response.
+        """,
+        metadata = "{ \"className\": \"$CLASS_NAME\", \"methodName\": \"searchWeb\" }",
+    )
+    fun searchWeb(
+        @P("The search query string — be concise and specific") query: String,
+        @P("Maximum number of results to return, between 1 and 10. Default 5.") maxResults: Int = 5,
+    ): String = try {
+        require(query.isNotBlank()) { "Query cannot be blank" }
+
+        val config = AppConfig.webSearch
+        if (!config.enabled) {
+            return ToolResponseBuilder.failure(
+                error = "Web search is disabled. Enable it in Settings → Web Search.",
+            )
+        }
+
+        val safeMax = maxResults.coerceIn(1, 10)
+        val backend = WebSearchDispatcher.activeBackend(config)
+
+        log.debug("searchWeb: query='{}', backend='{}', maxResults={}", query, backend.name, safeMax)
+
+        val results = backend.search(query, safeMax)
+
+        if (results.isEmpty()) {
+            return ToolResponseBuilder.failure(
+                error = "No results found for: \"$query\". Try a different or broader query.",
+                metadata = mapOf("query" to query, "backend" to backend.name),
+            )
+        }
+
+        val summary = results.mapIndexed { i, r ->
+            "${i + 1}. ${r.title}\n   URL: ${r.url}\n   ${r.snippet}"
+        }.joinToString("\n\n")
+
+        ToolResponseBuilder.successWithData(
+            output = summary,
+            data = mapOf(
+                "query" to query,
+                "backend" to backend.name,
+                "resultCount" to results.size,
+                "results" to results.map {
+                    mapOf("title" to it.title, "url" to it.url, "snippet" to it.snippet)
+                },
+            ),
+        )
+    } catch (e: Exception) {
+        log.error("searchWeb failed for query '{}': {}", query, e.message)
+        ToolResponseBuilder.failure(
+            error = "Web search failed: ${e.message}",
+            metadata = mapOf(
+                "query" to query,
+                "exception" to (e::class.simpleName ?: "Exception"),
+            ),
+        )
+    }
 
     /**
      * Fetch and extract the readable text content of a web page.


### PR DESCRIPTION
- add UI settings section for web search configuration
- add multiple search backends: DuckDuckGo, Brave, Tavily, SearxNG
- extend AppConfig with WebSearchBackend enum and related fields
- provide i18n strings for web search settings and placeholder hints