### PR TITLE
feat(providers): enable per-instance model overrides in provider settings

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
@@ -44,13 +44,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.askimo.core.AppConstants.DOMAIN
-import io.askimo.core.config.AppConfig
-import io.askimo.core.context.AppContext
 import io.askimo.core.providers.ChatModelFactory
 import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
+import io.askimo.core.providers.ProviderInstance
 import io.askimo.core.providers.ProviderRegistry
 import io.askimo.core.providers.ProviderSettings
+import io.askimo.core.providers.SettingField
 import io.askimo.core.providers.SpecialModelType
 import io.askimo.core.providers.filterModelsForType
 import io.askimo.ui.common.components.linkButton
@@ -151,9 +151,9 @@ fun aiProviderSettingsSection(viewModel: SettingsViewModel) {
                     }
                 }
 
-                // Model Config Card — only shown when a provider is selected
-                viewModel.provider?.let { provider ->
-                    providerModelConfigCard(provider)
+                // Model Config Card — only shown when a provider instance is active
+                viewModel.activeInstanceState?.let { instance ->
+                    providerModelConfigCard(instance, viewModel)
                 }
             } // end inner content Column
         } // end scrollable outer Column
@@ -169,7 +169,8 @@ fun aiProviderSettingsSection(viewModel: SettingsViewModel) {
 }
 
 @Composable
