### PR TITLE
Show error message when batch context size is too small

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/GlobalErrorHandler.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/GlobalErrorHandler.kt
@@ -57,6 +57,21 @@ fun globalErrorHandler(onStateChange: (ErrorDialogState) -> Unit) {
                             )
                         }
 
+                        IndexingErrorType.EMBEDDING_INPUT_TOO_LARGE -> {
+                            val files = event.details["files"] ?: "unknown"
+                            onStateChange(
+                                ErrorDialogState(
+                                    show = true,
+                                    title = LocalizationManager.getString("error.indexing.input_too_large.title"),
+                                    message = LocalizationManager.getString(
+                                        "error.indexing.input_too_large.message",
+                                        files,
+                                    ),
+                                    details = event.details["message"],
+                                ),
+                            )
+                        }
+
                         IndexingErrorType.IO_ERROR -> {
                             onStateChange(
                                 ErrorDialogState(

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1091,6 +1091,8 @@ error.send_message.title=Failed to Send Message
 # Indexing Errors
 error.indexing.model_not_found.title=Embedding Model Not Found
 error.indexing.model_not_found.message=The embedding model ''{0}'' was not found. Please pull or enable this embedding model from {1} before indexing.
+error.indexing.input_too_large.title=Embedding Input Too Large
+error.indexing.input_too_large.message=The embedding model rejected one or more segments from [{0}] because the token count exceeds the model''s maximum context size. Reduce the chunk size in Settings → Indexing → Max chars per chunk, then re-index.
 error.indexing.io_error.title=IO Error
 error.indexing.io_error.message=An IO error occurred during indexing
 error.indexing.unknown.title=Indexing Error

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1080,6 +1080,8 @@ error.send_message.title=Nachricht konnte nicht gesendet werden
 # Indexing Errors
 error.indexing.model_not_found.title=Einbettungsmodell nicht gefunden
 error.indexing.model_not_found.message=Das Einbettungsmodell ''{0}'' wurde nicht gefunden. Bitte laden oder aktivieren Sie dieses Einbettungsmodell von {1}, bevor Sie mit der Indexierung beginnen.
+error.indexing.input_too_large.title=Embedding-Eingabe zu groß
+error.indexing.input_too_large.message=Das Embedding-Modell hat ein oder mehrere Segmente aus [{0}] abgelehnt, da die Token-Anzahl die maximale Kontextgröße des Modells überschreitet. Reduzieren Sie die Chunk-Größe unter Einstellungen → Indexierung → Max. Zeichen pro Chunk und führen Sie die Indizierung erneut aus.
 error.indexing.io_error.title=E/A-Fehler
 error.indexing.io_error.message=Während der Indexierung ist ein E/A-Fehler aufgetreten
 error.indexing.unknown.title=Indexierungsfehler

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1076,6 +1076,8 @@ error.send_message.title=No se pudo enviar el mensaje
 # Indexing Errors
 error.indexing.model_not_found.title=Modelo de incrustación no encontrado
 error.indexing.model_not_found.message=No se encontró el modelo de incrustación ''{0}''. Descarga o habilita este modelo desde {1} antes de iniciar la indexación.
+error.indexing.input_too_large.title=Entrada de embedding demasiado grande
+error.indexing.input_too_large.message=El modelo de embedding rechazó uno o más segmentos de [{0}] porque el recuento de tokens supera el tamaño máximo de contexto del modelo. Reduzca el tamaño del fragmento (chunk) en Ajustes → Indexación → Máx. caracteres por fragmento, luego vuelva a indexar.
 error.indexing.io_error.title=Error de E/S
 error.indexing.io_error.message=Se produjo un error de E/S durante la indexación
 error.indexing.unknown.title=Error de indexación

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1077,6 +1077,8 @@ error.send_message.title=Échec de l’envoi du message
 # Indexing Errors
 error.indexing.model_not_found.title=Modèle d’embedding introuvable
 error.indexing.model_not_found.message=Le modèle d’embedding ''{0}'' est introuvable. Veuillez télécharger ou activer ce modèle depuis {1} avant l’indexation.
+error.indexing.input_too_large.title=Entrée d'embedding trop grande
+error.indexing.input_too_large.message=Le modèle d'embedding a rejeté un ou plusieurs segments de [{0}] car le nombre de jetons dépasse la taille maximale de contexte du modèle. Réduisez la taille des segments dans Paramètres → Indexation → Max. caractères par segment, puis relancez l'indexation.
 error.indexing.io_error.title=Erreur d’E/S
 error.indexing.io_error.message=Une erreur d’E/S s’est produite lors de l’indexation
 error.indexing.unknown.title=Erreur d’indexation

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1078,6 +1078,8 @@ error.send_message.title=メッセージの送信に失敗しました
 # Indexing Errors
 error.indexing.model_not_found.title=埋め込みモデルが見つかりません
 error.indexing.model_not_found.message=埋め込みモデル ''{0}'' が見つかりません。インデックス作成の前に、{1} からこのモデルを取得または有効化してください。
+error.indexing.input_too_large.title=埋め込み入力が大きすぎます
+error.indexing.input_too_large.message=トークン数がモデルの最大コンテキストサイズを超えているため、埋め込みモデルが [{0}] からの1つ以上のセグメントを拒否しました。設定 → インデックス作成 → チャンクあたりの最大文字数でチャンクサイズを減らしてから、再インデックスしてください。
 error.indexing.io_error.title=IO エラー
 error.indexing.io_error.message=インデックス作成中に IO エラーが発生しました
 error.indexing.unknown.title=インデックスエラー

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1077,6 +1077,8 @@ error.send_message.title=메시지 전송 실패
 # Indexing Errors
 error.indexing.model_not_found.title=임베딩 모델을 찾을 수 없음
 error.indexing.model_not_found.message=임베딩 모델 ''{0}''을(를) 찾을 수 없습니다. 인덱싱 전에 {1}에서 해당 모델을 다운로드하거나 활성화하세요.
+error.indexing.input_too_large.title=임베딩 입력이 너무 큼
+error.indexing.input_too_large.message=토큰 수가 모델의 최대 컨텍스트 크기를 초과하여 임베딩 모델이 [{0}]의 하나 이상의 세그먼트를 거부했습니다. 설정 → 인덱싱 → 청크당 최대 문자 수에서 청크 크기를 줄인 후 다시 인덱싱하십시오.
 error.indexing.io_error.title=IO 오류
 error.indexing.io_error.message=인덱싱 중 IO 오류가 발생했습니다
 error.indexing.unknown.title=인덱싱 오류

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1080,6 +1080,8 @@ error.send_message.title=Falha ao enviar mensagem
 # Indexing Errors
 error.indexing.model_not_found.title=Modelo de embedding não encontrado
 error.indexing.model_not_found.message=O modelo de embedding ''{0}'' não foi encontrado. Baixe ou ative este modelo em {1} antes da indexação.
+error.indexing.input_too_large.title=Entrada de embedding muito grande
+error.indexing.input_too_large.message=O modelo de embedding rejeitou um ou mais segmentos de [{0}] porque a contagem de tokens excede o tamanho máximo de contexto do modelo. Reduza o tamanho do fragmento (chunk) em Configurações → Indexação → Máx. caracteres por fragmento e, em seguida, indexe novamente.
 error.indexing.io_error.title=Erro de IO
 error.indexing.io_error.message=Ocorreu um erro de IO durante a indexação
 error.indexing.unknown.title=Erro de indexação

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1076,6 +1076,8 @@ error.send_message.title=Gửi tin nhắn thất bại
 # Indexing Errors
 error.indexing.model_not_found.title=Không tìm thấy mô hình embedding
 error.indexing.model_not_found.message=Không tìm thấy mô hình embedding ''{0}''. Vui lòng tải hoặc bật mô hình này từ {1} trước khi lập chỉ mục.
+error.indexing.input_too_large.title=Dữ liệu đầu vào embedding quá lớn
+error.indexing.input_too_large.message=Mô hình embedding đã từ chối một hoặc nhiều phân đoạn từ [{0}] vì số lượng token vượt quá kích thước ngữ cảnh tối đa của mô hình. Hãy giảm kích thước đoạn (chunk) trong Cài đặt → Đánh chỉ mục → Số ký tự tối đa mỗi đoạn, sau đó thực hiện đánh chỉ mục lại.
 error.indexing.io_error.title=Lỗi IO
 error.indexing.io_error.message=Đã xảy ra lỗi IO trong quá trình lập chỉ mục
 error.indexing.unknown.title=Lỗi lập chỉ mục

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1078,6 +1078,8 @@ error.send_message.title=发送消息失败
 # Indexing Errors
 error.indexing.model_not_found.title=未找到嵌入模型
 error.indexing.model_not_found.message=未找到嵌入模型 ''{0}''。请在索引前从 {1} 下载或启用该模型。
+error.indexing.input_too_large.title=嵌入输入过大
+error.indexing.input_too_large.message=由于 token 计数超过了模型的最大上下文大小，嵌入模型拒绝了来自 [{0}] 的一个或多个片段。请在 设置 → 索引 → 每个分块的最大字符数 中减小分块大小，然后重新索引。
 error.indexing.io_error.title=IO 错误
 error.indexing.io_error.message=索引过程中发生 IO 错误
 error.indexing.unknown.title=索引错误

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1079,6 +1079,8 @@ error.send_message.title=傳送訊息失敗
 # Indexing Errors
 error.indexing.model_not_found.title=找不到嵌入模型
 error.indexing.model_not_found.message=找不到嵌入模型 ''{0}''。請在索引前從 {1} 下載或啟用此模型。
+error.indexing.input_too_large.title=嵌入輸入過大
+error.indexing.input_too_large.message=由於 token 計數超過了模型的最大上下文大小，嵌入模型拒絕了來自 [{0}] 的一個或多個片段。請在 設定 → 索引 → 每個分塊的最大字元數 中減小分塊大小，然後重新索引。
 error.indexing.io_error.title=IO 錯誤
 error.indexing.io_error.message=索引過程中發生 IO 錯誤
 error.indexing.unknown.title=索引錯誤

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -98,7 +98,6 @@ private class CommaSeparatedSetDeserializer : StdDeserializer<Set<String>>(Set::
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Set<String> = parseCommaSeparated(p).toSet()
 }
 
-// TODO: Remove @JsonAlias camelCase aliases in v1.2.30 — kept for backward compatibility with pre-snake_case config files
 data class IndexingConfig(
     val maxFileBytes: Long = 5_000_000,
     val concurrentIndexingThreads: Int = 3,

--- a/shared/src/main/kotlin/io/askimo/core/event/error/IndexingErrorEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/event/error/IndexingErrorEvent.kt
@@ -30,6 +30,17 @@ data class IndexingErrorEvent(
  */
 enum class IndexingErrorType {
     EMBEDDING_MODEL_NOT_FOUND,
+
+    /**
+     * The embedding server rejected a segment because its token count exceeds the
+     * model's configured physical batch size (e.g. "input (767 tokens) is too large
+     * to process. increase the physical batch size (current batch size: 512)").
+     *
+     * The [IndexingErrorEvent.details] map contains:
+     * - `"files"` – comma-separated list of affected file names
+     * - `"message"` – the raw server error message
+     */
+    EMBEDDING_INPUT_TOO_LARGE,
     IO_ERROR,
     UNKNOWN_ERROR,
 }

--- a/shared/src/main/kotlin/io/askimo/core/rag/indexing/HybridIndexer.kt
+++ b/shared/src/main/kotlin/io/askimo/core/rag/indexing/HybridIndexer.kt
@@ -12,6 +12,8 @@ import io.askimo.core.chat.repository.ResourceSegmentRepository
 import io.askimo.core.config.AppConfig
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
+import io.askimo.core.event.error.IndexingErrorEvent
+import io.askimo.core.event.error.IndexingErrorType
 import io.askimo.core.event.system.ShellErrorEvent
 import io.askimo.core.logging.logger
 import io.askimo.core.rag.LuceneIndexer
@@ -70,7 +72,7 @@ class HybridIndexer(
             }
         }
 
-        return if (snapshot != null) flushSnapshot(snapshot) else true
+        return snapshot == null || flushSnapshot(snapshot)
     }
 
     /**
@@ -190,6 +192,23 @@ class HybridIndexer(
             } else {
                 "${fileNames.take(3).joinToString()} and ${fileNames.size - 3} more"
             }
+
+            if (e.isInputTooLargeError()) {
+                // Surface as a prominent dialog (ERROR channel) so the user sees it
+                // immediately, not just as a passive notification-bell entry.
+                EventBus.emit(
+                    IndexingErrorEvent(
+                        projectId = projectId,
+                        errorType = IndexingErrorType.EMBEDDING_INPUT_TOO_LARGE,
+                        details = mapOf(
+                            "files" to displayNames,
+                            "message" to (e.message ?: ""),
+                        ),
+                    ),
+                )
+            }
+            // Always keep a ShellErrorEvent so the notification-bell retains history
+            // even after the dialog is dismissed.
             EventBus.emit(
                 ShellErrorEvent(
                     cause = e,
@@ -245,6 +264,23 @@ class HybridIndexer(
 
     private fun Exception.isForeignKeyViolation(): Boolean = message?.contains("SQLITE_CONSTRAINT_FOREIGNKEY") == true ||
         cause?.message?.contains("SQLITE_CONSTRAINT_FOREIGNKEY") == true
+
+    /**
+     * Returns true when the embedding server rejects a segment because its token count
+     * exceeds the model's physical batch/context size.
+     *
+     * Matches error messages like:
+     * - "input (767 tokens) is too large to process. increase the physical batch size (current batch size: 512)"
+     * - "input is too large" / "too many tokens"
+     */
+    private fun Exception.isInputTooLargeError(): Boolean {
+        val msg = message?.lowercase() ?: ""
+        val causeMsg = cause?.message?.lowercase() ?: ""
+        return (
+            msg.contains("too large") || msg.contains("too many tokens") ||
+                causeMsg.contains("too large") || causeMsg.contains("too many tokens")
+            )
+    }
 
     /**
      * Remove all segments for a file from both the embedding store, keyword index, and tracking database


### PR DESCRIPTION
Problem
When an embedding server rejects a segment because its token count exceeds the model's physical batch/context size (e.g. "input (767 tokens) is too large to process. increase the physical batch size (current batch size: 512)"), the error was only emitted as a ShellErrorEvent - which routes to the notification bell. Since the bell is a passive indicator, users had no idea why indexing silently stopped for affected files