### PR TITLE
Fix stale MCP tools list after failed connection retest in Add/Edit Instance dialog

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/AddMcpInstanceDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/AddMcpInstanceDialog.kt
@@ -407,6 +407,8 @@ fun addMcpInstanceDialog(
             secondaryButton(
                 onClick = {
                     dialogState.clearError()
+                    testSuccess = null
+                    availableTools = emptyList()
                     isTesting = true
                     scope.launch {
                         try {
@@ -416,10 +418,12 @@ fun addMcpInstanceDialog(
                                 }
                                 .onFailure { e ->
                                     testSuccess = false
+                                    availableTools = emptyList()
                                     dialogState.setError(e, "Failed to connect to MCP server. Check your configuration.")
                                 }
                         } catch (e: Exception) {
                             testSuccess = false
+                            availableTools = emptyList()
                             dialogState.setError(e, "Connection test failed")
                         } finally {
                             isTesting = false
@@ -433,6 +437,8 @@ fun addMcpInstanceDialog(
             primaryButton(
                 onClick = {
                     dialogState.clearError()
+                    testSuccess = null
+                    availableTools = emptyList()
                     isTesting = true
                     scope.launch {
                         try {
@@ -447,10 +453,12 @@ fun addMcpInstanceDialog(
                                 }
                                 .onFailure { e ->
                                     testSuccess = false
+                                    availableTools = emptyList()
                                     dialogState.setError(e, "Failed to connect to MCP server. Check your configuration.")
                                 }
                         } catch (e: Exception) {
                             testSuccess = false
+                            availableTools = emptyList()
                             dialogState.setError(e, "Failed to save MCP instance")
                         } finally {
                             isTesting = false


### PR DESCRIPTION
When testing MCP connection settings in the Add/Edit Instance dialog, previously discovered tools could remain visible even after a later test failed due to invalid config changes.

Behavior after this change. The dialog now reflects the latest test result consistently:
* A failed connection test no longer leaves stale tools visible.
* Connection status is refreshed per test attempt, so users only see current results.