### PR TITLE
Show a user-friendly error when no embedding model is configured

### DIFF
--- a/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
@@ -284,6 +284,10 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
     override fun createEmbeddingModel(settings: T): EmbeddingModel {
         val baseUrl = settings.baseUrl.removeSuffix("/")
         val modelName = settings.embeddingModel.ifBlank { AppConfig.models[getProvider()].embeddingModel }
+        check(modelName.isNotBlank()) {
+            "No embedding model is configured for ${getProvider().name}. " +
+                "Go to Settings > AI Provider and select an embedding model under the provider configuration card."
+        }
         checkEmbeddingAvailability(baseUrl, modelName)
         return customizeEmbeddingBuilder(
             settings,

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
@@ -34,11 +34,18 @@ class OpenAiCompatibleModelFactory : OpenAiCompatibleChatModelFactory<OpenAiComp
      * OpenAI-compatible servers can be remote — skip the local model availability check.
      * Also uses the settings API key (via [resolveApiKey]) for the embedding request itself.
      */
-    override fun createEmbeddingModel(settings: OpenAiCompatibleSettings): EmbeddingModel = OpenAiEmbeddingModelBuilder()
-        .baseUrl(settings.baseUrl)
-        .apiKey(resolveApiKey(settings))
-        .modelName(AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel)
-        .build()
+    override fun createEmbeddingModel(settings: OpenAiCompatibleSettings): EmbeddingModel {
+        val modelName = AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel
+        check(modelName.isNotBlank()) {
+            "No embedding model is configured for ${ModelProvider.OPENAI_COMPATIBLE.name}. " +
+                "Go to Settings > AI Provider and select an embedding model under the provider configuration card."
+        }
+        return OpenAiEmbeddingModelBuilder()
+            .baseUrl(settings.baseUrl)
+            .apiKey(resolveApiKey(settings))
+            .modelName(modelName)
+            .build()
+    }
 
     override fun getEmbeddingTokenLimit(settings: OpenAiCompatibleSettings): Int {
         val modelName = AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel.lowercase()


### PR DESCRIPTION
## Summary
Fixes #549

When a user opens a project with reference materials but has not configured an embedding model, indexing failed with the raw langchain4j builder error `modelName cannot be null or blank` in the "Failed to index knowledge source" dialog.

This adds a guard before building the embedding model, so the resolved-but-blank model name now surfaces as an actionable message, matching the existing wording style used in `ensureLocalEmbeddingModelAvailable`:

```
No embedding model is configured for <PROVIDER>. Go to Settings > AI Provider and select an embedding model under the provider configuration card.
```

Applied in the two paths where the resolved model name can be blank (provider setting and AppConfig default both empty):
- `OpenAiCompatibleChatModelFactory.createEmbeddingModel` (Ollama, Docker AI, LocalAI, LM Studio, etc.)
- `OpenAiCompatibleModelFactory.createEmbeddingModel` (generic OpenAI-compatible provider)

Ran `./gradlew spotlessApply detekt test` — all pass.