### PR TITLE
feat(auto-refresh-session-title): add flag to suppress auto title refresh when renamed

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
@@ -8,6 +8,9 @@ import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.ChatMessage
 import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.request.ChatRequest
+import dev.langchain4j.model.chat.response.ChatResponse
 import io.askimo.core.chat.domain.SessionMemory
 import io.askimo.core.chat.repository.SessionMemoryRepository
 import io.askimo.core.config.AppConfig
@@ -50,20 +53,26 @@ class TokenAwareSummarizingMemoryTest {
 
     private lateinit var mockAppContext: AppContext
     private lateinit var mockChatClient: ChatClient
+    private lateinit var mockSecondaryModel: ChatModel
     private lateinit var mockRepository: SessionMemoryRepository
     private lateinit var mockParams: io.askimo.core.context.AppContextParams
     private lateinit var memory: TokenAwareSummarizingMemory
 
     private val sessionId = "test-session-123"
 
+    /** Builds a [ChatResponse] whose AI message contains [jsonText]. */
+    private fun chatResponseOf(jsonText: String): ChatResponse = ChatResponse.builder().aiMessage(AiMessage.from(jsonText)).build()
+
     @BeforeEach
     fun setup() {
         mockAppContext = mock()
         mockChatClient = mock()
+        mockSecondaryModel = mock()
         mockRepository = mock()
         mockParams = mock()
 
         whenever(mockAppContext.createUtilityClient()).thenReturn(mockChatClient)
+        whenever(mockAppContext.createSecondaryModel()).thenReturn(mockSecondaryModel)
         whenever(mockAppContext.getActiveProvider()).thenReturn(io.askimo.core.providers.ModelProvider.OPENAI)
         whenever(mockAppContext.params).thenReturn(mockParams)
         whenever(mockParams.model).thenReturn("gpt-4")
@@ -135,8 +144,8 @@ class TokenAwareSummarizingMemoryTest {
     fun `should trigger summarization above threshold`() {
         memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false)
 
-        whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """{"keyFacts":{"topic":"testing"},"mainTopics":["memory"],"recentContext":"test"}""",
+        whenever(mockSecondaryModel.chat(any<ChatRequest>())).thenReturn(
+            chatResponseOf("""{"keyFacts":{"topic":"testing"},"mainTopics":["memory"],"recentContext":"test"}"""),
         )
 
         repeat(100) { i ->
@@ -147,7 +156,7 @@ class TokenAwareSummarizingMemoryTest {
         Thread.sleep(2000)
         memory.close()
 
-        verify(mockChatClient, atLeastOnce()).sendMessage(any())
+        verify(mockSecondaryModel, atLeastOnce()).chat(any<ChatRequest>())
     }
 
     // ── Protected recent turns ───────────────────────────────────────────────
@@ -216,8 +225,8 @@ class TokenAwareSummarizingMemoryTest {
         memory.importState(TokenAwareSummarizingMemory.MemoryState(messages = emptyList(), summary = initialSummary))
 
         // Simulate a new summarization that adds 5 more facts (should evict oldest)
-        whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """{"keyFacts":{"fact31":"v31","fact32":"v32","fact33":"v33","fact34":"v34","fact35":"v35"},"mainTopics":[],"recentContext":"new"}""",
+        whenever(mockSecondaryModel.chat(any<ChatRequest>())).thenReturn(
+            chatResponseOf("""{"keyFacts":{"fact31":"v31","fact32":"v32","fact33":"v33","fact34":"v34","fact35":"v35"},"mainTopics":[],"recentContext":"new"}"""),
         )
 
         repeat(50) { i -> memory.add(UserMessage.from("msg $i " + "word ".repeat(30))) }
@@ -246,8 +255,8 @@ class TokenAwareSummarizingMemoryTest {
         memory.importState(TokenAwareSummarizingMemory.MemoryState(messages = emptyList(), summary = initialSummary))
 
         // Simulate a new cycle that updates fact1 (refreshes it) and adds 5 new facts
-        whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """{"keyFacts":{"fact1":"updated","fact31":"v31","fact32":"v32","fact33":"v33","fact34":"v34","fact35":"v35"},"mainTopics":[],"recentContext":"ctx"}""",
+        whenever(mockSecondaryModel.chat(any<ChatRequest>())).thenReturn(
+            chatResponseOf("""{"keyFacts":{"fact1":"updated","fact31":"v31","fact32":"v32","fact33":"v33","fact34":"v34","fact35":"v35"},"mainTopics":[],"recentContext":"ctx"}"""),
         )
 
         repeat(50) { i -> memory.add(UserMessage.from("msg $i " + "word ".repeat(30))) }
@@ -274,8 +283,8 @@ class TokenAwareSummarizingMemoryTest {
         memory.importState(TokenAwareSummarizingMemory.MemoryState(messages = emptyList(), summary = initialSummary))
 
         // New cycle adds 5 more distinct topics
-        whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """{"keyFacts":{},"mainTopics":["topic16","topic17","topic18","topic19","topic20"],"recentContext":"ctx"}""",
+        whenever(mockSecondaryModel.chat(any<ChatRequest>())).thenReturn(
+            chatResponseOf("""{"keyFacts":{},"mainTopics":["topic16","topic17","topic18","topic19","topic20"],"recentContext":"ctx"}"""),
         )
 
         repeat(50) { i -> memory.add(UserMessage.from("msg $i " + "word ".repeat(30))) }
@@ -298,14 +307,14 @@ class TokenAwareSummarizingMemoryTest {
     fun `should merge summaries when multiple summarizations occur`() {
         memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false)
 
-        whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """{"keyFacts":{"fact1":"value1"},"mainTopics":["topic1"],"recentContext":"First context"}""",
+        whenever(mockSecondaryModel.chat(any<ChatRequest>())).thenReturn(
+            chatResponseOf("""{"keyFacts":{"fact1":"value1"},"mainTopics":["topic1"],"recentContext":"First context"}"""),
         )
         repeat(100) { i -> memory.add(UserMessage.from("Batch 1 msg $i " + "word ".repeat(30))) }
         Thread.sleep(2000)
 
-        whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """{"keyFacts":{"fact2":"value2"},"mainTopics":["topic2"],"recentContext":"Second context"}""",
+        whenever(mockSecondaryModel.chat(any<ChatRequest>())).thenReturn(
+            chatResponseOf("""{"keyFacts":{"fact2":"value2"},"mainTopics":["topic2"],"recentContext":"Second context"}"""),
         )
         repeat(100) { i -> memory.add(UserMessage.from("Batch 2 msg $i " + "word ".repeat(30))) }
         Thread.sleep(2000)
@@ -325,8 +334,8 @@ class TokenAwareSummarizingMemoryTest {
     fun `should preserve system messages during summarization`() {
         memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false)
 
-        whenever(mockChatClient.sendMessage(any())).thenReturn(
-            """{"keyFacts":{},"mainTopics":[],"recentContext":"test"}""",
+        whenever(mockSecondaryModel.chat(any<ChatRequest>())).thenReturn(
+            chatResponseOf("""{"keyFacts":{},"mainTopics":[],"recentContext":"test"}"""),
         )
 
         memory.add(SystemMessage.from("You are a helpful assistant"))
@@ -439,7 +448,7 @@ class TokenAwareSummarizingMemoryTest {
     @Test
     fun `should handle summarization failure gracefully with fallback`() {
         memory = createMemory(summarizationThreshold = 0.01, asyncSummarization = false)
-        whenever(mockChatClient.sendMessage(any())).thenThrow(RuntimeException("API Error"))
+        whenever(mockSecondaryModel.chat(any<ChatRequest>())).thenThrow(RuntimeException("API Error"))
 
         repeat(100) { i -> memory.add(UserMessage.from("Message $i " + "word ".repeat(30))) }
 

--- a/shared/src/main/kotlin/io/askimo/core/chat/domain/ChatSession.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/domain/ChatSession.kt
@@ -17,6 +17,8 @@ data class ChatSession(
     val projectId: String? = null, // null = no project (general chat)
     val directiveId: String? = null,
     val isStarred: Boolean = false,
+    /** True when the user has manually renamed this session — suppresses auto title-refresh. */
+    val isUserRenamed: Boolean = false,
 )
 
 const val SESSION_TITLE_MAX_LENGTH = 256
@@ -35,6 +37,9 @@ object ChatSessionsTable : Table("chat_sessions") {
 
     val directiveId = varchar("directive_id", 36).nullable()
     val isStarred = integer("is_starred").default(0)
+
+    /** 1 = user manually renamed; auto title-refresh is suppressed. */
+    val isUserRenamed = integer("is_user_renamed").default(0)
 
     val syncedAt = varchar("synced_at", 32).nullable()
 

--- a/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatSessionRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatSessionRepository.kt
@@ -44,6 +44,7 @@ private fun ResultRow.toChatSession(): ChatSession = ChatSession(
     projectId = this[ChatSessionsTable.projectId],
     directiveId = this[ChatSessionsTable.directiveId],
     isStarred = this[ChatSessionsTable.isStarred] == 1,
+    isUserRenamed = this[ChatSessionsTable.isUserRenamed] == 1,
 )
 
 /**
@@ -315,6 +316,18 @@ class ChatSessionRepository internal constructor(
                 it[updatedAt] = Instant.now()
             } > 0
         }.also { if (it) EventBus.post(PushDataToServerEvent(reason = "session title updated")) }
+    }
+
+    /**
+     * Mark a session as user-renamed, suppressing future auto title-refresh from summarization.
+     *
+     * @param sessionId The ID of the session
+     * @return true if the session was updated
+     */
+    fun markAsUserRenamed(sessionId: String): Boolean = transaction(database) {
+        ChatSessionsTable.update({ ChatSessionsTable.id eq sessionId }) {
+            it[isUserRenamed] = 1
+        } > 0
     }
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -199,6 +199,7 @@ class ChatSessionService(
             sessionMemoryRepository = sessionMemoryRepository,
             userMemoryRepository = DatabaseManager.getInstance().getUserMemoryRepository(),
             summarizationTimeoutSeconds = AppConfig.chat.summarizationTimeoutSeconds,
+            onTitleSuggested = { candidate -> handleTitleSuggestion(sessionId, candidate) },
         )
     }
 
@@ -497,12 +498,19 @@ class ChatSessionService(
 
     /**
      * Rename the title of a chat session.
+     * Marks the session as user-renamed so automatic title refresh is suppressed going forward.
      *
      * @param sessionId The ID of the session to rename
      * @param newTitle The new title for the session
      * @return true if the session was renamed, false if it didn't exist or the title is invalid
      */
-    fun renameTitle(sessionId: String, newTitle: String): Boolean = sessionRepository.updateSessionTitle(sessionId, newTitle)
+    fun renameTitle(sessionId: String, newTitle: String): Boolean {
+        val renamed = sessionRepository.updateSessionTitle(sessionId, newTitle)
+        if (renamed) {
+            sessionRepository.markAsUserRenamed(sessionId)
+        }
+        return renamed
+    }
 
     /**
      * Update the directive for a chat session.
@@ -512,6 +520,80 @@ class ChatSessionService(
      * @return true if the session was updated, false if it didn't exist
      */
     fun updateSessionDirective(sessionId: String, directiveId: String?): Boolean = sessionRepository.updateSessionDirective(sessionId, directiveId)
+
+    /**
+     * Called from the summarization background thread each time a new structured summary
+     * is produced. Applies the suggested title if all guards pass:
+     *
+     * 1. The user has not manually renamed the session ([ChatSession.isUserRenamed] == false).
+     * 2. The candidate differs from the current title by more than 20 % Levenshtein distance
+     *    (avoids flickering on minor rewordings).
+     *
+     * No message-count guard needed — [TokenAwareSummarizingMemory.onTitleSuggested] only fires
+     * after structured summarization, which itself requires the token threshold to be exceeded
+     * (i.e. a sufficiently long conversation).
+     */
+    private fun handleTitleSuggestion(sessionId: String, candidate: String) {
+        val trimmed = candidate.trim().take(256)
+        if (trimmed.isBlank()) return
+
+        try {
+            val session = sessionRepository.getSession(sessionId) ?: return
+
+            // Guard 1 — suppress for user-renamed sessions
+            if (session.isUserRenamed) {
+                log.debug("Skipping title refresh for session {} — user has manually renamed it", sessionId)
+                return
+            }
+
+            // Guard 2 — candidate must differ meaningfully from current title
+            val currentTitle = session.title
+            val distance = levenshteinDistance(currentTitle, trimmed)
+            val threshold = (currentTitle.length * 0.20).toInt().coerceAtLeast(3)
+            if (distance <= threshold) {
+                log.debug("Skipping title refresh for session {} — Levenshtein distance {} <= threshold {}", sessionId, distance, threshold)
+                return
+            }
+
+            // All guards passed — apply the new title
+            sessionRepository.updateSessionTitle(sessionId, trimmed)
+            log.info("Auto-refreshed title for session {}: '{}' → '{}'", sessionId, currentTitle, trimmed)
+
+            eventScope.launch {
+                EventBus.emit(
+                    SessionTitleUpdatedEvent(
+                        sessionId = sessionId,
+                        newTitle = trimmed,
+                    ),
+                )
+            }
+        } catch (e: Exception) {
+            log.warn("handleTitleSuggestion failed for session {}: {}", sessionId, e.message)
+        }
+    }
+
+    /**
+     * Computes the Levenshtein edit distance between two strings.
+     * Used by [handleTitleSuggestion] to decide whether a title candidate differs
+     * enough from the current title to justify an update.
+     */
+    private fun levenshteinDistance(s1: String, s2: String): Int {
+        val m = s1.length
+        val n = s2.length
+        val dp = Array(m + 1) { IntArray(n + 1) }
+        for (i in 0..m) dp[i][0] = i
+        for (j in 0..n) dp[0][j] = j
+        for (i in 1..m) {
+            for (j in 1..n) {
+                dp[i][j] = if (s1[i - 1] == s2[j - 1]) {
+                    dp[i - 1][j - 1]
+                } else {
+                    minOf(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1]) + 1
+                }
+            }
+        }
+        return dp[m][n]
+    }
 
     /**
      * Add a message to a session and update the session's timestamp.

--- a/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
+++ b/shared/src/main/kotlin/io/askimo/core/context/AppContext.kt
@@ -131,6 +131,9 @@ class AppContext private constructor(
     @Volatile
     private var cachedUtilityClient: ChatClient? = null
 
+    @Volatile
+    private var cachedSecondaryModel: ChatModel? = null
+
     private var cachedImageModel: ImageModel? = null
     private var cachedEmbeddingModel: EmbeddingModel? = null
 
@@ -161,6 +164,7 @@ class AppContext private constructor(
         log.info("Model changed to ${event.newModel} for instance ${event.instanceId} (${event.provider}), clearing cached utility client")
         synchronized(this) {
             cachedUtilityClient = null
+            cachedSecondaryModel = null
             cachedImageModel = null
             cachedEmbeddingModel = null
         }
@@ -331,6 +335,37 @@ class AppContext private constructor(
             cachedUtilityClient = client
             log.debug("Created and cached utility client for provider {} with model {}", instance.providerType, params.model)
             return client
+        }
+    }
+
+    /**
+     * Creates (or returns the cached) secondary [ChatModel] for the active provider.
+     *
+     * The secondary model is the cheap, non-streaming model used for utility tasks
+     * such as conversation summarization. It supports [ResponseFormat] / JSON-schema
+     * structured output on all providers that declare [Capability.RESPONSE_FORMAT_JSON_SCHEMA].
+     *
+     * The returned instance is cached and invalidated on model/provider change.
+     *
+     * @return ChatModel configured with the provider's utility/cheap model
+     */
+    fun createSecondaryModel(): ChatModel {
+        cachedSecondaryModel?.let { return it }
+
+        synchronized(this) {
+            cachedSecondaryModel?.let { return it }
+
+            val instance = requireActiveInstance()
+            val factory = getModelFactory(instance.providerType)
+
+            @Suppress("UNCHECKED_CAST")
+            val model = (factory as ChatModelFactory<ProviderSettings>).createSecondaryModel(
+                settings = instance.settings,
+            )
+
+            cachedSecondaryModel = model
+            log.debug("Created and cached secondary model for provider {}", instance.providerType)
+            return model
         }
     }
 

--- a/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
@@ -262,6 +262,16 @@ class DatabaseManager private constructor(
                 // Column already exists — safe to ignore.
             }
 
+            // Migration: Add is_user_renamed column — tracks whether the user manually renamed
+            // the session. When 1, automatic title refresh from summarization is suppressed.
+            try {
+                stmt.executeUpdate(
+                    "ALTER TABLE chat_sessions ADD COLUMN is_user_renamed INTEGER DEFAULT 0",
+                )
+            } catch (_: Exception) {
+                // Column already exists — safe to ignore.
+            }
+
             try {
                 stmt.executeUpdate(
                     "ALTER TABLE chat_sessions DROP COLUMN sort_order",

--- a/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
@@ -151,6 +151,15 @@ class TokenAwareSummarizingMemory(
     private val tokenEstimator: (ChatMessage) -> Int = defaultTokenEstimator(),
     asyncSummarization: Boolean = true,
     private val summarizationTimeoutSeconds: Long = 300,
+    /**
+     * Optional callback invoked after each successful structured summarization cycle
+     * with a suggested title derived from the new summary. The caller decides whether
+     * to apply the title (change-detection guard lives in [ChatSessionService]).
+     *
+     * Invoked on the summarizer background thread — implementations must be thread-safe.
+     * Only fires when summarization used the structured (AI) path, not the basic fallback.
+     */
+    private val onTitleSuggested: ((String) -> Unit)? = null,
 ) : ChatMemory,
     AutoCloseable {
 
@@ -473,16 +482,51 @@ class TokenAwareSummarizingMemory(
     private fun generateStructuredSummary(messagesToSummarize: List<ChatMessage>) {
         try {
             val conversationText = buildConversationText(messagesToSummarize)
-            val newSummary = chatClient.getSummary(conversationText)
+            val secondaryModel = appContext.createSecondaryModel()
+            val newSummary = secondaryModel.getSummary(conversationText)
 
             structuredSummary = mergeWithExistingSummary(newSummary)
             log.info("Generated structured summary with ${newSummary.keyFacts.size} facts, ${newSummary.mainTopics.size} topics")
+
+            // Derive a title candidate from the merged summary — no extra AI call needed.
+            // Priority: first sentence of recentContext → top-2 mainTopics joined with " · "
+            if (onTitleSuggested != null) {
+                val candidate = deriveTitleFromSummary(structuredSummary)
+                if (candidate.isNotBlank()) {
+                    try {
+                        onTitleSuggested.invoke(candidate)
+                    } catch (e: Exception) {
+                        log.warn("onTitleSuggested callback failed for session {}: {}", sessionId, e.message)
+                    }
+                }
+            }
 
             // Merge stable user facts into the persistent user memory store
             mergeIntoUserMemory(conversationText)
         } catch (e: Exception) {
             log.error("Structured summarization failed for session $sessionId", e)
         }
+    }
+
+    /**
+     * Derives a short title candidate from an existing [SessionConversationSummary] without
+     * any additional AI call.
+     *
+     * Priority:
+     * 1. First sentence of [SessionConversationSummary.recentContext], truncated to 60 chars.
+     * 2. Top-2 [SessionConversationSummary.mainTopics] joined with " · ", truncated to 60 chars.
+     * 3. Empty string if neither yields anything useful.
+     */
+    private fun deriveTitleFromSummary(summary: SessionConversationSummary?): String {
+        if (summary == null) return ""
+        val fromContext = summary.recentContext
+            .split(Regex("[.!?]\\s+"))
+            .firstOrNull { it.isNotBlank() }
+            ?.trim()
+            ?.take(60)
+            .orEmpty()
+        if (fromContext.isNotBlank()) return fromContext
+        return summary.mainTopics.take(2).joinToString(" · ").take(60)
     }
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -7,6 +7,14 @@ package io.askimo.core.providers
 import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.exception.InternalServerException
 import dev.langchain4j.exception.ModelNotFoundException
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.request.ChatRequest
+import dev.langchain4j.model.chat.request.ResponseFormat
+import dev.langchain4j.model.chat.request.ResponseFormatType
+import dev.langchain4j.model.chat.request.json.JsonArraySchema
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema
+import dev.langchain4j.model.chat.request.json.JsonSchema
+import dev.langchain4j.model.chat.request.json.JsonStringSchema
 import dev.langchain4j.model.googleai.GeneratedImageHelper
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ChatContext
@@ -373,38 +381,77 @@ private inline fun <reified T> parseStructuredOutput(
 }
 
 /**
- * Generates a structured summary of a conversation.
+ * Generates a structured summary of a conversation using LangChain4j's native
+ * [ResponseFormat] + JSON-schema enforcement so the model is forced to return
+ * well-formed JSON without relying on prompt-only instructions.
  *
- * This extension function analyzes conversation text and extracts:
- * - Key facts as name-value pairs
- * - Main topics discussed
- * - Recent context summary
+ * After summarization, the caller derives a title candidate from [SessionConversationSummary.recentContext]
+ * and [SessionConversationSummary.mainTopics] — no extra AI call needed.
  *
- * The AI model is instructed to respond with JSON only, which is then parsed
- * into a [SessionConversationSummary] object using structured output parsing.
+ * Falls back to prompt-only parsing if schema enforcement fails (e.g. older local models).
  *
  * @param conversationText The conversation text to summarize
- * @return A SessionConversationSummary containing key facts, main topics, and recent context
+ * @return A [SessionConversationSummary] containing key facts, main topics, and recent context
  */
-fun ChatClient.getSummary(conversationText: String): SessionConversationSummary {
-    val log = logger<ChatClient>()
+fun ChatModel.getSummary(conversationText: String): SessionConversationSummary {
+    val log = logger<ChatModel>()
 
-    val prompt = buildSummaryPrompt(conversationText)
+    // Build JSON-schema that enforces the exact shape of SessionConversationSummary
+    val responseFormat = ResponseFormat.builder()
+        .type(ResponseFormatType.JSON)
+        .jsonSchema(
+            JsonSchema.builder()
+                .name("SessionConversationSummary")
+                .rootElement(
+                    JsonObjectSchema.builder()
+                        .addProperty(
+                            "keyFacts",
+                            JsonObjectSchema.builder()
+                                .description("Key facts as name-value pairs extracted from the conversation")
+                                .additionalProperties(true)
+                                .build(),
+                        )
+                        .addProperty(
+                            "mainTopics",
+                            JsonArraySchema.builder()
+                                .description("List of main topics discussed")
+                                .items(JsonStringSchema.builder().build())
+                                .build(),
+                        )
+                        .addStringProperty("recentContext", "1-3 sentence summary of the latest state and immediate goal")
+                        .required("keyFacts", "mainTopics", "recentContext")
+                        .build(),
+                )
+                .build(),
+        )
+        .build()
+
+    val chatRequest = ChatRequest.builder()
+        .messages(UserMessage.from(buildSummaryPrompt(conversationText)))
+        .responseFormat(responseFormat)
+        .build()
 
     return try {
-        val rawResponse = this.sendMessage(prompt)
-        parseStructuredOutput<SessionConversationSummary>(
-            rawResponse,
-            arrayKeys = setOf("mainTopics"), // must be array
-            stringKeys = setOf("recentContext"), // must be string
-        )
+        val rawJson = this.chat(chatRequest).aiMessage().text() ?: "{}"
+        json.decodeFromString<SessionConversationSummary>(rawJson)
     } catch (e: Exception) {
-        log.error("Failed to generate conversation summary. Response was likely malformed.", e)
-        SessionConversationSummary(
-            keyFacts = emptyMap(),
-            mainTopics = emptyList(),
-            recentContext = conversationText.takeLast(500),
-        )
+        log.warn("Native-schema summary failed ({}), retrying with prompt-only fallback", e.message)
+        // Fallback: send without ResponseFormat, parse manually
+        try {
+            val rawResponse = this.chat(ChatRequest.builder().messages(UserMessage.from(buildSummaryPrompt(conversationText))).build()).aiMessage().text() ?: "{}"
+            parseStructuredOutput<SessionConversationSummary>(
+                rawResponse,
+                arrayKeys = setOf("mainTopics"),
+                stringKeys = setOf("recentContext"),
+            )
+        } catch (fallback: Exception) {
+            log.error("Summary fallback also failed. Returning minimal context summary.", fallback)
+            SessionConversationSummary(
+                keyFacts = emptyMap(),
+                mainTopics = emptyList(),
+                recentContext = conversationText.takeLast(500),
+            )
+        }
     }
 }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -10,6 +10,7 @@ import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.anthropic.AnthropicChatModel
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
+import dev.langchain4j.model.chat.Capability
 import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.image.ImageModel
@@ -176,6 +177,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         return AnthropicStreamingChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .apiKey(safeApiKey(settings.apiKey))
+            .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
             .modelName(settings.defaultModel)
             .baseUrl(settings.baseUrl)
             .timeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
@@ -216,6 +218,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
         return AnthropicChatModel.builder()
             .httpClientBuilder(jdkHttpClientBuilder)
             .apiKey(safeApiKey(settings.apiKey))
+            .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
             .modelName(
                 settings.utilityModel
                     .ifBlank { AppConfig.models[ANTHROPIC].utilityModel }


### PR DESCRIPTION
- Add isUserRenamed flag to ChatSession to detect manual title changes.
- Persist flag in database and migrate schema accordingly.
- Repository method markAsUserRenamed updates flag for a session.
- Service now calls markAsUserRenamed when user renames title.
- Memory summarizer now checks flag and skips auto title refresh when set.
- Context caching now resets secondary model on settings change.

Ref: https://github.com/askimo-ai/askimo/issues/536