-private fun providerModelConfigCard(provider: ModelProvider) {
+private fun providerModelConfigCard(instance: ProviderInstance, viewModel: SettingsViewModel) {
+    val provider = instance.providerType
     val isLocalProvider = provider in setOf(
         ModelProvider.OLLAMA,
         ModelProvider.DOCKER,
@@ -244,7 +245,7 @@ private fun providerModelConfigCard(provider: ModelProvider) {
                 } else {
                     stringResource("settings.provider.model.utility.hint")
                 },
-                value = getProviderUtilityModel(provider),
+                value = instance.settings.utilityModel,
                 placeholder = if (isLocalProvider) {
                     stringResource("settings.utility.models.uses.selected")
                 } else {
@@ -255,12 +256,12 @@ private fun providerModelConfigCard(provider: ModelProvider) {
 
             if (showUtilityModelDialog) {
                 providerModelTypePickerDialog(
-                    provider = provider,
+                    instance = instance,
                     modelType = SpecialModelType.UTILITY,
-                    currentValue = getProviderUtilityModel(provider),
+                    currentValue = instance.settings.utilityModel,
                     onDismiss = { showUtilityModelDialog = false },
                     onSelect = { model ->
-                        AppConfig.updateField("models.${provider.name.lowercase()}.utilityModel", model)
+                        viewModel.updateInstanceModelOverride(instance.id, SettingField.UTILITY_MODEL, model)
                         showUtilityModelDialog = false
                     },
                 )
@@ -273,19 +274,19 @@ private fun providerModelConfigCard(provider: ModelProvider) {
             providerModelSelectorField(
                 label = stringResource("settings.vision.models.title"),
                 hint = stringResource("settings.provider.model.vision.hint"),
-                value = getProviderVisionModel(provider),
+                value = instance.settings.visionModel,
                 placeholder = stringResource("settings.model.placeholder.enter", "vision"),
                 onClick = { showVisionModelDialog = true },
             )
 
             if (showVisionModelDialog) {
                 providerModelTypePickerDialog(
-                    provider = provider,
+                    instance = instance,
                     modelType = SpecialModelType.VISION,
-                    currentValue = getProviderVisionModel(provider),
+                    currentValue = instance.settings.visionModel,
                     onDismiss = { showVisionModelDialog = false },
                     onSelect = { model ->
-                        AppConfig.updateField("models.${provider.name.lowercase()}.visionModel", model)
+                        viewModel.updateInstanceModelOverride(instance.id, SettingField.VISION_MODEL, model)
                         showVisionModelDialog = false
                     },
                 )
@@ -298,19 +299,19 @@ private fun providerModelConfigCard(provider: ModelProvider) {
             providerModelSelectorField(
                 label = stringResource("settings.image.models.title"),
                 hint = stringResource("settings.provider.model.image.hint"),
-                value = getProviderImageModel(provider),
+                value = instance.settings.imageModel,
                 placeholder = stringResource("settings.model.placeholder.enter", "image"),
                 onClick = { showImageModelDialog = true },
             )
 
             if (showImageModelDialog) {
                 providerModelTypePickerDialog(
-                    provider = provider,
+                    instance = instance,
                     modelType = SpecialModelType.IMAGE,
-                    currentValue = getProviderImageModel(provider),
+                    currentValue = instance.settings.imageModel,
                     onDismiss = { showImageModelDialog = false },
                     onSelect = { model ->
-                        AppConfig.updateField("models.${provider.name.lowercase()}.imageModel", model)
+                        viewModel.updateInstanceModelOverride(instance.id, SettingField.IMAGE_MODEL, model)
                         showImageModelDialog = false
                     },
                 )
@@ -324,19 +325,19 @@ private fun providerModelConfigCard(provider: ModelProvider) {
                 providerModelSelectorField(
                     label = stringResource("settings.rag.embedding.models"),
                     hint = stringResource("settings.provider.model.embedding.hint"),
-                    value = getProviderEmbeddingModel(provider),
+                    value = instance.settings.embeddingModel,
                     placeholder = stringResource("settings.model.placeholder.enter", "embedding"),
                     onClick = { showEmbeddingModelDialog = true },
                 )
 
                 if (showEmbeddingModelDialog) {
                     providerModelTypePickerDialog(
-                        provider = provider,
+                        instance = instance,
                         modelType = SpecialModelType.EMBEDDING,
-                        currentValue = getProviderEmbeddingModel(provider),
+                        currentValue = instance.settings.embeddingModel,
                         onDismiss = { showEmbeddingModelDialog = false },
                         onSelect = { model ->
-                            AppConfig.updateField("models.${provider.name.lowercase()}.embeddingModel", model)
+                            viewModel.updateInstanceModelOverride(instance.id, SettingField.EMBEDDING_MODEL, model)
                             showEmbeddingModelDialog = false
                         },
                     )
@@ -345,14 +346,6 @@ private fun providerModelConfigCard(provider: ModelProvider) {
         }
     }
 }
-
-private fun getProviderUtilityModel(provider: ModelProvider): String = AppConfig.models[provider].utilityModel
-
-private fun getProviderVisionModel(provider: ModelProvider): String = AppConfig.models[provider].visionModel
-
-private fun getProviderImageModel(provider: ModelProvider): String = AppConfig.models[provider].imageModel
-
-private fun getProviderEmbeddingModel(provider: ModelProvider): String = AppConfig.models[provider].embeddingModel
 
 @Composable
 private fun providerModelSelectorField(
@@ -420,12 +413,13 @@ private fun providerModelSelectorField(
 
 @Composable
 private fun providerModelTypePickerDialog(
-    provider: ModelProvider,
+    instance: ProviderInstance,
     modelType: SpecialModelType,
     currentValue: String,
     onDismiss: () -> Unit,
     onSelect: (String) -> Unit,
 ) {
+    val provider = instance.providerType
     var selectedModel by remember(currentValue) { mutableStateOf(currentValue.takeIf { it.isNotBlank() }) }
     var searchQuery by remember { mutableStateOf("") }
     var availableModels by remember { mutableStateOf<List<ModelDTO>>(emptyList()) }
@@ -433,8 +427,6 @@ private fun providerModelTypePickerDialog(
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var errorHelp by remember { mutableStateOf<String?>(null) }
     var showAll by remember { mutableStateOf(false) }
-
-    val appContext = remember { AppContext.getInstance() }
 
     LaunchedEffect(Unit) {
         isLoading = true
@@ -448,8 +440,8 @@ private fun providerModelTypePickerDialog(
                     isLoading = false
                     return@withContext
                 }
-                val settings = appContext.params.instancesForType(provider).firstOrNull()?.settings
-                    ?: factory.defaultSettings()
+                // Use this specific instance's settings (not the first instance of the type).
+                val settings = instance.settings
 
                 @Suppress("UNCHECKED_CAST")
                 val models = (factory as ChatModelFactory<ProviderSettings>).availableModels(settings)

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsViewModel.kt
@@ -74,6 +74,14 @@ class SettingsViewModel(
     /** The currently active [ProviderInstance], or null if none is configured. */
     val activeInstance get() = providerInstanceService.findById(instanceId)
 
+    /**
+     * Observable snapshot of the active [ProviderInstance].
+     * Updated by [loadConfiguration] and [updateInstanceModelOverride] so that
+     * Compose can recompose when instance settings change without switching instances.
+     */
+    var activeInstanceState by mutableStateOf<ProviderInstance?>(null)
+        private set
+
     var settingsDescription by mutableStateOf<List<String>>(emptyList())
         private set
 
@@ -212,28 +220,31 @@ class SettingsViewModel(
         instanceDisplayName = configInfo.instanceDisplayName
         instanceId = configInfo.instanceId
         settingsDescription = configInfo.settingsDescription
+        activeInstanceState = providerInstanceService.findById(configInfo.instanceId)
     }
 
     // ── Instance switching (from manage dialog, no wizard) ───────────────────────────────────
 
-    fun switchToInstance(targetInstanceId: String) {
-        scope.launch {
-            withContext(Dispatchers.IO) {
-                providerInstanceService.setActive(targetInstanceId)
-            }
-            loadConfiguration()
-        }
-    }
+    /**
+     * Persists a per-instance special model override (utility / vision / image / embedding)
+     * immediately in memory and asynchronously to disk.
+     *
+     * @param instanceId The ID of the instance to update.
+     * @param fieldName  One of [SettingField.UTILITY_MODEL], [SettingField.VISION_MODEL],
+     *                   [SettingField.IMAGE_MODEL], or [SettingField.EMBEDDING_MODEL].
+     * @param value      The model name to store, or blank to clear the override.
+     */
+    fun updateInstanceModelOverride(instanceId: String, fieldName: String, value: String) {
+        val instance = providerInstanceService.findById(instanceId) ?: return
+        val updatedSettings = instance.settings.updateField(fieldName, value)
 
-    fun deleteInstance(targetInstanceId: String) {
+        appContext.setInstanceSettings(instanceId, updatedSettings)
+        activeInstanceState = instance.copy(settings = updatedSettings)
+
         scope.launch {
             withContext(Dispatchers.IO) {
-                providerInstanceService.delete(targetInstanceId)
+                appContext.save()
             }
-            availableInstances = providerInstanceService.all
-            loadConfiguration()
-            successMessage = "Provider instance removed"
-            showSuccessMessage = true
         }
     }
 
@@ -516,11 +527,16 @@ class SettingsViewModel(
         scope.launch {
             try {
                 val result = withContext(Dispatchers.IO) {
+                    // Resolve the embedding model: prefer instance-level override, then AppConfig type-level default.
+                    fun resolveEmbeddingModel(p: ModelProvider): String {
+                        val instanceModel = editingInstance?.settings?.embeddingModel?.takeIf { it.isNotBlank() }
+                        return instanceModel ?: AppConfig.models[p].embeddingModel
+                    }
                     when (provider) {
-                        ModelProvider.OLLAMA -> LocalModelValidator.checkModelExists(provider, baseUrl, AppConfig.models[ModelProvider.OLLAMA].embeddingModel)
-                        ModelProvider.DOCKER -> LocalModelValidator.checkModelExists(provider, baseUrl, AppConfig.models[ModelProvider.DOCKER].embeddingModel)
-                        ModelProvider.LOCALAI -> LocalModelValidator.checkModelExists(provider, baseUrl, AppConfig.models[ModelProvider.LOCALAI].embeddingModel)
-                        ModelProvider.LMSTUDIO -> LocalModelValidator.checkModelExists(provider, baseUrl, AppConfig.models[ModelProvider.LMSTUDIO].embeddingModel)
+                        ModelProvider.OLLAMA -> LocalModelValidator.checkModelExists(provider, baseUrl, resolveEmbeddingModel(ModelProvider.OLLAMA))
+                        ModelProvider.DOCKER -> LocalModelValidator.checkModelExists(provider, baseUrl, resolveEmbeddingModel(ModelProvider.DOCKER))
+                        ModelProvider.LOCALAI -> LocalModelValidator.checkModelExists(provider, baseUrl, resolveEmbeddingModel(ModelProvider.LOCALAI))
+                        ModelProvider.LMSTUDIO -> LocalModelValidator.checkModelExists(provider, baseUrl, resolveEmbeddingModel(ModelProvider.LMSTUDIO))
                         ModelProvider.ANTHROPIC -> ModelAvailabilityResult.NotAvailable(reason = LocalizationManager.getString("settings.embedding.anthropic_no_embedding"), canAutoPull = false)
                         ModelProvider.XAI -> ModelAvailabilityResult.NotAvailable(reason = LocalizationManager.getString("settings.embedding.xai_no_embedding"), canAutoPull = false)
                         else -> ModelAvailabilityResult.Available

--- a/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
@@ -236,11 +236,14 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
 
     override fun createSecondaryModel(settings: T): ChatModel {
         val listener = createTelemetryListener()
+        val modelName = settings.utilityModel
+            .ifBlank { AppConfig.models[getProvider()].utilityModel }
+            .ifBlank { utilityModelFallback(settings) }
         return OpenAiResponsesChatModel.builder()
             .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener))
             .baseUrl(settings.baseUrl)
             .apiKey(resolveApiKey(settings))
-            .modelName(AppConfig.models[getProvider()].utilityModel.ifBlank { utilityModelFallback(settings) })
+            .modelName(modelName)
             .listeners(listOf(listener))
             .build()
     }
@@ -266,7 +269,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
     override fun createImageModel(settings: T): ImageModel = OpenAiImageModel.builder()
         .baseUrl(settings.baseUrl)
         .apiKey(resolveApiKey(settings))
-        .modelName(AppConfig.models[getProvider()].imageModel)
+        .modelName(settings.imageModel.ifBlank { AppConfig.models[getProvider()].imageModel })
         .logger(log)
         .logRequests(log.isDebugEnabled)
         .logResponses(log.isTraceEnabled)
@@ -280,7 +283,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
 
     override fun createEmbeddingModel(settings: T): EmbeddingModel {
         val baseUrl = settings.baseUrl.removeSuffix("/")
-        val modelName = AppConfig.models[getProvider()].embeddingModel
+        val modelName = settings.embeddingModel.ifBlank { AppConfig.models[getProvider()].embeddingModel }
         checkEmbeddingAvailability(baseUrl, modelName)
         return customizeEmbeddingBuilder(
             settings,
@@ -291,5 +294,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
         ).build()
     }
 
-    override fun getEmbeddingTokenLimit(settings: T): Int = LocalEmbeddingTokenLimits.resolve(AppConfig.models[getProvider()].embeddingModel)
+    override fun getEmbeddingTokenLimit(settings: T): Int = LocalEmbeddingTokenLimits.resolve(
+        settings.embeddingModel.ifBlank { AppConfig.models[getProvider()].embeddingModel },
+    )
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ProviderSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ProviderSettings.kt
@@ -40,6 +40,30 @@ import io.askimo.core.providers.xai.XAiSettings
 interface ProviderSettings {
     val defaultModel: String
 
+    /**
+     * Per-instance override for the utility/secondary model.
+     * Blank means "use the provider-type default from AppConfig.models".
+     */
+    val utilityModel: String get() = ""
+
+    /**
+     * Per-instance override for the vision model.
+     * Blank means "use the provider-type default from AppConfig.models".
+     */
+    val visionModel: String get() = ""
+
+    /**
+     * Per-instance override for the image-generation model.
+     * Blank means "use the provider-type default from AppConfig.models".
+     */
+    val imageModel: String get() = ""
+
+    /**
+     * Per-instance override for the embedding model.
+     * Blank means "use the provider-type default from AppConfig.models".
+     */
+    val embeddingModel: String get() = ""
+
     @JsonIgnore
     fun describe(): List<String>
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/SettingField.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/SettingField.kt
@@ -16,6 +16,10 @@ sealed class SettingField {
         const val API_KEY = "apiKey"
         const val BASE_URL = "baseUrl"
         const val DEFAULT_MODEL = "defaultModel"
+        const val UTILITY_MODEL = "utilityModel"
+        const val VISION_MODEL = "visionModel"
+        const val IMAGE_MODEL = "imageModel"
+        const val EMBEDDING_MODEL = "embeddingModel"
     }
 
     data class TextField(

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -188,7 +188,11 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         return AnthropicChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(AppConfig.models[ANTHROPIC].utilityModel.ifBlank { settings.defaultModel })
+            .modelName(
+                settings.utilityModel
+                    .ifBlank { AppConfig.models[ANTHROPIC].utilityModel }
+                    .ifBlank { settings.defaultModel },
+            )
             .baseUrl(settings.baseUrl)
             .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
             .build()

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicSettings.kt
@@ -13,6 +13,10 @@ data class AnthropicSettings(
     val baseUrl: String = "https://api.anthropic.com/v1",
     override var apiKey: String = "",
     override val defaultModel: String = "",
+    override val utilityModel: String = "",
+    override val visionModel: String = "",
+    override val imageModel: String = "",
+    override val embeddingModel: String = "",
 ) : ProviderSettings,
     HasApiKey {
     override fun describe(): List<String> = listOf(
@@ -42,6 +46,10 @@ data class AnthropicSettings(
         SettingField.API_KEY -> copy(apiKey = value)
         SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        SettingField.UTILITY_MODEL -> copy(utilityModel = value)
+        SettingField.VISION_MODEL -> copy(visionModel = value)
+        SettingField.IMAGE_MODEL -> copy(imageModel = value)
+        SettingField.EMBEDDING_MODEL -> copy(embeddingModel = value)
         else -> this
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -51,7 +51,11 @@ class DockerAiModelFactory : OpenAiCompatibleChatModelFactory<DockerAiSettings>(
         .httpClientBuilder(createHttpClientBuilder(settings.baseUrl))
         .baseUrl(settings.baseUrl)
         .apiKey(resolveApiKey(settings))
-        .modelName(AppConfig.models[getProvider()].utilityModel.ifBlank { utilityModelFallback(settings) })
+        .modelName(
+            settings.utilityModel
+                .ifBlank { AppConfig.models[getProvider()].utilityModel }
+                .ifBlank { utilityModelFallback(settings) },
+        )
         .logRequests(log.isDebugEnabled)
         .build()
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiSettings.kt
@@ -14,6 +14,10 @@ import kotlinx.serialization.Serializable
 data class DockerAiSettings(
     override var baseUrl: String = "http://localhost:12434/v1",
     override val defaultModel: String = "",
+    override val utilityModel: String = "",
+    override val visionModel: String = "",
+    override val imageModel: String = "",
+    override val embeddingModel: String = "",
 ) : ProviderSettings,
     HasBaseUrl {
     override fun describe(): List<String> = listOf(
@@ -32,6 +36,10 @@ data class DockerAiSettings(
     override fun updateField(fieldName: String, value: String): ProviderSettings = when (fieldName) {
         SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        SettingField.UTILITY_MODEL -> copy(utilityModel = value)
+        SettingField.VISION_MODEL -> copy(visionModel = value)
+        SettingField.IMAGE_MODEL -> copy(imageModel = value)
+        SettingField.EMBEDDING_MODEL -> copy(embeddingModel = value)
         else -> this
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -146,7 +146,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
     ): ImageModel = GoogleAiGeminiImageModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
         .baseUrl(settings.baseUrl)
-        .modelName(AppConfig.models[GEMINI].imageModel)
+        .modelName(settings.imageModel.ifBlank { AppConfig.models[GEMINI].imageModel })
         .logger(log)
         .logRequests(log.isDebugEnabled)
         .logResponses(log.isTraceEnabled)
@@ -192,7 +192,11 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
             .httpClientBuilder(jdkHttpClientBuilder)
             .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
             .apiKey(safeApiKey(settings.apiKey))
-            .modelName(AppConfig.models[GEMINI].utilityModel.ifBlank { settings.defaultModel })
+            .modelName(
+                settings.utilityModel
+                    .ifBlank { AppConfig.models[GEMINI].utilityModel }
+                    .ifBlank { settings.defaultModel },
+            )
             .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
             .build()
     }
@@ -219,11 +223,11 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
 
     override fun createEmbeddingModel(settings: GeminiSettings): EmbeddingModel = GoogleAiEmbeddingModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
-        .modelName(AppConfig.models[GEMINI].embeddingModel)
+        .modelName(settings.embeddingModel.ifBlank { AppConfig.models[GEMINI].embeddingModel })
         .build()
 
     override fun getEmbeddingTokenLimit(settings: GeminiSettings): Int {
-        val modelName = AppConfig.models[GEMINI].embeddingModel.lowercase()
+        val modelName = settings.embeddingModel.ifBlank { AppConfig.models[GEMINI].embeddingModel }.lowercase()
         return when {
             modelName.contains("embedding-001") -> 2048
             modelName.contains("text-embedding-004") -> 2048

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiSettings.kt
@@ -15,6 +15,10 @@ data class GeminiSettings(
     val baseUrl: String = "https://generativelanguage.googleapis.com/v1beta/openai",
     override var apiKey: String = "",
     override val defaultModel: String = "",
+    override val utilityModel: String = "",
+    override val visionModel: String = "",
+    override val imageModel: String = "",
+    override val embeddingModel: String = "",
 ) : ProviderSettings,
     HasApiKey {
     override fun describe(): List<String> = listOf(
@@ -44,6 +48,10 @@ data class GeminiSettings(
         SettingField.API_KEY -> copy(apiKey = value)
         SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        SettingField.UTILITY_MODEL -> copy(utilityModel = value)
+        SettingField.VISION_MODEL -> copy(visionModel = value)
+        SettingField.IMAGE_MODEL -> copy(imageModel = value)
+        SettingField.EMBEDDING_MODEL -> copy(embeddingModel = value)
         else -> this
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioSettings.kt
@@ -14,6 +14,10 @@ import kotlinx.serialization.Serializable
 data class LmStudioSettings(
     override var baseUrl: String = "http://localhost:1234/v1",
     override val defaultModel: String = "",
+    override val utilityModel: String = "",
+    override val visionModel: String = "",
+    override val imageModel: String = "",
+    override val embeddingModel: String = "",
 ) : ProviderSettings,
     HasBaseUrl {
     override fun describe(): List<String> = listOf(
@@ -32,6 +36,10 @@ data class LmStudioSettings(
     override fun updateField(fieldName: String, value: String): ProviderSettings = when (fieldName) {
         SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        SettingField.UTILITY_MODEL -> copy(utilityModel = value)
+        SettingField.VISION_MODEL -> copy(visionModel = value)
+        SettingField.IMAGE_MODEL -> copy(imageModel = value)
+        SettingField.EMBEDDING_MODEL -> copy(embeddingModel = value)
         else -> this
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/localai/LocalAiSettings.kt
@@ -14,6 +14,10 @@ import kotlinx.serialization.Serializable
 data class LocalAiSettings(
     override var baseUrl: String = "http://localhost:8080/v1",
     override val defaultModel: String = "",
+    override val utilityModel: String = "",
+    override val visionModel: String = "",
+    override val imageModel: String = "",
+    override val embeddingModel: String = "",
 ) : ProviderSettings,
     HasBaseUrl {
     override fun describe(): List<String> = listOf(
@@ -32,6 +36,10 @@ data class LocalAiSettings(
     override fun updateField(fieldName: String, value: String): ProviderSettings = when (fieldName) {
         SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        SettingField.UTILITY_MODEL -> copy(utilityModel = value)
+        SettingField.VISION_MODEL -> copy(visionModel = value)
+        SettingField.IMAGE_MODEL -> copy(imageModel = value)
+        SettingField.EMBEDDING_MODEL -> copy(embeddingModel = value)
         else -> this
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ollama/OllamaSettings.kt
@@ -14,6 +14,10 @@ import kotlinx.serialization.Serializable
 data class OllamaSettings(
     override var baseUrl: String = "http://localhost:11434/v1",
     override val defaultModel: String = "",
+    override val utilityModel: String = "",
+    override val visionModel: String = "",
+    override val imageModel: String = "",
+    override val embeddingModel: String = "",
 ) : ProviderSettings,
     HasBaseUrl {
     override fun describe(): List<String> = listOf(
@@ -32,6 +36,10 @@ data class OllamaSettings(
     override fun updateField(fieldName: String, value: String): ProviderSettings = when (fieldName) {
         SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        SettingField.UTILITY_MODEL -> copy(utilityModel = value)
+        SettingField.VISION_MODEL -> copy(visionModel = value)
+        SettingField.IMAGE_MODEL -> copy(imageModel = value)
+        SettingField.EMBEDDING_MODEL -> copy(embeddingModel = value)
         else -> this
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openai/OpenAiSettings.kt
@@ -14,6 +14,10 @@ data class OpenAiSettings(
     override var apiKey: String = "",
     override var baseUrl: String = DEFAULT_BASE_URL,
     override val defaultModel: String = "",
+    override val utilityModel: String = "",
+    override val visionModel: String = "",
+    override val imageModel: String = "",
+    override val embeddingModel: String = "",
 ) : ProviderSettings,
     HasApiKey,
     HasBaseUrl {
@@ -49,6 +53,10 @@ data class OpenAiSettings(
         SettingField.API_KEY -> copy(apiKey = value)
         SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        SettingField.UTILITY_MODEL -> copy(utilityModel = value)
+        SettingField.VISION_MODEL -> copy(visionModel = value)
+        SettingField.IMAGE_MODEL -> copy(imageModel = value)
+        SettingField.EMBEDDING_MODEL -> copy(embeddingModel = value)
         else -> this
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
@@ -17,6 +17,10 @@ data class OpenAiCompatibleSettings(
     override var apiKey: String = "",
     override var baseUrl: String = "http://localhost:8000/v1",
     override val defaultModel: String = "",
+    override val utilityModel: String = "",
+    override val visionModel: String = "",
+    override val imageModel: String = "",
+    override val embeddingModel: String = "",
 ) : ProviderSettings,
     HasApiKey,
     HasBaseUrl {
@@ -47,6 +51,10 @@ data class OpenAiCompatibleSettings(
         SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.API_KEY -> copy(apiKey = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        SettingField.UTILITY_MODEL -> copy(utilityModel = value)
+        SettingField.VISION_MODEL -> copy(visionModel = value)
+        SettingField.IMAGE_MODEL -> copy(imageModel = value)
+        SettingField.EMBEDDING_MODEL -> copy(embeddingModel = value)
         else -> this
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/xai/XAiSettings.kt
@@ -16,6 +16,10 @@ data class XAiSettings(
     override var baseUrl: String = "https://api.x.ai/v1",
     override var apiKey: String = "",
     override val defaultModel: String = "",
+    override val utilityModel: String = "",
+    override val visionModel: String = "",
+    override val imageModel: String = "",
+    override val embeddingModel: String = "",
 ) : ProviderSettings,
     HasApiKey,
     HasBaseUrl {
@@ -46,6 +50,10 @@ data class XAiSettings(
         SettingField.API_KEY -> copy(apiKey = value)
         SettingField.BASE_URL -> copy(baseUrl = value)
         SettingField.DEFAULT_MODEL -> copy(defaultModel = value)
+        SettingField.UTILITY_MODEL -> copy(utilityModel = value)
+        SettingField.VISION_MODEL -> copy(visionModel = value)
+        SettingField.IMAGE_MODEL -> copy(imageModel = value)
+        SettingField.EMBEDDING_MODEL -> copy(embeddingModel = value)
         else -> this
     }
 


### PR DESCRIPTION
- Allows setting custom utility, image, and embedding models for specific provider instances.
- Updates provider settings interfaces and concrete implementations to support granular model control.
- Improves flexibility in configuring AI provider setups.

Ref: https://github.com/askimo-ai/askimo/issues/546