### PR TITLE
refactor(ui): centralize popup component and clean up experimental API usage

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -93,9 +93,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
-import androidx.compose.ui.window.PopupProperties
 import io.askimo.core.AppConstants.DOMAIN
 import io.askimo.core.chat.domain.ChatDirective
 import io.askimo.core.chat.domain.DirectiveScope
@@ -1183,119 +1181,119 @@ private fun toolsIndicatorButton(
         }
 
         if (showToolsPopup) {
-            Popup(
+            AppComponents.anchoredPopup(
+                positionProvider = object : PopupPositionProvider {
+                    override fun calculatePosition(
+                        anchorBounds: IntRect,
+                        windowSize: IntSize,
+                        layoutDirection: LayoutDirection,
+                        popupContentSize: IntSize,
+                    ): IntOffset = IntOffset(
+                        x = anchorBounds.left,
+                        y = anchorBounds.top - popupContentSize.height - 4,
+                    )
+                },
                 onDismissRequest = { showToolsPopup = false },
-                alignment = Alignment.BottomStart,
+                modifier = Modifier.widthIn(min = 300.dp, max = 420.dp),
             ) {
-                Surface(
+                // Header: title on left, settings icon button on right
+                Row(
                     modifier = Modifier
-                        .widthIn(min = 300.dp, max = 420.dp),
-                    shape = MaterialTheme.shapes.medium,
-                    shadowElevation = 8.dp,
-                    color = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 2.dp,
+                        .fillMaxWidth()
+                        .padding(
+                            start = Spacing.medium,
+                            end = Spacing.extraSmall,
+                            top = Spacing.small,
+                            bottom = Spacing.small,
+                        ),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Column {
-                        // Header: title on left, settings icon button on right
+                    Text(
+                        text = stringResource("chat.tools.popup.title"),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    if (onNavigateToMcpSettings != null) {
+                        themedTooltip(text = stringResource("chat.tools.popup.manage")) {
+                            IconButton(
+                                onClick = {
+                                    showToolsPopup = false
+                                    onNavigateToMcpSettings()
+                                },
+                                modifier = Modifier
+                                    .size(32.dp)
+                                    .pointerHoverIcon(PointerIcon.Hand),
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Settings,
+                                    contentDescription = stringResource("chat.tools.popup.manage"),
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                HorizontalDivider()
+
+                // Content
+                when {
+                    isLoadingServers -> {
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(
-                                    start = Spacing.medium,
-                                    end = Spacing.extraSmall,
-                                    top = Spacing.small,
-                                    bottom = Spacing.small,
-                                ),
-                            horizontalArrangement = Arrangement.SpaceBetween,
+                                .padding(horizontal = Spacing.medium, vertical = Spacing.medium),
+                            horizontalArrangement = Arrangement.Center,
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            Text(
-                                text = stringResource("chat.tools.popup.title"),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
-                            if (onNavigateToMcpSettings != null) {
-                                themedTooltip(text = stringResource("chat.tools.popup.manage")) {
-                                    IconButton(
-                                        onClick = {
-                                            showToolsPopup = false
-                                            onNavigateToMcpSettings()
-                                        },
-                                        modifier = Modifier
-                                            .size(32.dp)
-                                            .pointerHoverIcon(PointerIcon.Hand),
-                                    ) {
-                                        Icon(
-                                            Icons.Outlined.Settings,
-                                            contentDescription = stringResource("chat.tools.popup.manage"),
-                                            modifier = Modifier.size(16.dp),
-                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    }
-                                }
-                            }
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(stringResource("chat.tools.popup.loading"))
                         }
+                    }
 
-                        HorizontalDivider()
+                    mcpServers.isEmpty() -> {
+                        Text(
+                            text = stringResource("chat.tools.popup.no.servers.global"),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(
+                                horizontal = Spacing.medium,
+                                vertical = Spacing.medium,
+                            ),
+                        )
+                    }
 
-                        // Content
-                        when {
-                            isLoadingServers -> {
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = Spacing.medium, vertical = Spacing.medium),
-                                    horizontalArrangement = Arrangement.Center,
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(24.dp),
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    Text(stringResource("chat.tools.popup.loading"))
-                                }
-                            }
-
-                            mcpServers.isEmpty() -> {
-                                Text(
-                                    text = stringResource("chat.tools.popup.no.servers.global"),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(
-                                        horizontal = Spacing.medium,
-                                        vertical = Spacing.medium,
-                                    ),
-                                )
-                            }
-
-                            else -> {
-                                // Server list — scrollable, capped at max height; popup expands freely
-                                Column(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .heightIn(max = 300.dp)
-                                        .verticalScroll(rememberScrollState())
-                                        .padding(Spacing.small),
-                                    verticalArrangement = Arrangement.spacedBy(Spacing.small),
-                                ) {
-                                    mcpServers.forEach { server ->
-                                        mcpServerItem(
-                                            server = server,
-                                            isEnabled = server.id in enabledServerIds,
-                                            onToggle = {
-                                                onEnabledServerIdsChange(
-                                                    if (server.id in enabledServerIds) {
-                                                        enabledServerIds - server.id
-                                                    } else {
-                                                        enabledServerIds + server.id
-                                                    },
-                                                )
+                    else -> {
+                        // Server list — scrollable, capped at max height; popup expands freely
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 300.dp)
+                                .verticalScroll(rememberScrollState())
+                                .padding(Spacing.small),
+                            verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                        ) {
+                            mcpServers.forEach { server ->
+                                mcpServerItem(
+                                    server = server,
+                                    isEnabled = server.id in enabledServerIds,
+                                    onToggle = {
+                                        onEnabledServerIdsChange(
+                                            if (server.id in enabledServerIds) {
+                                                enabledServerIds - server.id
+                                            } else {
+                                                enabledServerIds + server.id
                                             },
-                                            onCloseAll = { showToolsPopup = false },
                                         )
-                                    }
-                                }
+                                    },
+                                    onCloseAll = { showToolsPopup = false },
+                                )
                             }
                         }
                     }
@@ -1779,8 +1777,8 @@ private fun directiveChip(
 
         // Upward-opening popup anchored to the chip's top edge
         if (directivePopupExpanded) {
-            Popup(
-                popupPositionProvider = object : PopupPositionProvider {
+            AppComponents.anchoredPopup(
+                positionProvider = object : PopupPositionProvider {
                     override fun calculatePosition(
                         anchorBounds: IntRect,
                         windowSize: IntSize,
@@ -1792,176 +1790,166 @@ private fun directiveChip(
                     )
                 },
                 onDismissRequest = { onDirectivePopupExpandedChange(false) },
-                properties = PopupProperties(focusable = true),
+                modifier = Modifier.widthIn(min = 350.dp, max = 420.dp),
             ) {
-                Surface(
-                    modifier = Modifier.widthIn(min = 350.dp, max = 420.dp),
-                    shape = MaterialTheme.shapes.medium,
-                    shadowElevation = 8.dp,
-                    color = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 2.dp,
+                // Header: title on left, action icon buttons on right
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = Spacing.medium,
+                            end = Spacing.extraSmall,
+                            top = Spacing.small,
+                            bottom = Spacing.small,
+                        ),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Column {
-                        // Header: title on left, action icon buttons on right
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(
-                                    start = Spacing.medium,
-                                    end = Spacing.extraSmall,
-                                    top = Spacing.small,
-                                    bottom = Spacing.small,
-                                ),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = stringResource("chat.directive"),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                            )
-                            Row(horizontalArrangement = Arrangement.spacedBy(0.dp)) {
-                                themedTooltip(text = stringResource("chat.directive.new")) {
-                                    IconButton(
-                                        onClick = {
-                                            onShowNewDirectiveDialog()
-                                            onDirectivePopupExpandedChange(false)
-                                        },
-                                        modifier = Modifier.size(32.dp).pointerHoverIcon(PointerIcon.Hand),
-                                    ) {
-                                        Icon(
-                                            Icons.Default.Add,
-                                            contentDescription = stringResource("chat.directive.new"),
-                                            modifier = Modifier.size(16.dp),
-                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    }
-                                }
-                                themedTooltip(text = stringResource("chat.directive.manage")) {
-                                    IconButton(
-                                        onClick = {
-                                            onShowManageDirectivesDialog()
-                                            onDirectivePopupExpandedChange(false)
-                                        },
-                                        modifier = Modifier.size(32.dp).pointerHoverIcon(PointerIcon.Hand),
-                                    ) {
-                                        Icon(
-                                            Icons.Outlined.Settings,
-                                            contentDescription = stringResource("chat.directive.manage"),
-                                            modifier = Modifier.size(16.dp),
-                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    }
-                                }
-                                themedTooltip(text = stringResource("chat.directive.learn.more")) {
-                                    IconButton(
-                                        onClick = {
-                                            uriHandler.openUri("https://$DOMAIN/docs/desktop/directives/")
-                                            onDirectivePopupExpandedChange(false)
-                                        },
-                                        modifier = Modifier.size(32.dp).pointerHoverIcon(PointerIcon.Hand),
-                                    ) {
-                                        Icon(
-                                            Icons.Outlined.Info,
-                                            contentDescription = stringResource("chat.directive.learn.more"),
-                                            modifier = Modifier.size(16.dp),
-                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    }
-                                }
+                    Text(
+                        text = stringResource("chat.directive"),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(0.dp)) {
+                        themedTooltip(text = stringResource("chat.directive.new")) {
+                            IconButton(
+                                onClick = {
+                                    onShowNewDirectiveDialog()
+                                    onDirectivePopupExpandedChange(false)
+                                },
+                                modifier = Modifier.size(32.dp).pointerHoverIcon(PointerIcon.Hand),
+                            ) {
+                                Icon(
+                                    Icons.Default.Add,
+                                    contentDescription = stringResource("chat.directive.new"),
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
                             }
                         }
+                        themedTooltip(text = stringResource("chat.directive.manage")) {
+                            IconButton(
+                                onClick = {
+                                    onShowManageDirectivesDialog()
+                                    onDirectivePopupExpandedChange(false)
+                                },
+                                modifier = Modifier.size(32.dp).pointerHoverIcon(PointerIcon.Hand),
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Settings,
+                                    contentDescription = stringResource("chat.directive.manage"),
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        themedTooltip(text = stringResource("chat.directive.learn.more")) {
+                            IconButton(
+                                onClick = {
+                                    uriHandler.openUri("https://$DOMAIN/docs/desktop/directives/")
+                                    onDirectivePopupExpandedChange(false)
+                                },
+                                modifier = Modifier.size(32.dp).pointerHoverIcon(PointerIcon.Hand),
+                            ) {
+                                Icon(
+                                    Icons.Outlined.Info,
+                                    contentDescription = stringResource("chat.directive.learn.more"),
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
 
-                        HorizontalDivider()
+                HorizontalDivider()
 
-                        // Directive rows — scrollable list capped at max height; popup expands freely
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .heightIn(max = 280.dp)
-                                .verticalScroll(rememberScrollState()),
-                        ) {
-                            availableDirectives.forEach { directive ->
-                                val isSelected = selectedDirective == directive.id
-                                themedRichTooltip(
-                                    placement = TooltipPlacement.RIGHT,
-                                    tooltipContent = {
-                                        Column(
-                                            modifier = Modifier
-                                                .widthIn(min = 350.dp, max = 420.dp)
-                                                .padding(
-                                                    horizontal = Spacing.medium,
-                                                    vertical = Spacing.small,
-                                                ),
-                                            verticalArrangement = Arrangement.spacedBy(Spacing.small),
-                                        ) {
-                                            Text(
-                                                text = directive.name,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                fontWeight = FontWeight.SemiBold,
-                                                color = MaterialTheme.colorScheme.onSurface,
-                                            )
-                                            HorizontalDivider(
-                                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                                            )
-                                            Text(
-                                                text = directive.content,
-                                                style = MaterialTheme.typography.labelSmall,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                maxLines = 10,
-                                                overflow = TextOverflow.Ellipsis,
-                                            )
-                                        }
-                                    },
+                // Directive rows — scrollable list capped at max height; popup expands freely
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 280.dp)
+                        .verticalScroll(rememberScrollState()),
+                ) {
+                    availableDirectives.forEach { directive ->
+                        val isSelected = selectedDirective == directive.id
+                        themedRichTooltip(
+                            placement = TooltipPlacement.RIGHT,
+                            tooltipContent = {
+                                Column(
+                                    modifier = Modifier
+                                        .widthIn(min = 350.dp, max = 420.dp)
+                                        .padding(
+                                            horizontal = Spacing.medium,
+                                            vertical = Spacing.small,
+                                        ),
+                                    verticalArrangement = Arrangement.spacedBy(Spacing.small),
                                 ) {
-                                    Row(
+                                    Text(
+                                        text = directive.name,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                    )
+                                    HorizontalDivider(
+                                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                    )
+                                    Text(
+                                        text = directive.content,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 10,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                            },
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        onToggleDirective(if (isSelected) null else directive.id)
+                                    }
+                                    .padding(
+                                        start = Spacing.extraSmall,
+                                        end = Spacing.small,
+                                        top = 2.dp,
+                                        bottom = 2.dp,
+                                    )
+                                    .pointerHoverIcon(PointerIcon.Hand),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                @OptIn(ExperimentalMaterial3Api::class)
+                                CompositionLocalProvider(LocalRippleConfiguration provides null) {
+                                    Checkbox(
+                                        checked = isSelected,
+                                        onCheckedChange = { checked ->
+                                            onToggleDirective(if (checked) directive.id else null)
+                                        },
                                         modifier = Modifier
-                                            .fillMaxWidth()
-                                            .clickable {
-                                                onToggleDirective(if (isSelected) null else directive.id)
-                                            }
-                                            .padding(
-                                                start = Spacing.extraSmall,
-                                                end = Spacing.small,
-                                                top = 2.dp,
-                                                bottom = 2.dp,
-                                            )
+                                            .size(36.dp)
                                             .pointerHoverIcon(PointerIcon.Hand),
-                                        verticalAlignment = Alignment.CenterVertically,
+                                    )
+                                }
+                                Text(
+                                    text = directive.name,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    modifier = Modifier.weight(1f),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                if (directive.scope == DirectiveScope.TEAM) {
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Surface(
+                                        shape = MaterialTheme.shapes.extraSmall,
+                                        color = MaterialTheme.colorScheme.tertiaryContainer,
                                     ) {
-                                        @OptIn(ExperimentalMaterial3Api::class)
-                                        CompositionLocalProvider(LocalRippleConfiguration provides null) {
-                                            Checkbox(
-                                                checked = isSelected,
-                                                onCheckedChange = { checked ->
-                                                    onToggleDirective(if (checked) directive.id else null)
-                                                },
-                                                modifier = Modifier
-                                                    .size(36.dp)
-                                                    .pointerHoverIcon(PointerIcon.Hand),
-                                            )
-                                        }
                                         Text(
-                                            text = directive.name,
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            modifier = Modifier.weight(1f),
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
+                                            text = stringResource("directive.scope.team"),
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
                                         )
-                                        if (directive.scope == DirectiveScope.TEAM) {
-                                            Spacer(modifier = Modifier.width(4.dp))
-                                            Surface(
-                                                shape = MaterialTheme.shapes.extraSmall,
-                                                color = MaterialTheme.colorScheme.tertiaryContainer,
-                                            ) {
-                                                Text(
-                                                    text = stringResource("directive.scope.team"),
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = MaterialTheme.colorScheme.onTertiaryContainer,
-                                                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
-                                                )
-                                            }
-                                        }
                                     }
                                 }
                             }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -4,7 +4,6 @@
  */
 package io.askimo.ui.chat
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -108,7 +107,6 @@ import io.askimo.ui.common.theme.LocalBackgroundActive
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.TooltipPlacement
-import io.askimo.ui.common.ui.markdownText
 import io.askimo.ui.common.ui.themedRichTooltip
 import io.askimo.ui.common.ui.themedTooltip
 import io.askimo.ui.common.ui.util.FileDialogUtils
@@ -125,7 +123,7 @@ import java.util.UUID.randomUUID
 
 private val log = currentFileLogger()
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun chatView(
     state: ChatState,
@@ -729,10 +727,16 @@ fun chatView(
                                                 themedRichTooltip(
                                                     placement = TooltipPlacement.LEFT,
                                                     tooltipContent = {
-                                                        markdownText(
-                                                            markdown = msg.content.take(600),
+                                                        Text(
+                                                            text = msg.content.take(200).let {
+                                                                if (msg.content.length > 200) "$it…" else it
+                                                            },
+                                                            style = MaterialTheme.typography.bodySmall,
+                                                            color = MaterialTheme.colorScheme.onSurface,
+                                                            maxLines = 6,
+                                                            overflow = TextOverflow.Ellipsis,
                                                             modifier = Modifier
-                                                                .widthIn(max = 360.dp)
+                                                                .widthIn(max = 280.dp)
                                                                 .padding(horizontal = 10.dp, vertical = 8.dp),
                                                         )
                                                     },
@@ -783,8 +787,12 @@ fun chatView(
                                                                         .weight(1f),
                                                                     verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
                                                                 ) {
-                                                                    markdownText(
-                                                                        markdown = msg.content.take(120),
+                                                                    Text(
+                                                                        text = msg.content.take(120),
+                                                                        style = MaterialTheme.typography.bodyMedium,
+                                                                        color = MaterialTheme.colorScheme.onSurface,
+                                                                        maxLines = 3,
+                                                                        overflow = TextOverflow.Ellipsis,
                                                                         modifier = Modifier.fillMaxWidth(),
                                                                     )
                                                                     msg.timestamp?.let { ts ->

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -85,6 +85,9 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
 import io.askimo.ui.common.i18n.stringResource
 
 object AppComponents {
@@ -845,4 +848,40 @@ object AppComponents {
         unhoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
         hoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.50f),
     )
+
+    /**
+     * A floating popup anchored to any position via [positionProvider], using the same
+     * background, border, and elevation tokens as all other popup surfaces in the app.
+     *
+     * Use this instead of a raw [Popup] + [Surface] whenever you need a custom-positioned
+     * overlay (e.g. an upward-opening chip picker, command palette).
+     */
+    @Composable
+    fun anchoredPopup(
+        positionProvider: PopupPositionProvider,
+        onDismissRequest: () -> Unit,
+        modifier: Modifier = Modifier,
+        shape: Shape = MaterialTheme.shapes.medium,
+        properties: PopupProperties = PopupProperties(focusable = true),
+        content: @Composable ColumnScope.() -> Unit,
+    ) {
+        val border = popupBorderStroke()
+        Popup(
+            popupPositionProvider = positionProvider,
+            onDismissRequest = onDismissRequest,
+            properties = properties,
+        ) {
+            MaterialTheme(colorScheme = popupColorScheme()) {
+                Surface(
+                    modifier = modifier.border(border.width, border.brush, shape),
+                    shape = shape,
+                    color = popupContainerColor(),
+                    tonalElevation = popupSurfaceTonalElevation,
+                    shadowElevation = popupElevation,
+                ) {
+                    Column(content = content)
+                }
+            }
+        }
+    }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/CodeViewerBlock.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/CodeViewerBlock.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -136,19 +137,23 @@ fun codeViewerBlock(
             )
         }
 
-        HorizontalScrollbar(
-            adapter = rememberScrollbarAdapter(hScrollState),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp, vertical = 2.dp),
-            style = ScrollbarStyle(
-                minimalHeight = 16.dp,
-                thickness = 6.dp,
-                shape = MaterialTheme.shapes.small,
-                hoverDurationMillis = 150,
-                unhoverColor = contentColor.copy(alpha = 0.20f),
-                hoverColor = contentColor.copy(alpha = 0.50f),
-            ),
-        )
+        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+            if (maxWidth.value.isFinite()) {
+                HorizontalScrollbar(
+                    adapter = rememberScrollbarAdapter(hScrollState),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 4.dp, vertical = 2.dp),
+                    style = ScrollbarStyle(
+                        minimalHeight = 16.dp,
+                        thickness = 6.dp,
+                        shape = MaterialTheme.shapes.small,
+                        hoverDurationMillis = 150,
+                        unhoverColor = contentColor.copy(alpha = 0.20f),
+                        hoverColor = contentColor.copy(alpha = 0.50f),
+                    ),
+                )
+            }
+        }
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/Tooltip.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/Tooltip.kt
@@ -4,7 +4,6 @@
  */
 package io.askimo.ui.common.ui
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -81,7 +80,7 @@ enum class TooltipPlacement {
  * @param tooltip The tooltip popup content
  * @param content The anchor content
  */
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 private fun tooltipContainer(
     placement: TooltipPlacement = TooltipPlacement.AUTO,
@@ -147,7 +146,6 @@ private fun tooltipContainer(
  * @param modifier Optional modifier for the TooltipBox
  * @param content The composable content that the tooltip wraps
  */
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun themedTooltip(
     text: String,
@@ -199,7 +197,6 @@ fun themedTooltip(
  * @param tooltipContent The composable to render inside the tooltip popup
  * @param content The anchor composable the tooltip wraps
  */
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun themedRichTooltip(
     placement: TooltipPlacement = TooltipPlacement.AUTO,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
@@ -6,7 +6,6 @@ package io.askimo.ui.shell
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -756,7 +755,6 @@ private fun pinnedSection(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun pinnedProjectItem(
     project: Project,
@@ -839,7 +837,6 @@ private fun pinnedProjectItem(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun pinnedSessionItem(
     session: ChatSession,
@@ -1013,7 +1010,6 @@ private fun sessionsList(
 // Session item with context menu
 // ─────────────────────────────────────────────────────────────────────────────
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun sessionItemWithMenu(
     session: ChatSession,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/terminal/TerminalPanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/terminal/TerminalPanel.kt
@@ -4,7 +4,6 @@
  */
 package io.askimo.ui.terminal
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -256,7 +255,6 @@ fun terminalPanel(
                                         horizontalArrangement = Arrangement.spacedBy(Spacing.small),
                                     ) {
                                         // Tab title — single click switches tab, double click renames
-                                        @OptIn(ExperimentalFoundationApi::class)
                                         Text(
                                             text = tab.title,
                                             style = MaterialTheme.typography.bodyMedium,

--- a/desktop/src/main/kotlin/io/askimo/desktop/user/UserProfileDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/user/UserProfileDialog.kt
@@ -11,28 +11,17 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -50,7 +39,6 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import io.askimo.core.user.domain.UserProfile
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
@@ -87,7 +75,6 @@ enum class UserInterestCategory(val key: String, val displayKey: String) {
 /**
  * User profile dialog for viewing and editing user information
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun userProfileDialog(
     profile: UserProfile,
@@ -136,253 +123,199 @@ fun userProfileDialog(
         }
     }
 
-    Dialog(onDismissRequest = onDismiss) {
-        Surface(
-            modifier = Modifier.width(600.dp).height(700.dp),
-            shape = MaterialTheme.shapes.large,
-            tonalElevation = 8.dp,
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(Spacing.extraLarge),
-            ) {
-                // Header
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = stringResource("user.profile.title"),
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold,
+    AppComponents.scaffoldDialog(
+        onDismissRequest = onDismiss,
+        onCloseRequest = onDismiss,
+        width = 720.dp,
+        title = {
+            Text(
+                text = stringResource("user.profile.title"),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+        },
+        actions = {
+            secondaryButton(onClick = onDismiss) {
+                Text(stringResource("action.cancel"))
+            }
+            Spacer(Modifier.width(Spacing.small))
+            primaryButton(
+                onClick = {
+                    val allInterests = selectedInterests.toMutableSet()
+                    customInterests.split(",")
+                        .map { it.trim() }
+                        .filter { it.isNotBlank() }
+                        .forEach { allInterests.add(it) }
+
+                    val updatedPreferences = profile.preferences.toMutableMap()
+                    avatarPath?.let { updatedPreferences["avatarPath"] = it }
+
+                    onSave(
+                        profile.copy(
+                            name = name.ifBlank { null },
+                            email = email.ifBlank { null },
+                            occupation = occupation.ifBlank { null },
+                            location = location.ifBlank { null },
+                            bio = bio.ifBlank { null },
+                            interests = allInterests.toList(),
+                            preferences = updatedPreferences,
+                        ),
                     )
-                    IconButton(
-                        onClick = onDismiss,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                    ) {
-                        Icon(Icons.Default.Close, contentDescription = stringResource("action.close"))
-                    }
-                }
-
-                Spacer(Modifier.height(Spacing.large))
-
-                // Scrollable content
-                Column(
+                },
+            ) {
+                Text(stringResource("action.save"))
+            }
+        },
+        stickyHeader = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(Spacing.small),
+            ) {
+                Box(
                     modifier = Modifier
-                        .weight(1f)
-                        .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.large),
-                ) {
-                    // Avatar section
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(120.dp)
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.primaryContainer)
-                                .border(3.dp, MaterialTheme.colorScheme.primary, CircleShape)
-                                .clickable {
-                                    scope.launch {
-                                        val (path, bitmap) = avatarService.pickAndSaveUserAvatar() ?: return@launch
-                                        avatarPath = path
-                                        avatarImage = bitmap
-                                    }
-                                }
-                                .pointerHoverIcon(PointerIcon.Hand),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            if (avatarImage != null) {
-                                Image(
-                                    bitmap = avatarImage!!,
-                                    contentDescription = stringResource("user.profile.avatar"),
-                                    modifier = Modifier.fillMaxSize(),
-                                    contentScale = ContentScale.Crop,
-                                )
-                            } else {
-                                val initials = name.split(" ")
-                                    .mapNotNull { it.firstOrNull()?.uppercase() }
-                                    .take(2)
-                                    .joinToString("")
-                                    .ifBlank { "?" }
-
-                                Text(
-                                    text = initials,
-                                    style = MaterialTheme.typography.displayLarge,
-                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                )
+                        .size(96.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primaryContainer)
+                        .border(3.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                        .clickable {
+                            scope.launch {
+                                val (path, bitmap) = avatarService.pickAndSaveUserAvatar() ?: return@launch
+                                avatarPath = path
+                                avatarImage = bitmap
                             }
                         }
-
-                        Spacer(Modifier.height(Spacing.small))
-
+                        .pointerHoverIcon(PointerIcon.Hand),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (avatarImage != null) {
+                        Image(
+                            bitmap = avatarImage!!,
+                            contentDescription = stringResource("user.profile.avatar"),
+                            modifier = Modifier.size(96.dp),
+                            contentScale = ContentScale.Crop,
+                        )
+                    } else {
+                        val initials = name.split(" ")
+                            .mapNotNull { it.firstOrNull()?.uppercase() }
+                            .take(2)
+                            .joinToString("")
+                            .ifBlank { "?" }
                         Text(
-                            text = stringResource("user.profile.avatar.click_to_change"),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            text = initials,
+                            style = MaterialTheme.typography.headlineLarge,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
                         )
                     }
-
-                    HorizontalDivider()
-
-                    // Basic Information
-                    Text(
-                        text = stringResource("user.profile.basic_info"),
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-
-                    OutlinedTextField(
-                        value = name,
-                        onValueChange = { name = it },
-                        label = { Text(stringResource("user.profile.name")) },
-                        colors = AppComponents.outlinedTextFieldColors(),
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                    )
-
-                    OutlinedTextField(
-                        value = email,
-                        onValueChange = { email = it },
-                        label = { Text(stringResource("user.profile.email")) },
-                        colors = AppComponents.outlinedTextFieldColors(),
-                        placeholder = { Text(stringResource("user.profile.email.placeholder")) },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                    )
-
-                    OutlinedTextField(
-                        value = occupation,
-                        onValueChange = { occupation = it },
-                        label = { Text(stringResource("user.profile.occupation")) },
-                        colors = AppComponents.outlinedTextFieldColors(),
-                        placeholder = { Text(stringResource("user.profile.occupation.placeholder")) },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                    )
-
-                    OutlinedTextField(
-                        value = location,
-                        onValueChange = { location = it },
-                        label = { Text(stringResource("user.profile.location")) },
-                        colors = AppComponents.outlinedTextFieldColors(),
-                        placeholder = { Text(stringResource("user.profile.location.placeholder")) },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                    )
-
-                    OutlinedTextField(
-                        value = bio,
-                        onValueChange = { bio = it },
-                        label = { Text(stringResource("user.profile.bio")) },
-                        colors = AppComponents.outlinedTextFieldColors(),
-                        placeholder = { Text(stringResource("user.profile.bio.placeholder")) },
-                        modifier = Modifier.fillMaxWidth().height(100.dp),
-                        maxLines = 4,
-                    )
-
-                    HorizontalDivider()
-
-                    // Interests
-                    Text(
-                        text = stringResource("user.profile.interests"),
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-
-                    Text(
-                        text = stringResource("user.profile.interests.description"),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-
-                    // Predefined interest chips
-                    FlowRow(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(Spacing.small),
-                        verticalArrangement = Arrangement.spacedBy(Spacing.small),
-                    ) {
-                        UserInterestCategory.entries.forEach { category ->
-                            FilterChip(
-                                selected = category.key in selectedInterests,
-                                onClick = {
-                                    selectedInterests = if (category.key in selectedInterests) {
-                                        selectedInterests - category.key
-                                    } else {
-                                        selectedInterests + category.key
-                                    }
-                                },
-                                label = { Text(stringResource(category.displayKey)) },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                            )
-                        }
-                    }
-
-                    // Custom interests
-                    OutlinedTextField(
-                        value = customInterests,
-                        onValueChange = { customInterests = it },
-                        label = { Text(stringResource("user.profile.interests.custom")) },
-                        colors = AppComponents.outlinedTextFieldColors(),
-                        placeholder = { Text(stringResource("user.profile.interests.custom.placeholder")) },
-                        modifier = Modifier.fillMaxWidth(),
-                        supportingText = {
-                            Text(
-                                text = stringResource("user.profile.interests.custom.hint"),
-                                style = MaterialTheme.typography.bodySmall,
-                            )
-                        },
-                    )
                 }
+                Text(
+                    text = stringResource("user.profile.avatar.click_to_change"),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        showSectionDividers = true,
+        content = {
+            // ── Basic Information ─────────────────────────────────────────────
+            Text(
+                text = stringResource("user.profile.basic_info"),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
 
-                Spacer(Modifier.height(Spacing.large))
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text(stringResource("user.profile.name")) },
+                colors = AppComponents.outlinedTextFieldColors(),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+            OutlinedTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = { Text(stringResource("user.profile.email")) },
+                placeholder = { Text(stringResource("user.profile.email.placeholder")) },
+                colors = AppComponents.outlinedTextFieldColors(),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+            OutlinedTextField(
+                value = occupation,
+                onValueChange = { occupation = it },
+                label = { Text(stringResource("user.profile.occupation")) },
+                placeholder = { Text(stringResource("user.profile.occupation.placeholder")) },
+                colors = AppComponents.outlinedTextFieldColors(),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+            OutlinedTextField(
+                value = location,
+                onValueChange = { location = it },
+                label = { Text(stringResource("user.profile.location")) },
+                placeholder = { Text(stringResource("user.profile.location.placeholder")) },
+                colors = AppComponents.outlinedTextFieldColors(),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+            OutlinedTextField(
+                value = bio,
+                onValueChange = { bio = it },
+                label = { Text(stringResource("user.profile.bio")) },
+                placeholder = { Text(stringResource("user.profile.bio.placeholder")) },
+                colors = AppComponents.outlinedTextFieldColors(),
+                modifier = Modifier.fillMaxWidth().height(100.dp),
+                maxLines = 4,
+            )
 
-                // Action buttons
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    secondaryButton(
-                        onClick = onDismiss,
-                    ) {
-                        Text(stringResource("action.cancel"))
-                    }
+            HorizontalDivider()
 
-                    Spacer(Modifier.width(Spacing.small))
-
-                    primaryButton(
+            // ── Interests ─────────────────────────────────────────────────────
+            Text(
+                text = stringResource("user.profile.interests"),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = stringResource("user.profile.interests.description"),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                verticalArrangement = Arrangement.spacedBy(Spacing.small),
+            ) {
+                UserInterestCategory.entries.forEach { category ->
+                    FilterChip(
+                        selected = category.key in selectedInterests,
                         onClick = {
-                            // Combine selected predefined interests with custom interests
-                            val allInterests = selectedInterests.toMutableSet()
-                            customInterests.split(",")
-                                .map { it.trim() }
-                                .filter { it.isNotBlank() }
-                                .forEach { allInterests.add(it) }
-
-                            val updatedPreferences = profile.preferences.toMutableMap()
-                            avatarPath?.let { updatedPreferences["avatarPath"] = it }
-
-                            val updatedProfile = profile.copy(
-                                name = name.ifBlank { null },
-                                email = email.ifBlank { null },
-                                occupation = occupation.ifBlank { null },
-                                location = location.ifBlank { null },
-                                bio = bio.ifBlank { null },
-                                interests = allInterests.toList(),
-                                preferences = updatedPreferences,
-                            )
-                            onSave(updatedProfile)
+                            selectedInterests = if (category.key in selectedInterests) {
+                                selectedInterests - category.key
+                            } else {
+                                selectedInterests + category.key
+                            }
                         },
-                    ) {
-                        Text(stringResource("action.save"))
-                    }
+                        label = { Text(stringResource(category.displayKey)) },
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    )
                 }
             }
-        }
-    }
+            OutlinedTextField(
+                value = customInterests,
+                onValueChange = { customInterests = it },
+                label = { Text(stringResource("user.profile.interests.custom")) },
+                placeholder = { Text(stringResource("user.profile.interests.custom.placeholder")) },
+                colors = AppComponents.outlinedTextFieldColors(),
+                modifier = Modifier.fillMaxWidth(),
+                supportingText = {
+                    Text(
+                        text = stringResource("user.profile.interests.custom.hint"),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                },
+            )
+        },
+    )
 }


### PR DESCRIPTION
- Extract reusable Popup composable into AppComponents, replacing scattered inline Popup usages in ChatInputField
- Remove ExperimentalFoundationApi opt-in annotations from Tooltip, NavigationSidebar, and TerminalPanel now that the API is stable
- Replace markdownText with plain Text in chat message previews to reduce rendering overhead and apply proper overflow/maxLines constraints
- Improve CodeViewerBlock horizontal scrollbar with hover-aware opacity, refined thickness, and shape styling via BoxWithConstraints
- Simplify UserProfileDialog layout by removing unused imports and add supporting hint text for the custom interests field