### PR TITLE
feat(chat): Introduce tool call display in chat messages

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatState.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatState.kt
@@ -6,6 +6,7 @@ package io.askimo.ui.chat
 
 import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.dto.ChatMessageDTO
+import io.askimo.core.chat.dto.ToolCallInfo
 
 /**
  * State for the chat view.
@@ -40,4 +41,7 @@ data class ChatState(
     // Session state
     val sessionTitle: String,
     val project: Project?,
+
+    // Tool call state — ephemeral, populated only during active streaming
+    val activeToolCalls: List<ToolCallInfo> = emptyList(),
 )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -179,6 +179,7 @@ fun chatView(
     val selectedDirective = state.selectedDirective
     val sessionTitle = state.sessionTitle
     val project = state.project
+    val activeToolCalls = state.activeToolCalls
 
     // Internal state management for ChatView
     val scope = rememberCoroutineScope()
@@ -1222,6 +1223,7 @@ fun chatView(
                                         onRetryMessage = { messageId -> actions.retryMessage(messageId, currentEnabledServerIds) },
                                         viewportTopY = viewportBounds?.top,
                                         projectId = project?.id,
+                                        activeToolCalls = activeToolCalls,
                                     )
                                 }
                             }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
@@ -12,6 +12,7 @@ import io.askimo.core.analytics.AnalyticsEvent
 import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
+import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDTO
 import io.askimo.core.chat.repository.PaginationDirection
 import io.askimo.core.chat.service.ChatSessionService
@@ -110,6 +111,9 @@ class ChatViewModel(
     var project by mutableStateOf<Project?>(null)
         private set
 
+    var activeToolCalls by mutableStateOf<List<ToolCallInfo>>(emptyList())
+        private set
+
     val state: ChatState
         get() = ChatState(
             messages = messages,
@@ -129,6 +133,7 @@ class ChatViewModel(
             selectedDirective = selectedDirective,
             sessionTitle = sessionTitle ?: "",
             project = project,
+            activeToolCalls = activeToolCalls,
         )
 
     /**
@@ -352,6 +357,38 @@ class ChatViewModel(
             // Track this subscription by sessionId
             activeSubscriptions[sessionId] = subscriptionJob
 
+            // Subscribe to tool call state for the streaming message.
+            // When a tool fires before any text token arrives (no id=null message exists yet),
+            // inject a placeholder AI message so the bubble appears and can render tool chips.
+            scope.launch {
+                activeThread.toolCalls.collect { calls ->
+                    if (currentSessionId.value == sessionId) {
+                        activeToolCalls = calls
+                        // No streaming bubble yet — create placeholder so tool chips are visible
+                        if (calls.isNotEmpty() && messages.none { !it.isUser && it.id == null }) {
+                            isThinking = false
+                            stopThinkingTimer()
+                            val placeholder = ChatMessageDTO(
+                                content = "",
+                                isUser = false,
+                                id = null,
+                                timestamp = null,
+                            )
+                            messages = if (retryInsertPosition != null) {
+                                messages.toMutableList().apply { add(retryInsertPosition!!, placeholder) }
+                            } else {
+                                val lastMsg = messages.lastOrNull()
+                                if (lastMsg != null && !lastMsg.isUser) {
+                                    messages.dropLast(1) + placeholder
+                                } else {
+                                    messages + placeholder
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             // Monitor completion in a separate job
             scope.launch {
                 activeThread.isComplete.collect { isComplete ->
@@ -402,6 +439,9 @@ class ChatViewModel(
                         // Clear retry position tracker
                         retryInsertPosition = null
 
+                        // NOTE: activeToolCalls is NOT cleared here — chips stay visible on the
+                        // completed message until the user sends the next message.
+
                         // Refresh session title (in case it was auto-generated from first message)
                         refreshSessionTitle()
 
@@ -440,7 +480,7 @@ class ChatViewModel(
 
         val currentSessionId = currentSessionId.value
 
-        if (editingMessage != null && editingMessage.id != null) {
+        if (editingMessage?.id != null) {
             val originalMessageId = editingMessage.id ?: return currentSessionId
 
             scope.launch {
@@ -521,6 +561,9 @@ class ChatViewModel(
                 isThinking = true
                 thinkingElapsedSeconds = 0
 
+                // Clear tool chips from the previous response before retrying
+                activeToolCalls = emptyList()
+
                 startThinkingTimer()
 
                 // 6. Resend the user message
@@ -597,6 +640,9 @@ class ChatViewModel(
      */
     fun sendMessage(projectId: String?, mode: CreationMode, message: String, attachments: List<FileAttachmentDTO> = emptyList(), enabledServerIds: Set<String> = emptySet()) {
         if (message.isBlank() || isLoading) return
+
+        // Clear tool chips from the previous response now that a new message is starting
+        activeToolCalls = emptyList()
 
         // Session ID must be set by this point (from resumeSession)
         val sessionId = currentSessionId.value ?: run {
@@ -1137,6 +1183,9 @@ class ChatViewModel(
         // Clear session title and project
         sessionTitle = null
         project = null
+
+        // Clear ephemeral tool call state
+        activeToolCalls = emptyList()
 
         // Clear search state
         clearSearch()

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -26,13 +27,19 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
@@ -72,6 +79,8 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
+import io.askimo.core.chat.dto.ToolCallInfo
+import io.askimo.core.chat.dto.ToolCallStatus
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.RunCodeEvent
 import io.askimo.core.event.internal.parseFilePreviewRequestEvent
@@ -124,6 +133,7 @@ fun messageList(
     onRetryMessage: ((String) -> Unit)? = null,
     viewportTopY: Float? = null,
     projectId: String? = null,
+    activeToolCalls: List<ToolCallInfo> = emptyList(),
 ) {
     // Retry confirmation dialog state
     var showRetryConfirmDialog by remember { mutableStateOf(false) }
@@ -187,6 +197,16 @@ fun messageList(
                     val isActiveResult = searchQuery.isNotBlank() && messageIndex == currentSearchResultIndex
                     // A message is streaming when it's the last AI message still without a persisted ID
                     val isStreamingMessage = !group.message.isUser && group.message.id == null
+                    // Show tool chips on the last AI message whether streaming (id=null) or already
+                    // persisted (real id). Matching by id covers both cases:
+                    //   • streaming  → both ids are null        → matched
+                    //   • completed  → real id matches          → matched
+                    //   • older msg  → id differs               → emptyList
+                    val lastAiMessageId = messages.lastOrNull { !it.isUser }?.id
+                    val isLastAiMsg = !group.message.isUser && (
+                        (group.message.id != null && group.message.id == lastAiMessageId) ||
+                            (group.message.id == null && lastAiMessageId == null)
+                        )
                     messageBubble(
                         message = group.message,
                         searchQuery = searchQuery,
@@ -206,6 +226,7 @@ fun messageList(
                         },
                         isStreaming = isStreamingMessage,
                         projectId = projectId,
+                        toolCalls = if (isLastAiMsg) activeToolCalls else emptyList(),
                     )
                     isFirstMessage = false
                     messageIndex++
@@ -300,6 +321,7 @@ fun messageBubble(
     isOutdatedMessage: Boolean = false,
     isStreaming: Boolean = false,
     projectId: String? = null,
+    toolCalls: List<ToolCallInfo> = emptyList(),
 ) {
     Box(
         modifier = Modifier
@@ -333,6 +355,7 @@ fun messageBubble(
                 isOutdatedMessage = isOutdatedMessage,
                 isStreaming = isStreaming,
                 projectId = projectId,
+                toolCalls = toolCalls,
             )
         }
     }
@@ -588,6 +611,7 @@ private fun aiMessageBubble(
     isOutdatedMessage: Boolean = false,
     isStreaming: Boolean = false,
     projectId: String? = null,
+    toolCalls: List<ToolCallInfo> = emptyList(),
 ) {
     val clipboardManager = LocalClipboardManager.current
     var showCopyFeedback by remember { mutableStateOf(false) }
@@ -600,6 +624,13 @@ private fun aiMessageBubble(
         MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
     } else {
         MaterialTheme.colorScheme.onSurface
+    }
+
+    // Tool call collapsible state — auto-expand when any tool starts running
+    var toolCallsExpanded by remember { mutableStateOf(false) }
+    val hasRunningTool = toolCalls.any { it.status == ToolCallStatus.RUNNING }
+    LaunchedEffect(hasRunningTool) {
+        if (hasRunningTool) toolCallsExpanded = true
     }
 
     Column(
@@ -650,6 +681,15 @@ private fun aiMessageBubble(
                             ),
                     ) {
                         Column {
+                            // Tool call collapsible section — shown only during streaming
+                            if (toolCalls.isNotEmpty()) {
+                                toolCallsSection(
+                                    toolCalls = toolCalls,
+                                    isExpanded = toolCallsExpanded,
+                                    onToggle = { toolCallsExpanded = !toolCallsExpanded },
+                                )
+                            }
+
                             if (message.attachments.isNotEmpty()) {
                                 Column(
                                     modifier = Modifier.padding(start = Spacing.medium, end = Spacing.medium, top = Spacing.medium),
@@ -999,7 +1039,213 @@ private fun aiMessageBubble(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
+/**
+ * Collapsible section that displays AI tool calls above the response text.
+ * Shows "▶ Running tool…" when any tool is active, "▶ Used N tool(s)" when all are done.
+ * Expands automatically when a tool starts running; collapses manually by the user.
+ */
+@Composable
+private fun toolCallsSection(
+    toolCalls: List<ToolCallInfo>,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    val hasRunning = toolCalls.any { it.status == ToolCallStatus.RUNNING }
+    val headerText = if (hasRunning) {
+        stringResource("tool.call.header.running")
+    } else {
+        stringResource("tool.call.header.done", toolCalls.size)
+    }
+    val headerColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = Spacing.medium, end = Spacing.medium, top = Spacing.small),
+    ) {
+        // Collapsed / expanded header row — full width, hand cursor
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onToggle)
+                .pointerHoverIcon(PointerIcon.Hand)
+                .padding(vertical = Spacing.extraSmall),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+        ) {
+            Icon(
+                imageVector = if (isExpanded) Icons.Default.ExpandMore else Icons.Default.ChevronRight,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = headerColor,
+            )
+            Text(
+                text = headerText,
+                style = MaterialTheme.typography.labelSmall,
+                color = headerColor,
+            )
+        }
+
+        // Expanded: one row per tool call
+        if (isExpanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = Spacing.extraSmall, bottom = Spacing.extraSmall),
+                verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+            ) {
+                toolCalls.forEach { toolCall ->
+                    toolCallRow(toolCall)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Single row showing a tool name, its running/done/failed status icon, and an optional
+ * expandable section with the raw arguments and result.
+ */
+@Composable
+private fun toolCallRow(toolCall: ToolCallInfo) {
+    val isDone = toolCall.status == ToolCallStatus.DONE
+    val hasFailed = toolCall.hasFailed
+    val hasDetails = !toolCall.arguments.isNullOrBlank() || !toolCall.result.isNullOrBlank()
+
+    var detailsExpanded by remember { mutableStateOf(false) }
+
+    val statusColor = when {
+        hasFailed -> MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
+        isDone -> MaterialTheme.colorScheme.primary.copy(alpha = 0.8f)
+        else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+    }
+
+    Column(
+        modifier = Modifier
+            .background(
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                shape = RoundedCornerShape(6.dp),
+            )
+            .padding(horizontal = Spacing.small, vertical = 3.dp),
+    ) {
+        // Header row: icon + name + status indicator (+ expand chevron if details exist)
+        Row(
+            modifier = if (hasDetails && isDone) {
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                        onClick = { detailsExpanded = !detailsExpanded },
+                    )
+                    .pointerHoverIcon(PointerIcon.Hand)
+            } else {
+                Modifier.fillMaxWidth()
+            },
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Build,
+                contentDescription = null,
+                modifier = Modifier.size(12.dp),
+                tint = statusColor,
+            )
+            Text(
+                text = toolCall.toolName,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+            )
+            // Status indicator
+            when {
+                !isDone -> Text(
+                    text = "⏳",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = statusColor,
+                )
+
+                hasFailed -> Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource("tool.call.status.failed"),
+                    modifier = Modifier.size(12.dp),
+                    tint = statusColor,
+                )
+
+                else -> Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = stringResource("tool.call.status.done"),
+                    modifier = Modifier.size(12.dp),
+                    tint = statusColor,
+                )
+            }
+            // Expand chevron (only when done and has details)
+            if (hasDetails && isDone) {
+                Icon(
+                    imageVector = if (detailsExpanded) Icons.Default.ExpandMore else Icons.Default.ChevronRight,
+                    contentDescription = null,
+                    modifier = Modifier.size(12.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                )
+            }
+        }
+
+        // Expandable details: arguments + result
+        if (detailsExpanded && hasDetails) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = Spacing.extraSmall),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                if (!toolCall.arguments.isNullOrBlank()) {
+                    toolCallDetailSection(
+                        label = stringResource("tool.call.detail.arguments"),
+                        content = toolCall.arguments!!,
+                    )
+                }
+                if (!toolCall.result.isNullOrBlank()) {
+                    toolCallDetailSection(
+                        label = stringResource("tool.call.detail.result"),
+                        content = toolCall.result!!,
+                        labelColor = if (hasFailed) MaterialTheme.colorScheme.error.copy(alpha = 0.8f) else null,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A small labelled text block used inside an expanded tool-call row.
+ */
+@Composable
+private fun toolCallDetailSection(
+    label: String,
+    content: String,
+    labelColor: Color? = null,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = labelColor ?: MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+        )
+        Text(
+            text = content,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f),
+                    shape = RoundedCornerShape(4.dp),
+                )
+                .padding(horizontal = Spacing.extraSmall, vertical = 2.dp),
+        )
+    }
+}
+
 @Composable
 private fun fileAttachmentChip(
     attachment: FileAttachmentDTO,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
@@ -11,6 +11,8 @@ import io.askimo.core.chat.domain.ChatMessage
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
+import io.askimo.core.chat.dto.ToolCallInfo
+import io.askimo.core.chat.dto.ToolCallStatus
 import io.askimo.core.chat.service.ChatSessionService
 import io.askimo.core.context.AppContext
 import io.askimo.core.event.EventBus
@@ -120,10 +122,12 @@ class SessionManager(
         private val _isComplete: MutableStateFlow<Boolean>,
         private val _hasFailed: MutableStateFlow<Boolean>,
         private val _savedMessage: MutableStateFlow<ChatMessage?> = MutableStateFlow(null),
+        private val _toolCalls: MutableStateFlow<List<ToolCallInfo>> = MutableStateFlow(emptyList()),
     ) {
         val chunks: StateFlow<List<String>> = _chunks.asStateFlow()
         val isComplete: StateFlow<Boolean> = _isComplete.asStateFlow()
         val savedMessage: StateFlow<ChatMessage?> = _savedMessage.asStateFlow()
+        val toolCalls: StateFlow<List<ToolCallInfo>> = _toolCalls.asStateFlow()
 
         private val mutex = Mutex()
 
@@ -148,6 +152,39 @@ class SessionManager(
         suspend fun setSavedMessage(message: ChatMessage) {
             mutex.withLock {
                 _savedMessage.value = message
+            }
+        }
+
+        /** Mark a tool as RUNNING. Deduplicates: no-op if already tracked. */
+        suspend fun markToolRunning(toolName: String, arguments: String?) {
+            mutex.withLock {
+                if (_toolCalls.value.none { it.toolName == toolName }) {
+                    _toolCalls.value = _toolCalls.value + ToolCallInfo(
+                        toolName = toolName,
+                        status = ToolCallStatus.RUNNING,
+                        arguments = arguments,
+                    )
+                }
+            }
+        }
+
+        /** Mark a tool as DONE. Replaces existing RUNNING entry, or appends if not found. */
+        suspend fun markToolDone(toolName: String, arguments: String?, result: String?, hasFailed: Boolean) {
+            mutex.withLock {
+                val existing = _toolCalls.value
+                val idx = existing.indexOfFirst { it.toolName == toolName }
+                val updated = ToolCallInfo(
+                    toolName = toolName,
+                    status = ToolCallStatus.DONE,
+                    arguments = arguments,
+                    result = result,
+                    hasFailed = hasFailed,
+                )
+                _toolCalls.value = if (idx >= 0) {
+                    existing.toMutableList().also { it[idx] = updated }
+                } else {
+                    existing + updated
+                }
             }
         }
 
@@ -258,6 +295,16 @@ class SessionManager(
                                 capturedTotalTokens = total
                                 capturedDurationMs = durationMs
                                 log.debug("Token usage for session $sessionId: input=$input, output=$output, total=$total, duration=${durationMs}ms")
+                            },
+                            onToolStarted = { toolName, arguments ->
+                                streamingScope.launch {
+                                    thread.markToolRunning(toolName, arguments)
+                                }
+                            },
+                            onToolFinished = { toolName, arguments, result, hasFailed ->
+                                streamingScope.launch {
+                                    thread.markToolDone(toolName, arguments, result, hasFailed)
+                                }
                             },
                         )
 

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -847,7 +847,6 @@ tool.call.header.running=Running tool...
 tool.call.header.done=Used {0} tool(s)
 tool.call.status.done=Done
 tool.call.status.failed=Failed
-tool.call.status.running=Running
 tool.call.detail.arguments=Arguments
 tool.call.detail.result=Result
 

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -841,7 +841,8 @@ message.date.today=Today
 message.date.yesterday=Yesterday
 message.token.usage={0} tokens · {1} in / {2} out
 message.token.usage.tooltip=Tokens used by this response.\nInput: your prompt + context sent to the AI.\nOutput: the AI-generated reply.
-# Tool call display (ephemeral, streaming only)
+
+# Tool call display
 tool.call.header.running=Running tool...
 tool.call.header.done=Used {0} tool(s)
 tool.call.status.done=Done
@@ -849,6 +850,7 @@ tool.call.status.failed=Failed
 tool.call.status.running=Running
 tool.call.detail.arguments=Arguments
 tool.call.detail.result=Result
+
 attachment.download=Download attachment
 attachment.download.description=Download this file attachment
 attachment.save.file=Save Attachment

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -841,6 +841,14 @@ message.date.today=Today
 message.date.yesterday=Yesterday
 message.token.usage={0} tokens · {1} in / {2} out
 message.token.usage.tooltip=Tokens used by this response.\nInput: your prompt + context sent to the AI.\nOutput: the AI-generated reply.
+# Tool call display (ephemeral, streaming only)
+tool.call.header.running=Running tool...
+tool.call.header.done=Used {0} tool(s)
+tool.call.status.done=Done
+tool.call.status.failed=Failed
+tool.call.status.running=Running
+tool.call.detail.arguments=Arguments
+tool.call.detail.result=Result
 attachment.download=Download attachment
 attachment.download.description=Download this file attachment
 attachment.save.file=Save Attachment

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -818,6 +818,16 @@ message.date.today=Heute
 message.date.yesterday=Gestern
 message.token.usage={0} Tokens · {1} in / {2} out
 message.token.usage.tooltip=Von dieser Antwort verwendete Tokens.\nEingabe: Ihr Prompt + Kontext, der an die KI gesendet wurde.\nAusgabe: die KI-generierte Antwort.
+
+# Tool call display
+tool.call.header.running=Tool wird ausgeführt...
+tool.call.header.done={0} Tool(s) verwendet
+tool.call.status.done=Fertig
+tool.call.status.failed=Fehlgeschlagen
+tool.call.status.running=Wird ausgeführt
+tool.call.detail.arguments=Argumente
+tool.call.detail.result=Ergebnis
+
 attachment.download=Anhang herunterladen
 attachment.download.description=Diese Dateianlage herunterladen
 attachment.save.file=Anhang speichern

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -824,7 +824,6 @@ tool.call.header.running=Tool wird ausgeführt...
 tool.call.header.done={0} Tool(s) verwendet
 tool.call.status.done=Fertig
 tool.call.status.failed=Fehlgeschlagen
-tool.call.status.running=Wird ausgeführt
 tool.call.detail.arguments=Argumente
 tool.call.detail.result=Ergebnis
 

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -817,6 +817,16 @@ message.date.today=Hoy
 message.date.yesterday=Ayer
 message.token.usage={0} tokens · {1} de entrada / {2} de salida
 message.token.usage.tooltip=Tokens utilizados por esta respuesta.\nEntrada: su prompt + contexto enviado a la IA.\nSalida: la respuesta generada por la IA.
+
+# Tool call display
+tool.call.header.running=Ejecutando herramienta...
+tool.call.header.done={0} herramienta(s) utilizada(s)
+tool.call.status.done=Hecho
+tool.call.status.failed=Fallido
+tool.call.status.running=Ejecutando
+tool.call.detail.arguments=Argumentos
+tool.call.detail.result=Resultado
+
 attachment.download=Descargar adjunto
 attachment.download.description=Descargar este archivo adjunto
 attachment.save.file=Guardar adjunto

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -823,7 +823,6 @@ tool.call.header.running=Ejecutando herramienta...
 tool.call.header.done={0} herramienta(s) utilizada(s)
 tool.call.status.done=Hecho
 tool.call.status.failed=Fallido
-tool.call.status.running=Ejecutando
 tool.call.detail.arguments=Argumentos
 tool.call.detail.result=Resultado
 

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -817,6 +817,16 @@ message.date.today=Aujourd'hui
 message.date.yesterday=Hier
 message.token.usage={0} tokens · {1} en entrée / {2} en sortie
 message.token.usage.tooltip=Tokens utilisés par cette réponse.\nEntrée: votre prompt + contexte envoyé à l'IA.\nSortie: la réponse générée par l'IA.
+
+# Tool call display
+tool.call.header.running=Exécution de l'outil...
+tool.call.header.done={0} outil(s) utilisé(s)
+tool.call.status.done=Terminé
+tool.call.status.failed=Échoué
+tool.call.status.running=En cours
+tool.call.detail.arguments=Arguments
+tool.call.detail.result=Résultat
+
 attachment.download=Télécharger la pièce jointe
 attachment.download.description=Télécharger cette pièce jointe
 attachment.save.file=Enregistrer la pièce jointe

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -823,7 +823,6 @@ tool.call.header.running=Exécution de l'outil...
 tool.call.header.done={0} outil(s) utilisé(s)
 tool.call.status.done=Terminé
 tool.call.status.failed=Échoué
-tool.call.status.running=En cours
 tool.call.detail.arguments=Arguments
 tool.call.detail.result=Résultat
 

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -822,7 +822,6 @@ tool.call.header.running=ツールを実行中...
 tool.call.header.done={0} 個のツールを使用しました
 tool.call.status.done=完了
 tool.call.status.failed=失敗
-tool.call.status.running=実行中
 tool.call.detail.arguments=引数
 tool.call.detail.result=結果
 

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -816,6 +816,16 @@ message.date.today=今日
 message.date.yesterday=昨日
 message.token.usage={0} トークン · {1} 入力 / {2} 出力
 message.token.usage.tooltip=この応答で使用されたトークン。\n入力: AIに送信されたプロンプトとコンテキスト。\n出力: AIが生成した返信。
+
+# Tool call display
+tool.call.header.running=ツールを実行中...
+tool.call.header.done={0} 個のツールを使用しました
+tool.call.status.done=完了
+tool.call.status.failed=失敗
+tool.call.status.running=実行中
+tool.call.detail.arguments=引数
+tool.call.detail.result=結果
+
 attachment.download=添付ファイルをダウンロード
 attachment.download.description=この添付ファイルをダウンロード
 attachment.save.file=添付ファイルを保存

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -823,7 +823,6 @@ tool.call.header.running=도구 실행 중...
 tool.call.header.done={0}개의 도구 사용됨
 tool.call.status.done=완료
 tool.call.status.failed=실패
-tool.call.status.running=실행 중
 tool.call.detail.arguments=인수
 tool.call.detail.result=결과
 

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -817,6 +817,16 @@ message.date.today=오늘
 message.date.yesterday=어제
 message.token.usage={0} 토큰 · {1} 입력 / {2} 출력
 message.token.usage.tooltip=이 응답에 사용된 토큰입니다.\n입력: AI로 전송된 프롬프트 및 컨텍스트.\n출력: AI가 생성한 응답.
+
+# Tool call display
+tool.call.header.running=도구 실행 중...
+tool.call.header.done={0}개의 도구 사용됨
+tool.call.status.done=완료
+tool.call.status.failed=실패
+tool.call.status.running=실행 중
+tool.call.detail.arguments=인수
+tool.call.detail.result=결과
+
 attachment.download=첨부파일 다운로드
 attachment.download.description=이 첨부파일 다운로드
 attachment.save.file=첨부파일 저장

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -825,7 +825,6 @@ tool.call.header.running=Executando ferramenta...
 tool.call.header.done={0} ferramenta(s) usada(s)
 tool.call.status.done=Concluído
 tool.call.status.failed=Falhou
-tool.call.status.running=Em execução
 tool.call.detail.arguments=Argumentos
 tool.call.detail.result=Resultado
 

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -819,6 +819,16 @@ message.date.today=Hoje
 message.date.yesterday=Ontem
 message.token.usage={0} tokens · {1} de entrada / {2} de saída
 message.token.usage.tooltip=Tokens usados por esta resposta.\nEntrada: seu prompt + contexto enviado à IA.\nSaída: a resposta gerada pela IA.
+
+# Tool call display
+tool.call.header.running=Executando ferramenta...
+tool.call.header.done={0} ferramenta(s) usada(s)
+tool.call.status.done=Concluído
+tool.call.status.failed=Falhou
+tool.call.status.running=Em execução
+tool.call.detail.arguments=Argumentos
+tool.call.detail.result=Resultado
+
 attachment.download=Baixar anexo
 attachment.download.description=Baixar este anexo
 attachment.save.file=Salvar anexo

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -821,7 +821,6 @@ tool.call.header.running=Đang chạy công cụ...
 tool.call.header.done=Đã sử dụng {0} công cụ
 tool.call.status.done=Hoàn tất
 tool.call.status.failed=Thất bại
-tool.call.status.running=Đang chạy
 tool.call.detail.arguments=Đối số
 tool.call.detail.result=Kết quả
 

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -815,6 +815,16 @@ message.date.today=Hôm nay
 message.date.yesterday=Hôm qua
 message.token.usage={0} token · {1} vào / {2} ra
 message.token.usage.tooltip=Số token được sử dụng bởi phản hồi này.\nĐầu vào: prompt của bạn + ngữ cảnh được gửi đến AI.\nĐầu ra: phản hồi do AI tạo ra.
+
+# Tool call display
+tool.call.header.running=Đang chạy công cụ...
+tool.call.header.done=Đã sử dụng {0} công cụ
+tool.call.status.done=Hoàn tất
+tool.call.status.failed=Thất bại
+tool.call.status.running=Đang chạy
+tool.call.detail.arguments=Đối số
+tool.call.detail.result=Kết quả
+
 attachment.download=Tải xuống tệp đính kèm
 attachment.download.description=Tải xuống tệp đính kèm này
 attachment.save.file=Lưu tệp đính kèm

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -816,6 +816,16 @@ message.date.today=今天
 message.date.yesterday=昨天
 message.token.usage={0} 个 token · {1} 进 / {2} 出
 message.token.usage.tooltip=此回复使用的 token。\n输入: 您的 prompt + 发送给 AI 的上下文。\n输出: AI 生成的回复。
+
+# Tool call display
+tool.call.header.running=正在运行工具...
+tool.call.header.done=已使用 {0} 个工具
+tool.call.status.done=已完成
+tool.call.status.failed=失败
+tool.call.status.running=运行中
+tool.call.detail.arguments=参数
+tool.call.detail.result=结果
+
 attachment.download=下载附件
 attachment.download.description=下载此附件
 attachment.save.file=保存附件

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -822,7 +822,6 @@ tool.call.header.running=正在运行工具...
 tool.call.header.done=已使用 {0} 个工具
 tool.call.status.done=已完成
 tool.call.status.failed=失败
-tool.call.status.running=运行中
 tool.call.detail.arguments=参数
 tool.call.detail.result=结果
 

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -816,6 +816,16 @@ message.date.today=今天
 message.date.yesterday=昨天
 message.token.usage={0} 個 token · {1} 進 / {2} 出
 message.token.usage.tooltip=此回覆使用的 token。\n輸入: 您的 prompt + 傳送給 AI 的上下文。\n輸出: AI 產生的回覆。
+
+# Tool call display
+tool.call.header.running=正在執行工具...
+tool.call.header.done=已使用 {0} 個工具
+tool.call.status.done=已完成
+tool.call.status.failed=失敗
+tool.call.status.running=執行中
+tool.call.detail.arguments=參數
+tool.call.detail.result=結果
+
 attachment.download=下載附件
 attachment.download.description=下載此附件
 attachment.save.file=儲存附件

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -822,7 +822,6 @@ tool.call.header.running=正在執行工具...
 tool.call.header.done=已使用 {0} 個工具
 tool.call.status.done=已完成
 tool.call.status.failed=失敗
-tool.call.status.running=執行中
 tool.call.detail.arguments=參數
 tool.call.detail.result=結果
 

--- a/shared/src/main/kotlin/io/askimo/core/chat/dto/ToolCallInfo.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/dto/ToolCallInfo.kt
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.chat.dto
+
+/**
+ * Status of a single tool call made by the AI during a streaming response.
+ */
+enum class ToolCallStatus {
+    /** The tool has been requested and is currently executing. */
+    RUNNING,
+
+    /** The tool has finished executing successfully. */
+    DONE,
+}
+
+/**
+ * Represents a single tool call made by the AI during a streaming response.
+ *
+ * This is ephemeral state — it exists only for the duration of the active
+ * streaming session and is not persisted to the database.
+ *
+ * @param toolName  The name of the tool being called (e.g. "weather_lookup", "read_file")
+ * @param status    Current execution status: [ToolCallStatus.RUNNING] or [ToolCallStatus.DONE]
+ * @param arguments Raw JSON arguments string passed to the tool (available from the start)
+ * @param result    Tool output text; null while still running or if the tool produced no output
+ * @param hasFailed Whether the tool execution ended with an error
+ */
+data class ToolCallInfo(
+    val toolName: String,
+    val status: ToolCallStatus,
+    val arguments: String? = null,
+    val result: String? = null,
+    val hasFailed: Boolean = false,
+)

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -69,6 +69,8 @@ fun ChatClient.sendStreamingMessageWithCallback(
     onToken: (String) -> Unit = {},
     onFollowUpSuggestion: ((FollowUpSuggestion) -> Unit)? = null,
     onTokenUsage: ((inputTokens: Int, outputTokens: Int, totalTokens: Int, durationMs: Long) -> Unit)? = null,
+    onToolStarted: ((toolName: String, arguments: String?) -> Unit)? = null,
+    onToolFinished: ((toolName: String, arguments: String?, result: String?, hasFailed: Boolean) -> Unit)? = null,
 ): String {
     val log = logger<ChatClient>()
 
@@ -133,8 +135,18 @@ fun ChatClient.sendStreamingMessageWithCallback(
                                 }
                             }
                             done.countDown()
+                        }.beforeToolExecution { before ->
+                            val toolName = before.request().name()
+                            val arguments = before.request().arguments()
+                            log.debug("Tool starting: {}", toolName)
+                            onToolStarted?.invoke(toolName, arguments)
                         }.onToolExecuted { tool ->
-                            log.debug("Tool executed: {}", tool)
+                            val toolName = tool.request().name()
+                            val arguments = tool.request().arguments()
+                            val result = tool.result()
+                            val hasFailed = tool.hasFailed()
+                            log.debug("Tool executed: {}", toolName)
+                            onToolFinished?.invoke(toolName, arguments, result, hasFailed)
                         }
                         .onError { e ->
                             errorOccurred = true


### PR DESCRIPTION
- Allows users to see when the system is actively using tools during a response.
- Provides state for displaying tool call status (running, done, failed).
- Enables persistent management of tool call states across sessions.
- Adds UI components for visualizing tool execution.

Refs: [542](https://github.com/askimo-ai/askimo/issues/542)

<img width="1240" height="680" alt="Screenshot 2026-07-23 at 4 09 45 PM" src="https://github.com/user-attachments/assets/d04fcce1-28c6-4ba5-b35b-f59c4c5bcd00" />
