### PR TITLE
fix(rag): explain missing embedding model setup

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/providers/EmbeddingModelConfigurationTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/EmbeddingModelConfigurationTest.kt
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.providers
+
+import io.askimo.core.providers.ollama.OllamaModelFactory
+import io.askimo.core.providers.ollama.OllamaSettings
+import io.askimo.test.extensions.AskimoTestHome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+@AskimoTestHome
+class EmbeddingModelConfigurationTest {
+
+    @Test
+    fun `missing embedding model explains how to configure one`() {
+        val exception = assertThrows<IllegalStateException> {
+            OllamaModelFactory().createEmbeddingModel(
+                OllamaSettings(
+                    baseUrl = "http://localhost:11434/v1",
+                    embeddingModel = "",
+                ),
+            )
+        }
+
+        assertEquals(
+            "No embedding model is configured for OLLAMA. " +
+                "Go to Settings > AI Provider and select an embedding model under the provider configuration card.",
+            exception.message,
+        )
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
@@ -284,6 +284,10 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
     override fun createEmbeddingModel(settings: T): EmbeddingModel {
         val baseUrl = settings.baseUrl.removeSuffix("/")
         val modelName = settings.embeddingModel.ifBlank { AppConfig.models[getProvider()].embeddingModel }
+        check(modelName.isNotBlank()) {
+            "No embedding model is configured for ${getProvider().name}. " +
+                "Go to Settings > AI Provider and select an embedding model under the provider configuration card."
+        }
         checkEmbeddingAvailability(baseUrl, modelName)
         return customizeEmbeddingBuilder(
             settings,


### PR DESCRIPTION
## Summary

- I added an explicit check for a missing embedding model before provider initialization.
- I replaced the low-level failure with guidance that points to the embedding-model setting.
- I added a regression test for the user-facing message.

## Validation

- `./gradlew --no-daemon :cli:test --tests 'io.askimo.core.providers.EmbeddingModelConfigurationTest'`
- `./gradlew --no-daemon spotlessCheck -PspotlessRatchetFrom=upstream/main`
- `git diff --check`

The full multi-module test matrix is deferred to CI.

Fixes #549
