### PR TITLE
feat(desktop): improve Mermaid CLI setup screen with one-click install, check-again, and collapsible source

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -30,6 +31,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Remove
@@ -42,6 +45,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -397,6 +401,15 @@ fun mermaidChart(
                 log.debug("Showing setup instructions (CLI not available)")
                 mermaidSetupInstructions(
                     diagram = data.diagram,
+                    mermaidService = mermaidService,
+                    onRecheck = {
+                        // Reset the cached availability and re-run the existing
+                        // LaunchedEffect so the CLI check happens again without a restart
+                        mermaidService.resetAvailabilityCache()
+                        isMermaidCliAvailable = null
+                        error = null
+                        manualRetryTrigger++
+                    },
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -516,14 +529,32 @@ fun mermaidChart(
 
 /**
  * Composable that displays setup instructions when Mermaid CLI is not available.
+ *
+ * Offers a one-click install (when npm is available), a "Check Again" button that
+ * re-runs the CLI availability check without restarting the app, and a collapsible
+ * view of the raw diagram source.
  */
 @Composable
 private fun mermaidSetupInstructions(
     diagram: String,
+    mermaidService: MermaidSvgService,
+    onRecheck: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val clipboardManager = LocalClipboardManager.current
     val setupLink = stringResource("mermaid.setup.instructions.link")
+    val coroutineScope = rememberCoroutineScope()
+
+    var isNpmAvailable by remember { mutableStateOf<Boolean?>(null) }
+    var isInstalling by remember { mutableStateOf(false) }
+    var installFailed by remember { mutableStateOf(false) }
+    var installLog by remember { mutableStateOf("") }
+    var showDiagramSource by remember { mutableStateOf(false) }
+
+    // Detect npm up front so the one-click install button is only offered when it can run
+    LaunchedEffect(Unit) {
+        isNpmAvailable = withContext(Dispatchers.IO) { mermaidService.isNpmAvailable() }
+    }
 
     Column(
         modifier = modifier
@@ -598,6 +629,54 @@ private fun mermaidSetupInstructions(
 
         Spacer(modifier = Modifier.height(Spacing.extraLarge))
 
+        // npm missing — point the user to Node.js first
+        if (isNpmAvailable == false) {
+            Text(
+                text = stringResource("mermaid.setup.node.required"),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(modifier = Modifier.height(Spacing.medium))
+        }
+
+        mermaidSetupActions(
+            isNpmAvailable = isNpmAvailable,
+            isInstalling = isInstalling,
+            onInstall = {
+                isInstalling = true
+                installFailed = false
+                installLog = ""
+                coroutineScope.launch {
+                    val success = mermaidService.installMermaidCli { line ->
+                        installLog += line + "\n"
+                    }
+                    isInstalling = false
+                    if (success) {
+                        // Re-check availability and proceed to render
+                        onRecheck()
+                    } else {
+                        installFailed = true
+                    }
+                }
+            },
+            onRecheck = onRecheck,
+        )
+
+        // Install progress spinner, failure message, and installer output
+        if (isInstalling || installFailed) {
+            Spacer(modifier = Modifier.height(Spacing.large))
+
+            mermaidInstallProgress(
+                isInstalling = isInstalling,
+                installFailed = installFailed,
+                installLog = installLog,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.extraLarge))
+
         Row(
             horizontalArrangement = Arrangement.spacedBy(Spacing.medium),
         ) {
@@ -626,27 +705,161 @@ private fun mermaidSetupInstructions(
 
         Spacer(modifier = Modifier.height(Spacing.extraLarge))
 
-        // Show raw diagram
-        Text(
-            text = stringResource("mermaid.diagram.source.label"),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        // Collapsible raw diagram source — useful but secondary, so hidden by default
+        TextButton(
+            onClick = { showDiagramSource = !showDiagramSource },
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) {
+            Icon(
+                imageVector = if (showDiagramSource) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(Spacing.small))
+            Text(
+                stringResource(
+                    if (showDiagramSource) "mermaid.diagram.source.hide" else "mermaid.diagram.source.show",
+                ),
+            )
+        }
 
-        Spacer(modifier = Modifier.height(Spacing.small))
+        if (showDiagramSource) {
+            Spacer(modifier = Modifier.height(Spacing.small))
 
-        Text(
-            text = diagram,
-            style = MaterialTheme.typography.bodySmall,
-            fontFamily = FontFamily.Monospace,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    MaterialTheme.colorScheme.surfaceVariant,
-                    shape = MaterialTheme.shapes.small,
+            Text(
+                text = diagram,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        MaterialTheme.colorScheme.surfaceVariant,
+                        shape = MaterialTheme.shapes.small,
+                    )
+                    .padding(Spacing.medium),
+            )
+        }
+    }
+}
+
+/**
+ * Action buttons for the Mermaid setup screen: one-click install (npm present),
+ * Node.js download (npm missing), and "Check Again" to re-run the CLI check.
+ */
+@Composable
+private fun mermaidSetupActions(
+    isNpmAvailable: Boolean?,
+    isInstalling: Boolean,
+    onInstall: () -> Unit,
+    onRecheck: () -> Unit,
+) {
+    val nodeDownloadLink = stringResource("mermaid.setup.node.link")
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(Spacing.medium),
+    ) {
+        if (isNpmAvailable == true) {
+            Button(
+                onClick = onInstall,
+                enabled = !isInstalling,
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) {
+                Icon(Icons.Default.Download, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(Spacing.small))
+                Text(stringResource("mermaid.setup.button.install"))
+            }
+        }
+
+        if (isNpmAvailable == false) {
+            Button(
+                onClick = {
+                    try {
+                        Desktop.getDesktop().browse(URI(nodeDownloadLink))
+                    } catch (_: Exception) {
+                        // Ignore browser open failures
+                    }
+                },
+                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            ) {
+                Text(stringResource("mermaid.setup.button.download.node"))
+            }
+        }
+
+        Button(
+            onClick = onRecheck,
+            enabled = !isInstalling,
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        ) {
+            Icon(Icons.Default.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(modifier = Modifier.width(Spacing.small))
+            Text(stringResource("mermaid.setup.button.check.again"))
+        }
+    }
+}
+
+/**
+ * Progress indicator and installer log output shown while (or after) installing
+ * Mermaid CLI from the setup screen.
+ */
+@Composable
+private fun mermaidInstallProgress(
+    isInstalling: Boolean,
+    installFailed: Boolean,
+    installLog: String,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (isInstalling) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
-                .padding(Spacing.medium),
-        )
+                Spacer(modifier = Modifier.width(Spacing.small))
+                Text(
+                    text = stringResource("mermaid.setup.installing"),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+
+        if (installFailed) {
+            Text(
+                text = stringResource("mermaid.setup.install.failed"),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+            )
+        }
+
+        if (installLog.isNotBlank()) {
+            Spacer(modifier = Modifier.height(Spacing.small))
+
+            val logScrollState = rememberScrollState()
+
+            // Keep the newest installer output visible
+            LaunchedEffect(installLog) {
+                logScrollState.scrollTo(logScrollState.maxValue)
+            }
+
+            Text(
+                text = installLog,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 160.dp)
+                    .background(
+                        MaterialTheme.colorScheme.surfaceVariant,
+                        shape = MaterialTheme.shapes.small,
+                    )
+                    .verticalScroll(logScrollState)
+                    .padding(Spacing.medium),
+            )
+        }
     }
 }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/service/MermaidSvgService.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/service/MermaidSvgService.kt
@@ -18,6 +18,9 @@ import java.util.concurrent.TimeUnit
  */
 class MermaidCliNotAvailableException(message: String) : Exception(message)
 
+/** Maximum time to wait for `npm install -g @mermaid-js/mermaid-cli` to finish. */
+private const val INSTALL_TIMEOUT_MINUTES = 10L
+
 /**
  * Service for converting Mermaid diagrams to SVG using local Mermaid CLI.
  *
@@ -109,6 +112,94 @@ class MermaidSvgService {
 
         cachedAvailability = result
         return result
+    }
+
+    /**
+     * Clears the cached CLI availability so the next call to [isMermaidCliAvailable]
+     * performs a fresh check. Used by the setup screen's "Check Again" flow and after
+     * an in-app installation completes.
+     */
+    fun resetAvailabilityCache() {
+        cachedAvailability = null
+    }
+
+    /**
+     * Checks if npm is available on the system. Not cached — the setup screen calls
+     * this once to decide whether the one-click install button can be offered.
+     *
+     * @return true if npm is installed and accessible
+     */
+    fun isNpmAvailable(): Boolean = try {
+        val process = ProcessBuilderExt("npm", "--version")
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText().trim()
+        val available = process.waitFor(10, TimeUnit.SECONDS) && process.exitValue() == 0
+        if (available) {
+            log.debug("npm found ({})", output)
+        } else {
+            log.warn("npm not found on PATH")
+        }
+        available
+    } catch (e: Exception) {
+        log.warn("npm availability check threw an exception: {}", e.message)
+        false
+    }
+
+    /**
+     * Installs Mermaid CLI globally by running `npm install -g @mermaid-js/mermaid-cli`,
+     * streaming the installer output line by line.
+     *
+     * On success the cached availability is reset so the next
+     * [isMermaidCliAvailable] call re-checks and finds the freshly installed CLI.
+     *
+     * @param onOutput Invoked for each line of installer output (stdout and stderr merged).
+     *                 May be called from a background thread.
+     * @return true if the installation completed successfully
+     */
+    suspend fun installMermaidCli(onOutput: (String) -> Unit): Boolean = withContext(Dispatchers.IO) {
+        try {
+            log.info("Installing Mermaid CLI: npm install -g @mermaid-js/mermaid-cli")
+            val process = ProcessBuilderExt("npm", "install", "-g", "@mermaid-js/mermaid-cli")
+                .redirectErrorStream(true)
+                .start()
+
+            // Read output in a separate thread so a hung installer cannot block us;
+            // destroying the process on timeout closes the stream and unblocks the reader
+            val outputReader = Thread {
+                try {
+                    process.inputStream.bufferedReader().useLines { lines ->
+                        lines.forEach { line -> onOutput(line) }
+                    }
+                } catch (e: Exception) {
+                    log.debug("Installer output stream closed: {}", e.message)
+                }
+            }
+            outputReader.start()
+
+            val completed = process.waitFor(INSTALL_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+            if (!completed) {
+                log.warn("Mermaid CLI installation timed out after {} minutes", INSTALL_TIMEOUT_MINUTES)
+                process.destroyForcibly()
+                outputReader.join(1_000)
+                onOutput("Installation timed out after $INSTALL_TIMEOUT_MINUTES minutes.")
+                return@withContext false
+            }
+            outputReader.join(1_000)
+
+            val success = process.exitValue() == 0
+            if (success) {
+                log.info("Mermaid CLI installed successfully")
+                resetAvailabilityCache()
+            } else {
+                log.warn("Mermaid CLI installation failed with exit code {}", process.exitValue())
+            }
+            success
+        } catch (e: Exception) {
+            log.warn("Mermaid CLI installation threw an exception: {}", e.message)
+            onOutput(e.message ?: "Unknown installation error")
+            false
+        }
     }
 
     /**

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1200,7 +1200,6 @@ mermaid.setup.instructions.text=To render Mermaid diagrams in Askimo, please fol
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=Open Setup Guide
 mermaid.setup.button.copy.diagram=Copy Diagram
-mermaid.diagram.source.label=Diagram Source:
 mermaid.rendering.progress=Rendering diagram...
 mermaid.error.rendering.title=Error rendering diagram
 mermaid.error.unexpected.state=Unexpected state. Please try again.
@@ -1213,6 +1212,15 @@ mermaid.button.zoom.out=Zoom Out
 mermaid.button.reset.zoom=Reset Zoom
 mermaid.button.retry=Retry
 mermaid.feedback.copied=Copied!
+mermaid.setup.button.install=Install Mermaid CLI
+mermaid.setup.button.check.again=Check Again
+mermaid.setup.button.download.node=Download Node.js
+mermaid.setup.installing=Installing Mermaid CLI...
+mermaid.setup.install.failed=Installation failed. Check the output below for details.
+mermaid.setup.node.required=Node.js and npm were not found. Install Node.js first to enable one-click install.
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=Show Diagram Source
+mermaid.diagram.source.hide=Hide Diagram Source
 
 
 # Reference Material

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1191,7 +1191,6 @@ mermaid.setup.instructions.text=Um Mermaid-Diagramme in Askimo darzustellen, fol
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=Einrichtungsanleitung öffnen
 mermaid.setup.button.copy.diagram=Diagramm kopieren
-mermaid.diagram.source.label=Diagrammquelle:
 mermaid.rendering.progress=Diagramm wird gerendert...
 mermaid.error.rendering.title=Fehler beim Rendern des Diagramms
 mermaid.error.unexpected.state=Unerwarteter Zustand. Bitte versuchen Sie es erneut.
@@ -1204,6 +1203,15 @@ mermaid.button.zoom.out=Verkleinern
 mermaid.button.reset.zoom=Zoom zurücksetzen
 mermaid.button.retry=Erneut versuchen
 mermaid.feedback.copied=Kopiert!
+mermaid.setup.button.install=Mermaid CLI installieren
+mermaid.setup.button.check.again=Erneut prüfen
+mermaid.setup.button.download.node=Node.js herunterladen
+mermaid.setup.installing=Mermaid CLI wird installiert...
+mermaid.setup.install.failed=Installation fehlgeschlagen. Details finden Sie in der Ausgabe unten.
+mermaid.setup.node.required=Node.js und npm wurden nicht gefunden. Installieren Sie zuerst Node.js, um die Ein-Klick-Installation zu aktivieren.
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=Diagrammquelle anzeigen
+mermaid.diagram.source.hide=Diagrammquelle ausblenden
 
 # Reference Material
 knowledge.source.type.folder=Ordner (auf Änderungen überwacht)

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1187,7 +1187,6 @@ mermaid.setup.instructions.text=Para renderizar diagramas Mermaid en Askimo, sig
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=Abrir guía de configuración
 mermaid.setup.button.copy.diagram=Copiar diagrama
-mermaid.diagram.source.label=Fuente del diagrama:
 mermaid.rendering.progress=Renderizando diagrama...
 mermaid.error.rendering.title=Error al renderizar el diagrama
 mermaid.error.unexpected.state=Estado inesperado. Por favor, inténtalo de nuevo.
@@ -1200,6 +1199,15 @@ mermaid.button.zoom.out=Alejar
 mermaid.button.reset.zoom=Restablecer zoom
 mermaid.button.retry=Reintentar
 mermaid.feedback.copied=¡Copiado!
+mermaid.setup.button.install=Instalar Mermaid CLI
+mermaid.setup.button.check.again=Comprobar de nuevo
+mermaid.setup.button.download.node=Descargar Node.js
+mermaid.setup.installing=Instalando Mermaid CLI...
+mermaid.setup.install.failed=La instalación falló. Consulte la salida a continuación para más detalles.
+mermaid.setup.node.required=No se encontraron Node.js ni npm. Instale Node.js primero para habilitar la instalación con un clic.
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=Mostrar código del diagrama
+mermaid.diagram.source.hide=Ocultar código del diagrama
 
 # Reference Material
 knowledge.source.type.folder=Carpeta (supervisada para cambios)

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1188,7 +1188,6 @@ mermaid.setup.instructions.text=Pour afficher des diagrammes Mermaid dans Askimo
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=Ouvrir le guide de configuration
 mermaid.setup.button.copy.diagram=Copier le diagramme
-mermaid.diagram.source.label=Source du diagramme :
 mermaid.rendering.progress=Rendu du diagramme en cours...
 mermaid.error.rendering.title=Erreur lors du rendu du diagramme
 mermaid.error.unexpected.state=État inattendu. Veuillez réessayer.
@@ -1201,6 +1200,15 @@ mermaid.button.zoom.out=Zoom arrière
 mermaid.button.reset.zoom=Réinitialiser le zoom
 mermaid.button.retry=Réessayer
 mermaid.feedback.copied=Copié !
+mermaid.setup.button.install=Installer Mermaid CLI
+mermaid.setup.button.check.again=Vérifier à nouveau
+mermaid.setup.button.download.node=Télécharger Node.js
+mermaid.setup.installing=Installation de Mermaid CLI...
+mermaid.setup.install.failed=L'installation a échoué. Consultez la sortie ci-dessous pour plus de détails.
+mermaid.setup.node.required=Node.js et npm sont introuvables. Installez d'abord Node.js pour activer l'installation en un clic.
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=Afficher la source du diagramme
+mermaid.diagram.source.hide=Masquer la source du diagramme
 
 # Reference Material
 knowledge.source.type.folder=Dossier (surveillé pour les modifications)

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1188,7 +1188,6 @@ mermaid.setup.instructions.text=Askimo で Mermaid 図をレンダリングす�
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=セットアップガイドを開く
 mermaid.setup.button.copy.diagram=図をコピー
-mermaid.diagram.source.label=図のソース：
 mermaid.rendering.progress=図をレンダリング中...
 mermaid.error.rendering.title=図のレンダリングエラー
 mermaid.error.unexpected.state=予期しない状態です。もう一度お試しください。
@@ -1201,6 +1200,15 @@ mermaid.button.zoom.out=ズームアウト
 mermaid.button.reset.zoom=ズームをリセット
 mermaid.button.retry=再試行
 mermaid.feedback.copied=コピーしました！
+mermaid.setup.button.install=Mermaid CLI をインストール
+mermaid.setup.button.check.again=再確認
+mermaid.setup.button.download.node=Node.js をダウンロード
+mermaid.setup.installing=Mermaid CLI をインストールしています...
+mermaid.setup.install.failed=インストールに失敗しました。詳細は以下の出力を確認してください。
+mermaid.setup.node.required=Node.js と npm が見つかりませんでした。ワンクリックインストールを有効にするには、先に Node.js をインストールしてください。
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=ダイアグラムのソースを表示
+mermaid.diagram.source.hide=ダイアグラムのソースを非表示
 
 # Reference Material
 knowledge.source.type.folder=フォルダー（変更を監視）

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1187,7 +1187,6 @@ mermaid.setup.instructions.text=Askimo에서 Mermaid 다이어그램을 렌더�
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=설정 가이드 열기
 mermaid.setup.button.copy.diagram=다이어그램 복사
-mermaid.diagram.source.label=다이어그램 소스:
 mermaid.rendering.progress=다이어그램 렌더링 중...
 mermaid.error.rendering.title=다이어그램 렌더링 오류
 mermaid.error.unexpected.state=예기치 않은 상태입니다. 다시 시도하세요.
@@ -1200,6 +1199,15 @@ mermaid.button.zoom.out=축소
 mermaid.button.reset.zoom=확대/축소 초기화
 mermaid.button.retry=다시 시도
 mermaid.feedback.copied=복사됨!
+mermaid.setup.button.install=Mermaid CLI 설치
+mermaid.setup.button.check.again=다시 확인
+mermaid.setup.button.download.node=Node.js 다운로드
+mermaid.setup.installing=Mermaid CLI 설치 중...
+mermaid.setup.install.failed=설치에 실패했습니다. 자세한 내용은 아래 출력을 확인하세요.
+mermaid.setup.node.required=Node.js와 npm을 찾을 수 없습니다. 원클릭 설치를 사용하려면 먼저 Node.js를 설치하세요.
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=다이어그램 소스 표시
+mermaid.diagram.source.hide=다이어그램 소스 숨기기
 
 # Reference Material
 knowledge.source.type.folder=폴더 (변경 사항 감시)

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1190,7 +1190,6 @@ mermaid.setup.instructions.text=Para renderizar diagramas Mermaid no Askimo, sig
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=Abrir guia de configuração
 mermaid.setup.button.copy.diagram=Copiar diagrama
-mermaid.diagram.source.label=Fonte do diagrama:
 mermaid.rendering.progress=Renderizando diagrama...
 mermaid.error.rendering.title=Erro ao renderizar o diagrama
 mermaid.error.unexpected.state=Estado inesperado. Tente novamente.
@@ -1203,6 +1202,15 @@ mermaid.button.zoom.out=Diminuir zoom
 mermaid.button.reset.zoom=Redefinir zoom
 mermaid.button.retry=Tentar novamente
 mermaid.feedback.copied=Copiado!
+mermaid.setup.button.install=Instalar Mermaid CLI
+mermaid.setup.button.check.again=Verificar novamente
+mermaid.setup.button.download.node=Baixar Node.js
+mermaid.setup.installing=Instalando Mermaid CLI...
+mermaid.setup.install.failed=A instalação falhou. Verifique a saída abaixo para mais detalhes.
+mermaid.setup.node.required=Node.js e npm não foram encontrados. Instale o Node.js primeiro para habilitar a instalação com um clique.
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=Mostrar código do diagrama
+mermaid.diagram.source.hide=Ocultar código do diagrama
 
 # Reference Material
 knowledge.source.type.folder=Pasta (monitorada para alterações)

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1187,7 +1187,6 @@ mermaid.setup.instructions.text=Để hiển thị sơ đồ Mermaid trong Askim
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=Mở hướng dẫn cài đặt
 mermaid.setup.button.copy.diagram=Sao chép sơ đồ
-mermaid.diagram.source.label=Nguồn sơ đồ:
 mermaid.rendering.progress=Đang hiển thị sơ đồ...
 mermaid.error.rendering.title=Lỗi hiển thị sơ đồ
 mermaid.error.unexpected.state=Trạng thái không mong đợi. Vui lòng thử lại.
@@ -1200,6 +1199,15 @@ mermaid.button.zoom.out=Thu nhỏ
 mermaid.button.reset.zoom=Đặt lại thu phóng
 mermaid.button.retry=Thử lại
 mermaid.feedback.copied=Đã sao chép!
+mermaid.setup.button.install=Cài đặt Mermaid CLI
+mermaid.setup.button.check.again=Kiểm tra lại
+mermaid.setup.button.download.node=Tải xuống Node.js
+mermaid.setup.installing=Đang cài đặt Mermaid CLI...
+mermaid.setup.install.failed=Cài đặt thất bại. Xem chi tiết trong phần kết quả bên dưới.
+mermaid.setup.node.required=Không tìm thấy Node.js và npm. Vui lòng cài đặt Node.js trước để bật tính năng cài đặt một cú nhấp.
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=Hiện mã nguồn sơ đồ
+mermaid.diagram.source.hide=Ẩn mã nguồn sơ đồ
 
 # Reference Material
 knowledge.source.type.folder=Thư mục (theo dõi thay đổi)

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1189,7 +1189,6 @@ mermaid.setup.instructions.text=要在 Askimo 中渲染 Mermaid 图表，请按�
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=打开安装指南
 mermaid.setup.button.copy.diagram=复制图表
-mermaid.diagram.source.label=图表来源：
 mermaid.rendering.progress=正在渲染图表...
 mermaid.error.rendering.title=渲染图表时出错
 mermaid.error.unexpected.state=出现意外状态。请重试。
@@ -1202,6 +1201,15 @@ mermaid.button.zoom.out=缩小
 mermaid.button.reset.zoom=重置缩放
 mermaid.button.retry=重试
 mermaid.feedback.copied=已复制！
+mermaid.setup.button.install=安装 Mermaid CLI
+mermaid.setup.button.check.again=重新检查
+mermaid.setup.button.download.node=下载 Node.js
+mermaid.setup.installing=正在安装 Mermaid CLI...
+mermaid.setup.install.failed=安装失败。请查看下方输出了解详情。
+mermaid.setup.node.required=未找到 Node.js 和 npm。请先安装 Node.js 以启用一键安装。
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=显示图表源码
+mermaid.diagram.source.hide=隐藏图表源码
 
 # Reference Material
 knowledge.source.type.folder=文件夹（监控更改）

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1190,7 +1190,6 @@ mermaid.setup.instructions.text=要在 Askimo 中渲染 Mermaid 圖表，請依�
 mermaid.setup.instructions.link=https://askimo.chat/docs/desktop/mermaid-diagrams/
 mermaid.setup.button.open.guide=開啟安裝指南
 mermaid.setup.button.copy.diagram=複製圖表
-mermaid.diagram.source.label=圖表來源：
 mermaid.rendering.progress=正在渲染圖表...
 mermaid.error.rendering.title=渲染圖表時發生錯誤
 mermaid.error.unexpected.state=發生未預期的狀態。請再試一次。
@@ -1203,6 +1202,15 @@ mermaid.button.zoom.out=縮小
 mermaid.button.reset.zoom=重設縮放
 mermaid.button.retry=重試
 mermaid.feedback.copied=已複製！
+mermaid.setup.button.install=安裝 Mermaid CLI
+mermaid.setup.button.check.again=重新檢查
+mermaid.setup.button.download.node=下載 Node.js
+mermaid.setup.installing=正在安裝 Mermaid CLI...
+mermaid.setup.install.failed=安裝失敗。請查看下方輸出以瞭解詳情。
+mermaid.setup.node.required=找不到 Node.js 和 npm。請先安裝 Node.js 以啟用一鍵安裝。
+mermaid.setup.node.link=https://nodejs.org/en/download
+mermaid.diagram.source.show=顯示圖表原始碼
+mermaid.diagram.source.hide=隱藏圖表原始碼
 
 # Reference Material
 knowledge.source.type.folder=資料夾（監控變更）


### PR DESCRIPTION
## What changed

When Mermaid CLI is not detected, the setup screen previously only showed static instructions and required installing externally plus an app restart. This PR makes that flow self-service:

- **One-click install** — an "Install Mermaid CLI" button (shown when npm is detected) runs `npm install -g @mermaid-js/mermaid-cli` in the background via `ProcessBuilderExt`, with a progress spinner and a scrollable, auto-following installer output area. On success the CLI availability check re-runs automatically and the diagram proceeds to render. On failure the npm output stays visible so the user can see what went wrong.
- **Check Again** — a button that resets the cached availability (`MermaidSvgService.resetAvailabilityCache()`), sets `isMermaidCliAvailable` back to `null`, and re-triggers the existing `LaunchedEffect`, so users who installed the CLI externally no longer need to restart the app.
- **Node.js detection** — the screen checks `npm` availability up front (`MermaidSvgService.isNpmAvailable()`). If npm is missing, the install button is replaced by a "Download Node.js" button plus a hint, so the primary CTA is always actionable.
- **Collapsible diagram source** — the raw diagram code is now behind a Show/Hide Diagram Source toggle, hidden by default, so the setup screen is less noisy.

Service changes live in `MermaidSvgService` (`isNpmAvailable()`, `installMermaidCli()` with a 10-minute timeout and threaded output reader matching the existing `isMermaidCliAvailable()` pattern, and `resetAvailabilityCache()`). New UI strings were added to `messages.properties` and all nine locale files; the now-unused `mermaid.diagram.source.label` key was removed.

## How to test

1. Ensure `mmdc` is not installed (`npm uninstall -g @mermaid-js/mermaid-cli`) and ask Askimo for a Mermaid diagram — the setup screen appears with the install and Check Again buttons.
2. Click "Install Mermaid CLI" — installer output streams into the log area; when it finishes the availability check re-runs and the diagram renders without a restart.
3. Alternatively install the CLI in a terminal, then click "Check Again" — the diagram renders without a restart.
4. With Node/npm absent from PATH, the screen shows the "install Node.js first" hint and a "Download Node.js" button instead of the install button.
5. "Show Diagram Source" toggles the raw diagram code, which is hidden by default.

## Verification

Using Temurin JDK 25, as required by the Gradle toolchain:

- `./gradlew :desktop-shared:build` (includes tests)
- `./gradlew :desktop-shared:spotlessCheck`
- `./gradlew detekt` (aggregate gate: 0 errors)

All tasks completed successfully.

Closes #562
