### PR TITLE
refactor(telemetry): migrate metrics from provider to instance-based tracking

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -667,7 +667,7 @@ object AppComponents {
     @Composable
     fun scaffoldDialog(
         onDismissRequest: () -> Unit,
-        actions: @Composable RowScope.() -> Unit,
+        actions: (@Composable RowScope.() -> Unit)? = null,
         modifier: Modifier = Modifier,
         width: Dp = 650.dp,
         maxHeightFraction: Float = 0.85f,
@@ -740,14 +740,16 @@ object AppComponents {
 
                             if (showSectionDividers) HorizontalDivider()
 
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .heightIn(min = dialogActionBarMinHeight),
-                                horizontalArrangement = Arrangement.End,
-                                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-                                content = actions,
-                            )
+                            if (actions != null) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .heightIn(min = dialogActionBarMinHeight),
+                                    horizontalArrangement = Arrangement.End,
+                                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+                                    content = actions,
+                                )
+                            }
                         }
                     }
                 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/discover/DiscoverView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/discover/DiscoverView.kt
@@ -367,7 +367,7 @@ private fun tokenUsageSection(
     onOpenSystemDiagnostics: () -> Unit,
 ) {
     val totalTokens = telemetryMetrics.totalTokensUsed
-    val topModels = telemetryMetrics.llmTokensByProvider
+    val topModels = telemetryMetrics.llmTokensByInstance
         .entries
         .sortedByDescending { it.value }
         .take(5)

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/service/TelemetryExportService.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/service/TelemetryExportService.kt
@@ -95,10 +95,10 @@ object TelemetryExportService {
         }
 
         // LLM summary metrics
-        if (metrics.llmCallsByProvider.isNotEmpty()) {
-            val totalCalls = metrics.llmCallsByProvider.values.sum()
-            val totalTokens = metrics.llmTokensByProvider.values.sum()
-            val totalErrors = metrics.llmErrorsByProvider.values.sum()
+        if (metrics.llmCallsByInstance.isNotEmpty()) {
+            val totalCalls = metrics.llmCallsByInstance.values.sum()
+            val totalTokens = metrics.llmTokensByInstance.values.sum()
+            val totalErrors = metrics.llmErrorsByInstance.values.sum()
             sw.appendCsvLine(capturedAt, "llm_total_calls", "LLM Total Calls", "count", LocalizationManager.formatNumber(totalCalls))
             sw.appendCsvLine(capturedAt, "llm_total_tokens", "LLM Total Tokens", "tokens", LocalizationManager.formatNumber(totalTokens))
             sw.appendCsvLine(capturedAt, "llm_total_errors", "LLM Total Errors", "count", LocalizationManager.formatNumber(totalErrors))
@@ -111,7 +111,7 @@ object TelemetryExportService {
         val sw = StringWriter()
         sw.appendCsvLine(
             "captured_at",
-            "provider",
+            "instance_or_provider",
             "model",
             "calls",
             "tokens",
@@ -119,17 +119,17 @@ object TelemetryExportService {
             "errors",
         )
 
-        metrics.llmCallsByProvider.forEach { (providerModel, calls) ->
-            val parts = providerModel.split(":", limit = 2)
-            val provider = parts.getOrElse(0) { providerModel }
+        metrics.llmCallsByInstance.forEach { (instanceModel, calls) ->
+            val parts = instanceModel.split(":", limit = 2)
+            val instanceOrProvider = parts.getOrElse(0) { instanceModel }
             val model = parts.getOrElse(1) { "" }
-            val tokens = metrics.llmTokensByProvider[providerModel] ?: 0L
-            val avgDurationMs = metrics.llmAvgDurationMsByProvider[providerModel] ?: 0L
-            val errors = metrics.llmErrorsByProvider[providerModel] ?: 0
+            val tokens = metrics.llmTokensByInstance[instanceModel] ?: 0L
+            val avgDurationMs = metrics.llmAvgDurationMsByInstance[instanceModel] ?: 0L
+            val errors = metrics.llmErrorsByInstance[instanceModel] ?: 0
 
             sw.appendCsvLine(
                 capturedAt,
-                provider,
+                instanceOrProvider,
                 model,
                 LocalizationManager.formatNumber(calls),
                 LocalizationManager.formatNumber(tokens),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/StarPromptDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/StarPromptDialog.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
@@ -45,8 +44,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import io.askimo.core.analytics.Analytics
 import io.askimo.core.analytics.AnalyticsEvent
 import io.askimo.core.service.StatsService
@@ -82,70 +79,64 @@ fun happinessGateDialog(
     onNeutral: () -> Unit,
     onUnhappy: () -> Unit,
 ) {
-    Dialog(
+    AppComponents.scaffoldDialog(
         onDismissRequest = {},
-        properties = DialogProperties(usePlatformDefaultWidth = false),
+        width = 480.dp,
     ) {
-        Surface(
-            modifier = Modifier.width(480.dp),
-            shape = MaterialTheme.shapes.large,
-            tonalElevation = 8.dp,
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Text(
+                text = "😊",
+                style = MaterialTheme.typography.displaySmall,
+            )
             Column(
-                modifier = Modifier.padding(28.dp),
-                verticalArrangement = Arrangement.spacedBy(20.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(Spacing.small),
             ) {
                 Text(
-                    text = "😊",
-                    style = MaterialTheme.typography.displaySmall,
+                    text = stringResource("happiness.gate.title"),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
                 )
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(Spacing.small),
-                ) {
-                    Text(
-                        text = stringResource("happiness.gate.title"),
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        textAlign = TextAlign.Center,
-                    )
-                    Text(
-                        text = stringResource("happiness.gate.subtitle"),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center,
-                    )
-                }
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.small),
-                ) {
-                    sentimentButton(
-                        label = stringResource("happiness.gate.happy"),
-                        onClick = {
-                            Analytics.track(AnalyticsEvent.USER_SENTIMENT_HAPPY)
-                            onHappy()
-                        },
-                        containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    )
-                    sentimentButton(
-                        label = stringResource("happiness.gate.neutral"),
-                        onClick = {
-                            Analytics.track(AnalyticsEvent.USER_SENTIMENT_NEUTRAL)
-                            onNeutral()
-                        },
-                    )
-                    sentimentButton(
-                        label = stringResource("happiness.gate.unhappy"),
-                        onClick = {
-                            Analytics.track(AnalyticsEvent.USER_SENTIMENT_UNHAPPY)
-                            onUnhappy()
-                        },
-                    )
-                }
+                Text(
+                    text = stringResource("happiness.gate.subtitle"),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(Spacing.small),
+            ) {
+                sentimentButton(
+                    label = stringResource("happiness.gate.happy"),
+                    onClick = {
+                        Analytics.track(AnalyticsEvent.USER_SENTIMENT_HAPPY)
+                        onHappy()
+                    },
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                sentimentButton(
+                    label = stringResource("happiness.gate.neutral"),
+                    onClick = {
+                        Analytics.track(AnalyticsEvent.USER_SENTIMENT_NEUTRAL)
+                        onNeutral()
+                    },
+                )
+                sentimentButton(
+                    label = stringResource("happiness.gate.unhappy"),
+                    onClick = {
+                        Analytics.track(AnalyticsEvent.USER_SENTIMENT_UNHAPPY)
+                        onUnhappy()
+                    },
+                )
             }
         }
     }
@@ -205,188 +196,182 @@ fun feedbackPromptDialog(
     var submitted by remember { mutableStateOf(false) }
     var showReminder by remember { mutableStateOf(false) }
 
-    Dialog(
+    AppComponents.scaffoldDialog(
         onDismissRequest = {},
-        properties = DialogProperties(usePlatformDefaultWidth = false),
+        width = 700.dp,
     ) {
-        Surface(
-            modifier = Modifier.width(700.dp),
-            shape = MaterialTheme.shapes.large,
-            tonalElevation = 8.dp,
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Column(
-                modifier = Modifier.padding(28.dp),
-                verticalArrangement = Arrangement.spacedBy(20.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                when {
-                    submitted -> {
-                        // ── Thank-you screen ───────────────────────────────────
-                        Text(text = "🙏", style = MaterialTheme.typography.displaySmall)
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(Spacing.small),
-                        ) {
-                            Text(
-                                text = stringResource("feedback.thanks.title"),
-                                style = MaterialTheme.typography.titleLarge,
-                                fontWeight = FontWeight.SemiBold,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                textAlign = TextAlign.Center,
-                            )
-                            Text(
-                                text = stringResource("feedback.thanks.message"),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                textAlign = TextAlign.Center,
-                            )
-                        }
-                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                            TextButton(onClick = onClose, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
-                                Text(text = stringResource("feedback.thanks.close"), style = MaterialTheme.typography.bodySmall)
-                            }
+            when {
+                submitted -> {
+                    // ── Thank-you screen ───────────────────────────────────
+                    Text(text = "🙏", style = MaterialTheme.typography.displaySmall)
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                    ) {
+                        Text(
+                            text = stringResource("feedback.thanks.title"),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Center,
+                        )
+                        Text(
+                            text = stringResource("feedback.thanks.message"),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                        TextButton(onClick = onClose, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
+                            Text(text = stringResource("feedback.thanks.close"), style = MaterialTheme.typography.bodySmall)
                         }
                     }
+                }
 
-                    showReminder -> {
-                        // ── Skip reminder screen ───────────────────────────────
-                        Text(text = "💡", style = MaterialTheme.typography.displaySmall)
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(Spacing.small),
-                        ) {
-                            Text(
-                                text = stringResource("feedback.remind.title"),
-                                style = MaterialTheme.typography.titleLarge,
-                                fontWeight = FontWeight.SemiBold,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                textAlign = TextAlign.Center,
-                            )
-                            Text(
-                                text = stringResource("feedback.remind.message"),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                textAlign = TextAlign.Center,
-                            )
-                        }
-                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                            TextButton(onClick = onSnooze, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
-                                Text(text = stringResource("feedback.remind.got.it"), style = MaterialTheme.typography.bodySmall)
-                            }
+                showReminder -> {
+                    // ── Skip reminder screen ───────────────────────────────
+                    Text(text = "💡", style = MaterialTheme.typography.displaySmall)
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                    ) {
+                        Text(
+                            text = stringResource("feedback.remind.title"),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Center,
+                        )
+                        Text(
+                            text = stringResource("feedback.remind.message"),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                        TextButton(onClick = onSnooze, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
+                            Text(text = stringResource("feedback.remind.got.it"), style = MaterialTheme.typography.bodySmall)
                         }
                     }
+                }
 
-                    else -> {
-                        // ── Input screen ───────────────────────────────────────
-                        Text(text = "💬", style = MaterialTheme.typography.displaySmall)
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(Spacing.small),
-                        ) {
-                            Text(
-                                text = stringResource("feedback.dialog.title"),
-                                style = MaterialTheme.typography.titleLarge,
-                                fontWeight = FontWeight.SemiBold,
-                                color = MaterialTheme.colorScheme.onSurface,
-                                textAlign = TextAlign.Center,
-                            )
-                            Text(
-                                text = stringResource("feedback.dialog.subtitle"),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                textAlign = TextAlign.Center,
-                            )
-                        }
-                        // ── Reason chips (2-column grid) ───────────────────────
-                        Column(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalArrangement = Arrangement.spacedBy(Spacing.small),
-                        ) {
-                            FeedbackReason.entries.chunked(2).forEach { row ->
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.spacedBy(Spacing.small),
-                                ) {
-                                    row.forEach { reason ->
-                                        feedbackReasonChip(
-                                            reason = reason,
-                                            selected = reason in selectedReasons,
-                                            onToggle = {
-                                                selectedReasons = if (reason in selectedReasons) {
-                                                    selectedReasons - reason
-                                                } else {
-                                                    selectedReasons + reason
-                                                }
-                                            },
-                                            modifier = Modifier.weight(1f),
-                                        )
-                                    }
-                                    if (row.size == 1) Spacer(modifier = Modifier.weight(1f))
+                else -> {
+                    // ── Input screen ───────────────────────────────────────
+                    Text(text = "💬", style = MaterialTheme.typography.displaySmall)
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                    ) {
+                        Text(
+                            text = stringResource("feedback.dialog.title"),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Center,
+                        )
+                        Text(
+                            text = stringResource("feedback.dialog.subtitle"),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                    // ── Reason chips (2-column grid) ───────────────────────
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                    ) {
+                        FeedbackReason.entries.chunked(2).forEach { row ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                            ) {
+                                row.forEach { reason ->
+                                    feedbackReasonChip(
+                                        reason = reason,
+                                        selected = reason in selectedReasons,
+                                        onToggle = {
+                                            selectedReasons = if (reason in selectedReasons) {
+                                                selectedReasons - reason
+                                            } else {
+                                                selectedReasons + reason
+                                            }
+                                        },
+                                        modifier = Modifier.weight(1f),
+                                    )
                                 }
+                                if (row.size == 1) Spacer(modifier = Modifier.weight(1f))
                             }
                         }
-                        // ── Optional comment ───────────────────────────────────
-                        OutlinedTextField(
-                            value = comment,
-                            onValueChange = { comment = it },
-                            modifier = Modifier.fillMaxWidth(),
-                            label = {
-                                Text(text = stringResource("feedback.comment.label"), style = MaterialTheme.typography.bodySmall)
-                            },
-                            placeholder = {
-                                Text(text = stringResource("feedback.comment.placeholder"), style = MaterialTheme.typography.bodySmall)
-                            },
-                            minLines = 3,
-                            maxLines = 5,
-                            shape = MaterialTheme.shapes.medium,
-                        )
-                        // ── Optional email ─────────────────────────────────────
-                        OutlinedTextField(
-                            value = email,
-                            onValueChange = { email = it },
-                            modifier = Modifier.fillMaxWidth(),
-                            label = {
-                                Text(text = stringResource("feedback.email.label"), style = MaterialTheme.typography.bodySmall)
-                            },
-                            placeholder = {
-                                Text(text = stringResource("feedback.email.placeholder"), style = MaterialTheme.typography.bodySmall)
-                            },
-                            supportingText = {
-                                Text(
-                                    text = stringResource("feedback.email.hint"),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            },
-                            singleLine = true,
-                            shape = MaterialTheme.shapes.medium,
-                        )
-                        // ── Action buttons ─────────────────────────────────────
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
+                    }
+                    // ── Optional comment ───────────────────────────────────
+                    OutlinedTextField(
+                        value = comment,
+                        onValueChange = { comment = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = {
+                            Text(text = stringResource("feedback.comment.label"), style = MaterialTheme.typography.bodySmall)
+                        },
+                        placeholder = {
+                            Text(text = stringResource("feedback.comment.placeholder"), style = MaterialTheme.typography.bodySmall)
+                        },
+                        minLines = 3,
+                        maxLines = 5,
+                        shape = MaterialTheme.shapes.medium,
+                    )
+                    // ── Optional email ─────────────────────────────────────
+                    OutlinedTextField(
+                        value = email,
+                        onValueChange = { email = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = {
+                            Text(text = stringResource("feedback.email.label"), style = MaterialTheme.typography.bodySmall)
+                        },
+                        placeholder = {
+                            Text(text = stringResource("feedback.email.placeholder"), style = MaterialTheme.typography.bodySmall)
+                        },
+                        supportingText = {
+                            Text(
+                                text = stringResource("feedback.email.hint"),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        singleLine = true,
+                        shape = MaterialTheme.shapes.medium,
+                    )
+                    // ── Action buttons ─────────────────────────────────────
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        TextButton(
+                            onClick = { if (showReminderOnSkip) showReminder = true else onSnooze() },
+                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                         ) {
-                            TextButton(
-                                onClick = { if (showReminderOnSkip) showReminder = true else onSnooze() },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                            ) {
-                                Text(
-                                    text = stringResource("feedback.action.skip"),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                            Button(
-                                onClick = {
-                                    onSubmit(selectedReasons, comment.trim(), email.trim())
-                                    submitted = true
-                                },
-                                enabled = selectedReasons.isNotEmpty() || comment.isNotBlank(),
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                            ) {
-                                Text(text = stringResource("feedback.action.send"), style = MaterialTheme.typography.labelLarge)
-                            }
+                            Text(
+                                text = stringResource("feedback.action.skip"),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Button(
+                            onClick = {
+                                onSubmit(selectedReasons, comment.trim(), email.trim())
+                                submitted = true
+                            },
+                            enabled = selectedReasons.isNotEmpty() || comment.isNotBlank(),
+                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Text(text = stringResource("feedback.action.send"), style = MaterialTheme.typography.labelLarge)
                         }
                     }
                 }
@@ -455,168 +440,162 @@ fun starPromptDialog(
         }
     }
 
-    Dialog(
+    AppComponents.scaffoldDialog(
         onDismissRequest = {},
-        properties = DialogProperties(usePlatformDefaultWidth = false),
+        width = 700.dp,
     ) {
-        Surface(
-            modifier = Modifier.width(700.dp),
-            shape = MaterialTheme.shapes.large,
-            tonalElevation = 8.dp,
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            Column(
-                modifier = Modifier.padding(Spacing.extraLarge),
-                verticalArrangement = Arrangement.spacedBy(20.dp),
-            ) {
-                if (thanked) {
-                    // ── Thank-you screen ───────────────────────────────────
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(Spacing.medium),
+            if (thanked) {
+                // ── Thank-you screen ───────────────────────────────────
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(Spacing.medium),
+                ) {
+                    Text(
+                        text = "🙏",
+                        style = MaterialTheme.typography.displaySmall,
+                    )
+                    Text(
+                        text = stringResource("star.prompt.thanks.title"),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = stringResource("star.prompt.thanks.message"),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(
+                        onClick = onAlreadyStarred,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
-                            text = "🙏",
-                            style = MaterialTheme.typography.displaySmall,
-                        )
-                        Text(
-                            text = stringResource("star.prompt.thanks.title"),
-                            style = MaterialTheme.typography.titleLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            textAlign = TextAlign.Center,
-                        )
-                        Text(
-                            text = stringResource("star.prompt.thanks.message"),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            textAlign = TextAlign.Center,
+                            text = stringResource("star.prompt.thanks.done"),
+                            style = MaterialTheme.typography.bodySmall,
                         )
                     }
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
+                }
+            } else if (showReminder) {
+                // ── Maybe-later reminder screen ────────────────────────
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(Spacing.medium),
+                ) {
+                    Text(
+                        text = "💡",
+                        style = MaterialTheme.typography.displaySmall,
+                    )
+                    Text(
+                        text = stringResource("star.prompt.remind.title"),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = stringResource("star.prompt.remind.message"),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
-                        TextButton(
-                            onClick = onAlreadyStarred,
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        ) {
-                            Text(
-                                text = stringResource("star.prompt.thanks.done"),
-                                style = MaterialTheme.typography.bodySmall,
-                            )
-                        }
-                    }
-                } else if (showReminder) {
-                    // ── Maybe-later reminder screen ────────────────────────
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(Spacing.medium),
-                    ) {
                         Text(
-                            text = "💡",
-                            style = MaterialTheme.typography.displaySmall,
-                        )
-                        Text(
-                            text = stringResource("star.prompt.remind.title"),
-                            style = MaterialTheme.typography.titleLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            textAlign = TextAlign.Center,
-                        )
-                        Text(
-                            text = stringResource("star.prompt.remind.message"),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            textAlign = TextAlign.Center,
+                            text = stringResource("star.prompt.remind.got.it"),
+                            style = MaterialTheme.typography.bodySmall,
                         )
                     }
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
-                    ) {
-                        TextButton(
-                            onClick = onDismiss,
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        ) {
-                            Text(
-                                text = stringResource("star.prompt.remind.got.it"),
-                                style = MaterialTheme.typography.bodySmall,
-                            )
-                        }
-                    }
-                } else {
-                    // ── Default screen ─────────────────────────────────────
-                    Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+                }
+            } else {
+                // ── Default screen ─────────────────────────────────────
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+                    Text(
+                        text = stringResource("star.prompt.title"),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = stringResource("star.prompt.message"),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    val count = starCount
+                    if (count != null) {
                         Text(
-                            text = stringResource("star.prompt.title"),
-                            style = MaterialTheme.typography.titleLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface,
+                            text = stringResource("star.prompt.social.proof", count),
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.secondary,
                         )
-                        Text(
-                            text = stringResource("star.prompt.message"),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        val count = starCount
-                        if (count != null) {
-                            Text(
-                                text = stringResource("star.prompt.social.proof", count),
-                                style = MaterialTheme.typography.labelMedium,
-                                fontWeight = FontWeight.Medium,
-                                color = MaterialTheme.colorScheme.secondary,
-                            )
-                        }
                     }
+                }
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(Spacing.medium),
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.medium),
+                ) {
+                    supportActionCard(
+                        icon = Icons.Default.Star,
+                        iconTint = Color(0xFFFFC107),
+                        label = stringResource("star.prompt.star.button"),
+                        description = stringResource("star.prompt.star.description"),
+                        onClick = {
+                            onStar()
+                            thanked = true
+                        },
+                        modifier = Modifier.weight(1f),
+                    )
+                    shareActionCard(
+                        onShared = { thanked = true },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(
+                        onClick = onAlreadyStarred,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
-                        supportActionCard(
-                            icon = Icons.Default.Star,
-                            iconTint = Color(0xFFFFC107),
-                            label = stringResource("star.prompt.star.button"),
-                            description = stringResource("star.prompt.star.description"),
-                            onClick = {
-                                onStar()
-                                thanked = true
-                            },
-                            modifier = Modifier.weight(1f),
-                        )
-                        shareActionCard(
-                            onShared = { thanked = true },
-                            modifier = Modifier.weight(1f),
+                        Text(
+                            text = stringResource("star.prompt.already.starred"),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
+                    TextButton(
+                        onClick = { if (showReminderOnMaybeLater) showReminder = true else onDismiss() },
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
-                        TextButton(
-                            onClick = onAlreadyStarred,
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        ) {
-                            Text(
-                                text = stringResource("star.prompt.already.starred"),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        TextButton(
-                            onClick = { if (showReminderOnMaybeLater) showReminder = true else onDismiss() },
-                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        ) {
-                            Text(
-                                text = stringResource("star.prompt.maybe.later"),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
+                        Text(
+                            text = stringResource("star.prompt.maybe.later"),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
                     }
                 }
             }

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1038,7 +1038,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=Total Queries
 telemetry.rag.triggered.label=Triggered
 telemetry.rag.skipped.label=Skipped
-telemetry.llm.col.provider=Provider
+telemetry.llm.col.instance=Instance
 telemetry.llm.col.model=Model
 telemetry.llm.col.calls=Calls
 telemetry.llm.col.tokens=Tokens
@@ -1117,17 +1117,6 @@ error.indexing.io_error.title=IO Error
 error.indexing.io_error.message=An IO error occurred during indexing
 error.indexing.unknown.title=Indexing Error
 error.indexing.unknown.message=An unknown error occurred during indexing
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=Embedding Model Status (Required for RAG Features Only)
-settings.embedding.not_available_rag_only=⚠️ {0}.\n\nNote: This only affects project-based RAG features. Regular chat functionality will work normally.
-settings.embedding.provider_unreachable=⚠️ Cannot connect to provider: {0}.\n\nNote: Embedding models are only needed for project-based RAG features.
-settings.embedding.check_failed=Failed to check embedding model: {0}
-settings.embedding.download_success=✅ Successfully downloaded embedding model: {0}
-settings.embedding.download_failed=❌ Failed to download embedding model: {0}. Please try manually: ollama pull {0}
-settings.embedding.download_error=Error downloading model: {0}
-settings.embedding.anthropic_no_embedding=Anthropic does not provide embedding models
-settings.embedding.xai_no_embedding=xAI does not provide embedding models
 
 # RAG Configuration
 settings.rag.title=RAG Configuration

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1028,7 +1028,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=Gesamte Anfragen
 telemetry.rag.triggered.label=Ausgelöst
 telemetry.rag.skipped.label=Übersprungen
-telemetry.llm.col.provider=Anbieter
+telemetry.llm.col.instance=Instanz
 telemetry.llm.col.model=Modell
 telemetry.llm.col.calls=Aufrufe
 telemetry.llm.col.tokens=Tokens
@@ -1109,18 +1109,6 @@ error.indexing.io_error.title=E/A-Fehler
 error.indexing.io_error.message=Während der Indexierung ist ein E/A-Fehler aufgetreten
 error.indexing.unknown.title=Indexierungsfehler
 error.indexing.unknown.message=Während der Indexierung ist ein unbekannter Fehler aufgetreten
-
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=Status des Einbettungsmodells (nur für RAG-Funktionen erforderlich)
-settings.embedding.not_available_rag_only=⚠️ {0}.\n\nHinweis: Dies betrifft nur projektbasierte RAG-Funktionen. Normale Chat-Funktionen bleiben unbeeinträchtigt.
-settings.embedding.provider_unreachable=⚠️ Verbindung zum Anbieter nicht möglich: {0}.\n\nHinweis: Einbettungsmodelle werden nur für projektbasierte RAG-Funktionen benötigt.
-settings.embedding.check_failed=Überprüfung des Einbettungsmodells fehlgeschlagen: {0}
-settings.embedding.download_success=✅ Einbettungsmodell erfolgreich heruntergeladen: {0}
-settings.embedding.download_failed=❌ Einbettungsmodell konnte nicht heruntergeladen werden: {0}. Bitte manuell versuchen: ollama pull {0}
-settings.embedding.download_error=Fehler beim Herunterladen des Modells: {0}
-settings.embedding.anthropic_no_embedding=Anthropic stellt keine Einbettungsmodelle bereit
-settings.embedding.xai_no_embedding=xAI stellt keine Einbettungsmodelle bereit
 
 # RAG Configuration
 settings.rag.title=RAG-Konfiguration

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1023,7 +1023,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=Consultas Totales
 telemetry.rag.triggered.label=Activado
 telemetry.rag.skipped.label=Omitido
-telemetry.llm.col.provider=Proveedor
+telemetry.llm.col.instance=Instancia
 telemetry.llm.col.model=Modelo
 telemetry.llm.col.calls=Llamadas
 telemetry.llm.col.tokens=Tokens
@@ -1102,18 +1102,6 @@ error.indexing.io_error.title=Error de E/S
 error.indexing.io_error.message=Se produjo un error de E/S durante la indexación
 error.indexing.unknown.title=Error de indexación
 error.indexing.unknown.message=Se produjo un error desconocido durante la indexación
-
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=Estado del modelo de incrustación (solo requerido para funciones RAG)
-settings.embedding.not_available_rag_only=⚠️ {0}.\n\nNota: Esto solo afecta a las funciones RAG basadas en proyectos. El chat normal seguirá funcionando.
-settings.embedding.provider_unreachable=⚠️ No se puede conectar con el proveedor: {0}.\n\nNota: Los modelos de incrustación solo son necesarios para funciones RAG basadas en proyectos.
-settings.embedding.check_failed=No se pudo verificar el modelo de incrustación: {0}
-settings.embedding.download_success=✅ Modelo de incrustación descargado correctamente: {0}
-settings.embedding.download_failed=❌ No se pudo descargar el modelo de incrustación: {0}. Intente manualmente: ollama pull {0}
-settings.embedding.download_error=Error al descargar el modelo: {0}
-settings.embedding.anthropic_no_embedding=Anthropic no proporciona modelos de incrustación
-settings.embedding.xai_no_embedding=xAI no proporciona modelos de incrustación
 
 # RAG Configuration
 settings.rag.title=Configuración de RAG

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1023,7 +1023,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=Requêtes Totales
 telemetry.rag.triggered.label=Déclenché
 telemetry.rag.skipped.label=Ignoré
-telemetry.llm.col.provider=Fournisseur
+telemetry.llm.col.instance=Instance
 telemetry.llm.col.model=Modèle
 telemetry.llm.col.calls=Appels
 telemetry.llm.col.tokens=Tokens
@@ -1103,18 +1103,6 @@ error.indexing.io_error.title=Erreur d’E/S
 error.indexing.io_error.message=Une erreur d’E/S s’est produite lors de l’indexation
 error.indexing.unknown.title=Erreur d’indexation
 error.indexing.unknown.message=Une erreur inconnue s’est produite lors de l’indexation
-
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=État du modèle d’embedding (requis uniquement pour les fonctionnalités RAG)
-settings.embedding.not_available_rag_only=⚠️ {0}.\n\nRemarque : cela affecte uniquement les fonctionnalités RAG basées sur les projets. Le chat standard fonctionne normalement.
-settings.embedding.provider_unreachable=⚠️ Impossible de se connecter au fournisseur : {0}.\n\nRemarque : les modèles d’embedding sont nécessaires uniquement pour les fonctionnalités RAG basées sur les projets.
-settings.embedding.check_failed=Échec de la vérification du modèle d’embedding : {0}
-settings.embedding.download_success=✅ Modèle d’embedding téléchargé avec succès : {0}
-settings.embedding.download_failed=❌ Échec du téléchargement du modèle d’embedding : {0}. Veuillez essayer manuellement : ollama pull {0}
-settings.embedding.download_error=Erreur lors du téléchargement du modèle : {0}
-settings.embedding.anthropic_no_embedding=Anthropic ne fournit pas de modèles d’embedding
-settings.embedding.xai_no_embedding=xAI ne fournit pas de modèles d’embedding
 
 # RAG Configuration
 settings.rag.title=Configuration RAG

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1023,7 +1023,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=総クエリ数
 telemetry.rag.triggered.label=トリガー済み
 telemetry.rag.skipped.label=スキップ済み
-telemetry.llm.col.provider=プロバイダー
+telemetry.llm.col.instance=インスタンス
 telemetry.llm.col.model=モデル
 telemetry.llm.col.calls=呼び出し
 telemetry.llm.col.tokens=トークン
@@ -1104,18 +1104,6 @@ error.indexing.io_error.title=IO エラー
 error.indexing.io_error.message=インデックス作成中に IO エラーが発生しました
 error.indexing.unknown.title=インデックスエラー
 error.indexing.unknown.message=インデックス作成中に不明なエラーが発生しました
-
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=埋め込みモデルの状態（RAG 機能専用）
-settings.embedding.not_available_rag_only=⚠️ {0}。\n\n注意：これはプロジェクトベースの RAG 機能にのみ影響します。通常のチャット機能は問題なく動作します。
-settings.embedding.provider_unreachable=⚠️ プロバイダーに接続できません：{0}。\n\n注意：埋め込みモデルはプロジェクトベースの RAG 機能にのみ必要です。
-settings.embedding.check_failed=埋め込みモデルの確認に失敗しました：{0}
-settings.embedding.download_success=✅ 埋め込みモデルを正常にダウンロードしました：{0}
-settings.embedding.download_failed=❌ 埋め込みモデルのダウンロードに失敗しました：{0}。手動でお試しください：ollama pull {0}
-settings.embedding.download_error=モデルのダウンロード中にエラーが発生しました：{0}
-settings.embedding.anthropic_no_embedding=Anthropic は埋め込みモデルを提供していません
-settings.embedding.xai_no_embedding=xAI は埋め込みモデルを提供していません
 
 # RAG Configuration
 settings.rag.title=RAG 設定

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1023,7 +1023,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=총 쿼리
 telemetry.rag.triggered.label=트리거됨
 telemetry.rag.skipped.label=건너뜀
-telemetry.llm.col.provider=제공자
+telemetry.llm.col.instance=인스턴스
 telemetry.llm.col.model=모델
 telemetry.llm.col.calls=호출
 telemetry.llm.col.tokens=토큰
@@ -1103,18 +1103,6 @@ error.indexing.io_error.title=IO 오류
 error.indexing.io_error.message=인덱싱 중 IO 오류가 발생했습니다
 error.indexing.unknown.title=인덱싱 오류
 error.indexing.unknown.message=인덱싱 중 알 수 없는 오류가 발생했습니다
-
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=임베딩 모델 상태 (RAG 기능에만 필요)
-settings.embedding.not_available_rag_only=⚠️ {0}.\n\n참고: 이는 프로젝트 기반 RAG 기능에만 영향을 미칩니다. 일반 채팅 기능은 정상적으로 작동합니다.
-settings.embedding.provider_unreachable=⚠️ 제공자에 연결할 수 없습니다: {0}.\n\n참고: 임베딩 모델은 프로젝트 기반 RAG 기능에만 필요합니다.
-settings.embedding.check_failed=임베딩 모델 확인 실패: {0}
-settings.embedding.download_success=✅ 임베딩 모델을 성공적으로 다운로드했습니다: {0}
-settings.embedding.download_failed=❌ 임베딩 모델 다운로드에 실패했습니다: {0}. 수동으로 시도하세요: ollama pull {0}
-settings.embedding.download_error=모델 다운로드 중 오류 발생: {0}
-settings.embedding.anthropic_no_embedding=Anthropic은 임베딩 모델을 제공하지 않습니다
-settings.embedding.xai_no_embedding=xAI는 임베딩 모델을 제공하지 않습니다
 
 # RAG Configuration
 settings.rag.title=RAG 구성

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1026,7 +1026,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=Consultas Totais
 telemetry.rag.triggered.label=Acionado
 telemetry.rag.skipped.label=Ignorado
-telemetry.llm.col.provider=Provedor
+telemetry.llm.col.instance=Instância
 telemetry.llm.col.model=Modelo
 telemetry.llm.col.calls=Chamadas
 telemetry.llm.col.tokens=Tokens
@@ -1106,18 +1106,6 @@ error.indexing.io_error.title=Erro de IO
 error.indexing.io_error.message=Ocorreu um erro de IO durante a indexação
 error.indexing.unknown.title=Erro de indexação
 error.indexing.unknown.message=Ocorreu um erro desconhecido durante a indexação
-
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=Status do modelo de embedding (necessário apenas para recursos RAG)
-settings.embedding.not_available_rag_only=⚠️ {0}.\n\nNota: Isso afeta apenas recursos RAG baseados em projetos. O chat normal continuará funcionando.
-settings.embedding.provider_unreachable=⚠️ Não foi possível conectar ao provedor: {0}.\n\nNota: Modelos de embedding são necessários apenas para recursos RAG baseados em projetos.
-settings.embedding.check_failed=Falha ao verificar o modelo de embedding: {0}
-settings.embedding.download_success=✅ Modelo de embedding baixado com sucesso: {0}
-settings.embedding.download_failed=❌ Falha ao baixar o modelo de embedding: {0}. Tente manualmente: ollama pull {0}
-settings.embedding.download_error=Erro ao baixar o modelo: {0}
-settings.embedding.anthropic_no_embedding=Anthropic não fornece modelos de embedding
-settings.embedding.xai_no_embedding=xAI não fornece modelos de embedding
 
 # RAG Configuration
 settings.rag.title=Configuração de RAG

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1022,7 +1022,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=Tổng số truy vấn
 telemetry.rag.triggered.label=Đã kích hoạt
 telemetry.rag.skipped.label=Đã bỏ qua
-telemetry.llm.col.provider=Nhà cung cấp
+telemetry.llm.col.instance=Instance
 telemetry.llm.col.model=Mô hình
 telemetry.llm.col.calls=Cuộc gọi
 telemetry.llm.col.tokens=Token
@@ -1102,18 +1102,6 @@ error.indexing.io_error.title=Lỗi IO
 error.indexing.io_error.message=Đã xảy ra lỗi IO trong quá trình lập chỉ mục
 error.indexing.unknown.title=Lỗi lập chỉ mục
 error.indexing.unknown.message=Đã xảy ra lỗi không xác định trong quá trình lập chỉ mục
-
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=Trạng thái mô hình embedding (chỉ cần cho tính năng RAG)
-settings.embedding.not_available_rag_only=⚠️ {0}.\n\nLưu ý: Điều này chỉ ảnh hưởng đến các tính năng RAG theo dự án. Chức năng trò chuyện thông thường vẫn hoạt động bình thường.
-settings.embedding.provider_unreachable=⚠️ Không thể kết nối tới nhà cung cấp: {0}.\n\nLưu ý: Mô hình embedding chỉ cần cho các tính năng RAG theo dự án.
-settings.embedding.check_failed=Không thể kiểm tra mô hình embedding: {0}
-settings.embedding.download_success=✅ Đã tải thành công mô hình embedding: {0}
-settings.embedding.download_failed=❌ Không thể tải mô hình embedding: {0}. Vui lòng thử thủ công: ollama pull {0}
-settings.embedding.download_error=Lỗi khi tải mô hình: {0}
-settings.embedding.anthropic_no_embedding=Anthropic không cung cấp mô hình embedding
-settings.embedding.xai_no_embedding=xAI không cung cấp mô hình embedding
 
 # RAG Configuration
 settings.rag.title=Cấu hình RAG

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1023,7 +1023,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=总查询数
 telemetry.rag.triggered.label=已触发
 telemetry.rag.skipped.label=已跳过
-telemetry.llm.col.provider=提供商
+telemetry.llm.col.instance=实例
 telemetry.llm.col.model=模型
 telemetry.llm.col.calls=调用
 telemetry.llm.col.tokens=Token
@@ -1104,18 +1104,6 @@ error.indexing.io_error.title=IO 错误
 error.indexing.io_error.message=索引过程中发生 IO 错误
 error.indexing.unknown.title=索引错误
 error.indexing.unknown.message=索引过程中发生未知错误
-
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=嵌入模型状态（仅用于 RAG 功能）
-settings.embedding.not_available_rag_only=⚠️ {0}。\n\n说明：这只影响基于项目的 RAG 功能，普通聊天功能可正常使用。
-settings.embedding.provider_unreachable=⚠️ 无法连接到提供商：{0}。\n\n说明：嵌入模型仅用于基于项目的 RAG 功能。
-settings.embedding.check_failed=检查嵌入模型失败：{0}
-settings.embedding.download_success=✅ 已成功下载嵌入模型：{0}
-settings.embedding.download_failed=❌ 下载嵌入模型失败：{0}。请手动尝试：ollama pull {0}
-settings.embedding.download_error=下载模型时出错：{0}
-settings.embedding.anthropic_no_embedding=Anthropic 不提供嵌入模型
-settings.embedding.xai_no_embedding=xAI 不提供嵌入模型
 
 # RAG Configuration
 settings.rag.title=RAG 配置

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1023,7 +1023,7 @@ telemetry.tab.llm=LLM
 telemetry.rag.total.queries=總查詢數
 telemetry.rag.triggered.label=已觸發
 telemetry.rag.skipped.label=已跳過
-telemetry.llm.col.provider=提供者
+telemetry.llm.col.instance=Instance
 telemetry.llm.col.model=模型
 telemetry.llm.col.calls=呼叫
 telemetry.llm.col.tokens=Token
@@ -1105,18 +1105,6 @@ error.indexing.io_error.title=IO 錯誤
 error.indexing.io_error.message=索引過程中發生 IO 錯誤
 error.indexing.unknown.title=索引錯誤
 error.indexing.unknown.message=索引過程中發生未知錯誤
-
-
-# Settings - Embedding Models (for RAG features)
-settings.embedding.rag_feature_only=嵌入模型狀態（僅供 RAG 功能使用）
-settings.embedding.not_available_rag_only=⚠️ {0}。\n\n說明：此問題僅影響以專案為基礎的 RAG 功能，一般聊天功能可正常使用。
-settings.embedding.provider_unreachable=⚠️ 無法連線至提供商：{0}。\n\n說明：嵌入模型僅用於以專案為基礎的 RAG 功能。
-settings.embedding.check_failed=檢查嵌入模型失敗：{0}
-settings.embedding.download_success=✅ 已成功下載嵌入模型：{0}
-settings.embedding.download_failed=❌ 無法下載嵌入模型：{0}。請手動嘗試：ollama pull {0}
-settings.embedding.download_error=下載模型時發生錯誤：{0}
-settings.embedding.anthropic_no_embedding=Anthropic 不提供嵌入模型
-settings.embedding.xai_no_embedding=xAI 不提供嵌入模型
 
 # RAG Configuration
 settings.rag.title=RAG 設定

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -88,8 +88,8 @@ import io.askimo.desktop.project.editProjectDialog
 import io.askimo.desktop.project.newProjectDialog
 import io.askimo.desktop.project.projectView
 import io.askimo.desktop.project.projectsView
+import io.askimo.desktop.settings.AIProviderViewModel
 import io.askimo.desktop.settings.SettingsSection
-import io.askimo.desktop.settings.SettingsViewModel
 import io.askimo.desktop.settings.aboutDialog
 import io.askimo.desktop.settings.fileViewerDialog
 import io.askimo.desktop.settings.providerWizardDialog
@@ -290,7 +290,7 @@ fun main(args: Array<String>) {
             icon = icon,
             onCloseRequest = {
                 val messageCount = runCatching {
-                    AppContext.getInstance().telemetry.metricsFlow.value.llmCallsByProvider.values.sum()
+                    AppContext.getInstance().telemetry.metricsFlow.value.llmCallsByInstance.values.sum()
                 }.getOrDefault(0)
                 Analytics.trackSessionEnd(messageCount)
                 Analytics.shutdown()
@@ -504,7 +504,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
     val projectsViewModel = remember { koin.get<ProjectsViewModel> { parametersOf(scope) } }
     val plansViewModel = remember { koin.get<PlansViewModel> { parametersOf(scope) } }
     val discoverViewModel = remember { koin.get<DiscoverViewModel> { parametersOf(scope) } }
-    val settingsViewModel = remember { koin.get<SettingsViewModel> { parametersOf(scope) } }
+    val settingsViewModel = remember { koin.get<AIProviderViewModel> { parametersOf(scope) } }
     val updateViewModel = remember { koin.get<UpdateViewModel> { parametersOf(scope) } }
 
     val deleteSessionCommand = remember {

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/EditProjectDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/EditProjectDialog.kt
@@ -123,7 +123,7 @@ fun editProjectDialog(
                         CircularProgressIndicator()
                     }
                 },
-                actions = {},
+                actions = null,
             )
         }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderViewModel.kt
@@ -216,6 +216,3 @@ class AIProviderViewModel(
         showSuccessMessage = true
     }
 }
-
-/** Backward-compat alias — prefer [AIProviderViewModel] in new code. */
-typealias SettingsViewModel = AIProviderViewModel

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
@@ -220,7 +220,7 @@ fun providerWizardDialog(viewModel: ProviderWizardViewModel) {
                             enabled = viewModel.connectionTestSuccess && !viewModel.isFetchingModelsForConfig,
                         ) {
                             if (viewModel.isFetchingModelsForConfig) {
-                                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.surface)
                                 Spacer(Modifier.width(Spacing.small))
                             }
                             Text(stringResource("action.next"))
@@ -232,7 +232,7 @@ fun providerWizardDialog(viewModel: ProviderWizardViewModel) {
                             enabled = !viewModel.isTestingConnection && !viewModel.isFetchingModelsForConfig,
                         ) {
                             if (viewModel.isTestingConnection) {
-                                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
+                                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.surface)
                                 Spacer(Modifier.width(Spacing.small))
                             }
                             Text(stringResource("settings.save"))
@@ -711,22 +711,6 @@ private fun instanceConfigScreen(viewModel: ProviderWizardViewModel) {
                             viewModel.connectionErrorHelp?.let {
                                 Spacer(Modifier.height(Spacing.extraSmall))
                                 Text(text = it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f))
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Embedding model warning
-            if (viewModel.embeddingModelWarning != null) {
-                Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)) {
-                    Column(modifier = Modifier.fillMaxWidth().padding(Spacing.medium), verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
-                        Row(horizontalArrangement = Arrangement.spacedBy(Spacing.small), verticalAlignment = Alignment.Top) {
-                            Icon(Icons.Default.Info, contentDescription = "Info", tint = MaterialTheme.colorScheme.tertiary)
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(text = stringResource("settings.embedding.rag_feature_only"), style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.onTertiaryContainer)
-                                Spacer(Modifier.height(Spacing.extraSmall))
-                                Text(text = viewModel.embeddingModelWarning ?: "", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.9f))
                             }
                         }
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderWizardViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderWizardViewModel.kt
@@ -7,7 +7,6 @@ package io.askimo.desktop.settings
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.error.AppError
 import io.askimo.core.event.EventBus
@@ -15,8 +14,6 @@ import io.askimo.core.event.internal.ProviderInstanceSavedEvent
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.core.logging.logger
 import io.askimo.core.providers.ChatModelFactory
-import io.askimo.core.providers.LocalModelValidator
-import io.askimo.core.providers.ModelAvailabilityResult
 import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ProviderConfigField
@@ -430,17 +427,10 @@ class ProviderWizardViewModel(
 
             val result = withContext(Dispatchers.IO) {
                 try {
-                    val baseSettings = editingInstance?.settings
-                        ?: ProviderRegistry.getFactory(provider)?.defaultSettings()
-
-                    val newSettings = baseSettings?.applyConfigFields(providerFieldValues)
-                        ?: return@withContext ProviderTestResult.Failure("Failed to create settings")
-
-                    if (!newSettings.validate()) {
-                        return@withContext ProviderTestResult.Failure(
-                            message = "Cannot connect to ${provider.name.lowercase()} provider",
-                            helpText = newSettings.getSetupHelpText(LocalizationManager.messageResolver),
-                        )
+                    val newSettings = try {
+                        buildValidatedSettings(provider)
+                    } catch (e: SettingsValidationException) {
+                        return@withContext e.failure
                     }
 
                     val pendingModel = pendingModelForNewProvider?.takeIf { it.isNotBlank() }
@@ -511,79 +501,34 @@ class ProviderWizardViewModel(
         }
     }
 
-    // ── Embedding model availability ──────────────────────────────────────────────────────────
-
-    fun checkEmbeddingModelAvailability(provider: ModelProvider, baseUrl: String) {
-        isCheckingEmbeddingModel = true
-        embeddingModelWarning = null
-        embeddingModelProvider = null
-        canPullEmbeddingModel = false
-
-        scope.launch {
-            try {
-                val result = withContext(Dispatchers.IO) {
-                    fun resolveEmbeddingModel(p: ModelProvider): String {
-                        val instanceModel = editingInstance?.settings?.embeddingModel?.takeIf { it.isNotBlank() }
-                        return instanceModel ?: AppConfig.models[p].embeddingModel
-                    }
-                    when (provider) {
-                        ModelProvider.OLLAMA -> LocalModelValidator.checkModelExists(provider, baseUrl, resolveEmbeddingModel(ModelProvider.OLLAMA))
-                        ModelProvider.DOCKER -> LocalModelValidator.checkModelExists(provider, baseUrl, resolveEmbeddingModel(ModelProvider.DOCKER))
-                        ModelProvider.LOCALAI -> LocalModelValidator.checkModelExists(provider, baseUrl, resolveEmbeddingModel(ModelProvider.LOCALAI))
-                        ModelProvider.LMSTUDIO -> LocalModelValidator.checkModelExists(provider, baseUrl, resolveEmbeddingModel(ModelProvider.LMSTUDIO))
-                        ModelProvider.ANTHROPIC -> ModelAvailabilityResult.NotAvailable(reason = LocalizationManager.getString("settings.embedding.anthropic_no_embedding"), canAutoPull = false)
-                        ModelProvider.XAI -> ModelAvailabilityResult.NotAvailable(reason = LocalizationManager.getString("settings.embedding.xai_no_embedding"), canAutoPull = false)
-                        else -> ModelAvailabilityResult.Available
-                    }
-                }
-                when (result) {
-                    is ModelAvailabilityResult.Available -> embeddingModelWarning = null
-
-                    is ModelAvailabilityResult.NotAvailable -> {
-                        embeddingModelWarning = LocalizationManager.getString("settings.embedding.not_available_rag_only", result.reason)
-                        embeddingModelProvider = provider.name
-                        canPullEmbeddingModel = result.canAutoPull
-                    }
-
-                    is ModelAvailabilityResult.ProviderUnreachable -> {
-                        embeddingModelWarning = LocalizationManager.getString("settings.embedding.provider_unreachable", result.error)
-                        embeddingModelProvider = provider.name
-                        canPullEmbeddingModel = false
-                    }
-                }
-            } catch (e: Exception) {
-                log.error("Error checking embedding model availability", e)
-                embeddingModelWarning = LocalizationManager.getString("settings.embedding.check_failed", e.message ?: "Unknown error")
-            } finally {
-                isCheckingEmbeddingModel = false
-            }
-        }
-    }
-
-    fun pullEmbeddingModel(provider: ModelProvider, baseUrl: String) {
-        if (provider != ModelProvider.OLLAMA) return
-        isCheckingEmbeddingModel = true
-        scope.launch {
-            try {
-                val modelName = AppConfig.models[ModelProvider.OLLAMA].embeddingModel
-                val success = withContext(Dispatchers.IO) { LocalModelValidator.pullOllamaModel(baseUrl, modelName) }
-                if (success) {
-                    embeddingModelWarning = null
-                    successMessage = LocalizationManager.getString("settings.embedding.download_success", modelName)
-                    showSuccessMessage = true
-                } else {
-                    embeddingModelWarning = LocalizationManager.getString("settings.embedding.download_failed", modelName)
-                }
-            } catch (e: Exception) {
-                log.error("Error pulling embedding model", e)
-                embeddingModelWarning = LocalizationManager.getString("settings.embedding.download_error", e.message ?: "Unknown error")
-            } finally {
-                isCheckingEmbeddingModel = false
-            }
-        }
-    }
-
     // ── Private helpers ───────────────────────────────────────────────────────────────────────
+
+    /** Thrown by [buildValidatedSettings] when settings cannot be created or fail validation. */
+    private class SettingsValidationException(val failure: ProviderTestResult.Failure) : Exception()
+
+    /**
+     * Resolves the base settings for [provider], applies the current [providerFieldValues],
+     * and validates the result. Throws [SettingsValidationException] on any failure so that
+     * callers inside a `withContext` block can simply `return@withContext e.failure`.
+     */
+    private fun buildValidatedSettings(provider: ModelProvider): ProviderSettings {
+        val baseSettings = editingInstance?.settings
+            ?: ProviderRegistry.getFactory(provider)?.defaultSettings()
+
+        val settings = baseSettings?.applyConfigFields(providerFieldValues)
+            ?: throw SettingsValidationException(ProviderTestResult.Failure("Failed to create settings"))
+
+        if (!settings.validate()) {
+            throw SettingsValidationException(
+                ProviderTestResult.Failure(
+                    message = "Cannot connect to ${provider.name.lowercase()} provider",
+                    helpText = settings.getSetupHelpText(LocalizationManager.messageResolver),
+                ),
+            )
+        }
+
+        return settings
+    }
 
     /** Debounced model fetch triggered on field changes; validates connection and loads models. */
     private fun scheduleAutoModelFetch() {
@@ -606,15 +551,10 @@ class ProviderWizardViewModel(
 
             val result = withContext(Dispatchers.IO) {
                 try {
-                    val baseSettings = editingInstance?.settings ?: ProviderRegistry.getFactory(provider)?.defaultSettings()
-                    val newSettings = baseSettings?.applyConfigFields(providerFieldValues)
-                        ?: return@withContext ProviderTestResult.Failure("Failed to create settings")
-
-                    if (!newSettings.validate()) {
-                        return@withContext ProviderTestResult.Failure(
-                            message = "Cannot connect to ${provider.name.lowercase()} provider",
-                            helpText = newSettings.getSetupHelpText(LocalizationManager.messageResolver),
-                        )
+                    try {
+                        buildValidatedSettings(provider)
+                    } catch (e: SettingsValidationException) {
+                        return@withContext e.failure
                     }
 
                     val factory = ProviderRegistry.getFactory(provider)
@@ -646,8 +586,6 @@ class ProviderWizardViewModel(
                     connectionErrorHelp = null
                     connectionTestSuccess = true
                     loadModelsForSelectedProvider()
-                    val baseUrl = providerFieldValues[SettingField.BASE_URL]
-                    if (!baseUrl.isNullOrBlank()) checkEmbeddingModelAvailability(provider, baseUrl)
                 }
 
                 is ProviderTestResult.Failure -> {

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/ProviderModelPanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/ProviderModelPanel.kt
@@ -33,8 +33,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.RadioButtonChecked
@@ -780,24 +778,12 @@ private fun instanceEditForm(
             horizontalArrangement = Arrangement.spacedBy(Spacing.small, Alignment.End),
         ) {
             secondaryButton(onClick = onCancel, enabled = !state.isTestingEdit) {
-                Icon(Icons.Default.Close, contentDescription = null, modifier = Modifier.size(14.dp))
-                Spacer(Modifier.width(Spacing.extraSmall))
                 Text(stringResource("settings.cancel"), style = MaterialTheme.typography.bodySmall)
             }
             primaryButton(
                 onClick = onSave,
                 enabled = !state.isTestingEdit && state.editDisplayNameError == null,
             ) {
-                if (state.isTestingEdit) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(14.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                } else {
-                    Icon(Icons.Default.Check, contentDescription = null, modifier = Modifier.size(14.dp))
-                }
-                Spacer(Modifier.width(Spacing.extraSmall))
                 Text(stringResource("settings.save"), style = MaterialTheme.typography.bodySmall)
             }
         }

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/TelemetryPanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/TelemetryPanel.kt
@@ -96,7 +96,7 @@ internal fun telemetryPanel(metrics: TelemetryMetrics, maxHeight: Dp) {
                         fontWeight = FontWeight.SemiBold,
                     )
 
-                    if (metrics.ragClassificationTotal > 0 || metrics.llmCallsByProvider.isNotEmpty()) {
+                    if (metrics.ragClassificationTotal > 0 || metrics.llmCallsByInstance.isNotEmpty()) {
                         themedTooltip(text = stringResource("telemetry.reset")) {
                             IconButton(
                                 onClick = { appContext.telemetry.reset() },
@@ -113,7 +113,7 @@ internal fun telemetryPanel(metrics: TelemetryMetrics, maxHeight: Dp) {
                     }
                 }
 
-                if (metrics.ragClassificationTotal == 0 && metrics.llmCallsByProvider.isEmpty()) {
+                if (metrics.ragClassificationTotal == 0 && metrics.llmCallsByInstance.isEmpty()) {
                     Text(
                         text = stringResource("telemetry.no.data"),
                         style = MaterialTheme.typography.bodyMedium,
@@ -185,7 +185,7 @@ internal fun telemetryPanel(metrics: TelemetryMetrics, maxHeight: Dp) {
                 }
 
                 // ── LLM section ───────────────────────────────────────────
-                if (metrics.llmCallsByProvider.isNotEmpty()) {
+                if (metrics.llmCallsByInstance.isNotEmpty()) {
                     if (metrics.ragClassificationTotal > 0) {
                         HorizontalDivider()
                     }
@@ -197,7 +197,7 @@ internal fun telemetryPanel(metrics: TelemetryMetrics, maxHeight: Dp) {
                         fontWeight = FontWeight.SemiBold,
                     )
 
-                    var sortColumn by remember { mutableStateOf(LlmSortColumn.PROVIDER) }
+                    var sortColumn by remember { mutableStateOf(LlmSortColumn.INSTANCE) }
                     var sortAscending by remember { mutableStateOf(true) }
 
                     fun toggleSort(column: LlmSortColumn) {
@@ -222,19 +222,19 @@ internal fun telemetryPanel(metrics: TelemetryMetrics, maxHeight: Dp) {
                     var totalTokens = 0L
                     var totalErrors = 0
 
-                    val rows = metrics.llmCallsByProvider.map { (providerModel, calls) ->
+                    val rows = metrics.llmCallsByInstance.map { (providerModel, calls) ->
                         val parts = providerModel.split(":", limit = 2)
-                        val provider = parts.getOrElse(0) { providerModel }
+                        val instance = parts.getOrElse(0) { providerModel }
                             .replaceFirstChar { if (it.isLowerCase()) it.titlecase(getDefault()) else it.toString() }
                         val model = parts.getOrElse(1) { "" }
-                        val tokens = metrics.llmTokensByProvider[providerModel] ?: 0L
-                        val avgDuration = metrics.llmAvgDurationMsByProvider[providerModel] ?: 0L
-                        val errors = metrics.llmErrorsByProvider[providerModel] ?: 0
-                        LlmRow(provider, model, calls, tokens, avgDuration, errors)
+                        val tokens = metrics.llmTokensByInstance[providerModel] ?: 0L
+                        val avgDuration = metrics.llmAvgDurationMsByInstance[providerModel] ?: 0L
+                        val errors = metrics.llmErrorsByInstance[providerModel] ?: 0
+                        LlmRow(instance, model, calls, tokens, avgDuration, errors)
                     }
 
                     val sorted = when (sortColumn) {
-                        LlmSortColumn.PROVIDER -> rows.sortedBy { it.provider }
+                        LlmSortColumn.INSTANCE -> rows.sortedBy { it.instance }
                         LlmSortColumn.MODEL -> rows.sortedBy { it.model }
                         LlmSortColumn.CALLS -> rows.sortedBy { it.calls }
                         LlmSortColumn.TOKENS -> rows.sortedBy { it.tokens }
@@ -254,7 +254,7 @@ internal fun telemetryPanel(metrics: TelemetryMetrics, maxHeight: Dp) {
 
                     // Totals row
                     llmTableRow(
-                        provider = stringResource("telemetry.llm.col.total"),
+                        instance = stringResource("telemetry.llm.col.total"),
                         model = "",
                         calls = LocalizationManager.formatNumber(totalCalls),
                         tokens = LocalizationManager.formatNumber(totalTokens),
@@ -278,10 +278,10 @@ internal fun telemetryPanel(metrics: TelemetryMetrics, maxHeight: Dp) {
     }
 }
 
-private enum class LlmSortColumn { PROVIDER, MODEL, CALLS, TOKENS, AVG_DURATION, ERRORS }
+private enum class LlmSortColumn { INSTANCE, MODEL, CALLS, TOKENS, AVG_DURATION, ERRORS }
 
 private data class LlmRow(
-    val provider: String,
+    val instance: String,
     val model: String,
     val calls: Int,
     val tokens: Long,
@@ -308,7 +308,7 @@ private fun llmTableHeader(
     val inactiveColor = MaterialTheme.colorScheme.onSurfaceVariant
 
     val cols = listOf(
-        Triple(stringResource("telemetry.llm.col.provider"), LlmSortColumn.PROVIDER, COL_PROVIDER),
+        Triple(stringResource("telemetry.llm.col.instance"), LlmSortColumn.INSTANCE, COL_PROVIDER),
         Triple(stringResource("telemetry.llm.col.model"), LlmSortColumn.MODEL, COL_MODEL),
         Triple(stringResource("telemetry.llm.col.calls"), LlmSortColumn.CALLS, COL_CALLS),
         Triple(stringResource("telemetry.llm.col.tokens"), LlmSortColumn.TOKENS, COL_TOKENS),
@@ -360,7 +360,7 @@ private fun llmTableDataRow(row: LlmRow) {
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text = row.provider, style = style, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(COL_PROVIDER), maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(text = row.instance, style = style, color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(COL_PROVIDER), maxLines = 1, overflow = TextOverflow.Ellipsis)
         Text(text = row.model, style = style, color = secondary, modifier = Modifier.weight(COL_MODEL), maxLines = 1, overflow = TextOverflow.Ellipsis)
         Text(text = LocalizationManager.formatNumber(row.calls), style = style, color = secondary, modifier = Modifier.weight(COL_CALLS), maxLines = 1)
         Text(text = LocalizationManager.formatNumber(row.tokens), style = style, color = secondary, modifier = Modifier.weight(COL_TOKENS), maxLines = 1)
@@ -381,7 +381,7 @@ private fun llmTableDataRow(row: LlmRow) {
 
 @Composable
 private fun llmTableRow(
-    provider: String,
+    instance: String,
     model: String,
     calls: String,
     tokens: String,
@@ -399,7 +399,7 @@ private fun llmTableRow(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text = provider, style = style, fontWeight = fontWeight, color = defaultColor, modifier = Modifier.weight(COL_PROVIDER), maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(text = instance, style = style, fontWeight = fontWeight, color = defaultColor, modifier = Modifier.weight(COL_PROVIDER), maxLines = 1, overflow = TextOverflow.Ellipsis)
         Text(text = model, style = style, fontWeight = fontWeight, color = secondaryColor, modifier = Modifier.weight(COL_MODEL), maxLines = 1, overflow = TextOverflow.Ellipsis)
         Text(text = calls, style = style, fontWeight = fontWeight, color = secondaryColor, modifier = Modifier.weight(COL_CALLS), maxLines = 1)
         Text(text = tokens, style = style, fontWeight = fontWeight, color = secondaryColor, modifier = Modifier.weight(COL_TOKENS), maxLines = 1)

--- a/shared/src/main/kotlin/io/askimo/core/telemetry/TelemetryCollector.kt
+++ b/shared/src/main/kotlin/io/askimo/core/telemetry/TelemetryCollector.kt
@@ -38,11 +38,11 @@ class TelemetryCollector {
     private val ragRetrievalTotalTime = AtomicLong(0L)
     private val ragChunksRetrievedTotal = AtomicInteger(0)
 
-    // LLM Call Metrics (per provider)
-    private val llmCallsByProvider = ConcurrentHashMap<String, AtomicInteger>()
-    private val llmTokensByProvider = ConcurrentHashMap<String, AtomicLong>()
-    private val llmDurationByProvider = ConcurrentHashMap<String, AtomicLong>()
-    private val llmErrorsByProvider = ConcurrentHashMap<String, AtomicInteger>()
+    // LLM Call Metrics — keyed by "$instanceId:$model" or "$provider:$model" (legacy fallback)
+    private val llmCallsByInstance = ConcurrentHashMap<String, AtomicInteger>()
+    private val llmTokensByInstance = ConcurrentHashMap<String, AtomicLong>()
+    private val llmDurationByInstance = ConcurrentHashMap<String, AtomicLong>()
+    private val llmErrorsByInstance = ConcurrentHashMap<String, AtomicInteger>()
 
     init {
         // Load persisted telemetry data on initialization
@@ -60,29 +60,25 @@ class TelemetryCollector {
         ragTriggered.set(loaded.ragTriggered)
         ragSkipped.set(loaded.ragSkipped)
         ragClassificationTotalTime.set(loaded.ragAvgClassificationTimeMs * loaded.ragClassificationTotal)
-
         ragRetrievalTotal.set(loaded.ragRetrievalTotal)
         ragRetrievalTotalTime.set(loaded.ragAvgRetrievalTimeMs * loaded.ragRetrievalTotal)
         ragChunksRetrievedTotal.set((loaded.ragAvgChunksRetrieved * loaded.ragRetrievalTotal).toInt())
 
         // Restore LLM metrics
-        loaded.llmCallsByProvider.forEach { (key, calls) ->
-            llmCallsByProvider[key] = AtomicInteger(calls)
+        loaded.llmCallsByInstance.forEach { (key, calls) ->
+            llmCallsByInstance[key] = AtomicInteger(calls)
         }
-        loaded.llmTokensByProvider.forEach { (key, tokens) ->
-            llmTokensByProvider[key] = AtomicLong(tokens)
+        loaded.llmTokensByInstance.forEach { (key, tokens) ->
+            llmTokensByInstance[key] = AtomicLong(tokens)
         }
-        loaded.llmAvgDurationMsByProvider.forEach { (key, avgDuration) ->
-            val calls = loaded.llmCallsByProvider[key] ?: 0
-            if (calls > 0) {
-                llmDurationByProvider[key] = AtomicLong(avgDuration * calls)
-            }
+        loaded.llmAvgDurationMsByInstance.forEach { (key, avgDuration) ->
+            val calls = loaded.llmCallsByInstance[key] ?: 0
+            if (calls > 0) llmDurationByInstance[key] = AtomicLong(avgDuration * calls)
         }
-        loaded.llmErrorsByProvider.forEach { (key, errors) ->
-            llmErrorsByProvider[key] = AtomicInteger(errors)
+        loaded.llmErrorsByInstance.forEach { (key, errors) ->
+            llmErrorsByInstance[key] = AtomicInteger(errors)
         }
 
-        // Update the flow with loaded data
         updateMetricsFlow()
 
         if (loaded != TelemetryMetrics.empty()) {
@@ -119,20 +115,23 @@ class TelemetryCollector {
 
     /**
      * Records an LLM call (from LangChain4J listener).
+     *
+     * The aggregation key is `"$instanceId:$model"` when [instanceId] is supplied,
+     * or `"$provider:$model"` as a legacy fallback when no instance is known.
      */
     fun recordLLMCall(
         provider: String,
         model: String,
         tokenUsage: TokenUsage?,
         durationMs: Long,
+        instanceId: String? = null,
     ) {
-        val key = "$provider:$model"
+        val key = "${instanceId ?: provider}:$model"
 
-        llmCallsByProvider.getOrPut(key) { AtomicInteger(0) }.incrementAndGet()
-        llmDurationByProvider.getOrPut(key) { AtomicLong(0L) }.addAndGet(durationMs)
-
+        llmCallsByInstance.getOrPut(key) { AtomicInteger(0) }.incrementAndGet()
+        llmDurationByInstance.getOrPut(key) { AtomicLong(0L) }.addAndGet(durationMs)
         tokenUsage?.let {
-            llmTokensByProvider.getOrPut(key) { AtomicLong(0L) }.addAndGet(it.totalTokenCount().toLong())
+            llmTokensByInstance.getOrPut(key) { AtomicLong(0L) }.addAndGet(it.totalTokenCount().toLong())
         }
 
         log.debug("LLM call to $key: ${tokenUsage?.totalTokenCount() ?: 0} tokens in ${durationMs}ms")
@@ -141,10 +140,17 @@ class TelemetryCollector {
 
     /**
      * Records an LLM error.
+     *
+     * Uses the same key scheme as [recordLLMCall].
      */
-    fun recordLLMError(provider: String, model: String, error: Throwable) {
-        val key = "$provider:$model"
-        llmErrorsByProvider.getOrPut(key) { AtomicInteger(0) }.incrementAndGet()
+    fun recordLLMError(
+        provider: String,
+        model: String,
+        error: Throwable,
+        instanceId: String? = null,
+    ) {
+        val key = "${instanceId ?: provider}:$model"
+        llmErrorsByInstance.getOrPut(key) { AtomicInteger(0) }.incrementAndGet()
         log.warn("LLM error for $key: ${error.message}")
     }
 
@@ -160,36 +166,20 @@ class TelemetryCollector {
             ragClassificationTotal = classificationCount,
             ragTriggered = ragTriggered.get(),
             ragSkipped = ragSkipped.get(),
-            ragTriggeredPercent = if (classificationCount > 0) {
-                (ragTriggered.get() * 100.0 / classificationCount)
-            } else {
-                0.0
-            },
-            ragAvgClassificationTimeMs = if (classificationCount > 0) {
-                ragClassificationTotalTime.get() / classificationCount
-            } else {
-                0L
-            },
+            ragTriggeredPercent = if (classificationCount > 0) ragTriggered.get() * 100.0 / classificationCount else 0.0,
+            ragAvgClassificationTimeMs = if (classificationCount > 0) ragClassificationTotalTime.get() / classificationCount else 0L,
             // RAG Retrieval
             ragRetrievalTotal = retrievalCount,
-            ragAvgRetrievalTimeMs = if (retrievalCount > 0) {
-                ragRetrievalTotalTime.get() / retrievalCount
-            } else {
-                0L
-            },
-            ragAvgChunksRetrieved = if (retrievalCount > 0) {
-                ragChunksRetrievedTotal.get().toDouble() / retrievalCount
-            } else {
-                0.0
-            },
+            ragAvgRetrievalTimeMs = if (retrievalCount > 0) ragRetrievalTotalTime.get() / retrievalCount else 0L,
+            ragAvgChunksRetrieved = if (retrievalCount > 0) ragChunksRetrievedTotal.get().toDouble() / retrievalCount else 0.0,
             // LLM Calls
-            llmCallsByProvider = llmCallsByProvider.mapValues { it.value.get() },
-            llmTokensByProvider = llmTokensByProvider.mapValues { it.value.get() },
-            llmAvgDurationMsByProvider = llmDurationByProvider.mapValues { (key, totalDuration) ->
-                val calls = llmCallsByProvider[key]?.get() ?: 0
+            llmCallsByInstance = llmCallsByInstance.mapValues { it.value.get() },
+            llmTokensByInstance = llmTokensByInstance.mapValues { it.value.get() },
+            llmAvgDurationMsByInstance = llmDurationByInstance.mapValues { (key, totalDuration) ->
+                val calls = llmCallsByInstance[key]?.get() ?: 0
                 if (calls > 0) totalDuration.get() / calls else 0L
             },
-            llmErrorsByProvider = llmErrorsByProvider.mapValues { it.value.get() },
+            llmErrorsByInstance = llmErrorsByInstance.mapValues { it.value.get() },
         )
     }
 
@@ -212,19 +202,14 @@ class TelemetryCollector {
         ragTriggered.set(0)
         ragSkipped.set(0)
         ragClassificationTotalTime.set(0L)
-
         ragRetrievalTotal.set(0)
         ragRetrievalTotalTime.set(0L)
         ragChunksRetrievedTotal.set(0)
-
-        llmCallsByProvider.clear()
-        llmTokensByProvider.clear()
-        llmDurationByProvider.clear()
-        llmErrorsByProvider.clear()
-
+        llmCallsByInstance.clear()
+        llmTokensByInstance.clear()
+        llmDurationByInstance.clear()
+        llmErrorsByInstance.clear()
         log.info("Telemetry metrics reset")
-
-        // Update flow and delete persisted file
         updateMetricsFlow()
         TelemetryPersistenceManager.delete()
     }
@@ -247,14 +232,14 @@ data class TelemetryMetrics(
     val ragAvgRetrievalTimeMs: Long,
     val ragAvgChunksRetrieved: Double,
 
-    // LLM Calls
-    val llmCallsByProvider: Map<String, Int>,
-    val llmTokensByProvider: Map<String, Long>,
-    val llmAvgDurationMsByProvider: Map<String, Long>,
-    val llmErrorsByProvider: Map<String, Int>,
+    // LLM Calls — key is "$instanceId:$model" or "$provider:$model" (legacy)
+    val llmCallsByInstance: Map<String, Int>,
+    val llmTokensByInstance: Map<String, Long>,
+    val llmAvgDurationMsByInstance: Map<String, Long>,
+    val llmErrorsByInstance: Map<String, Int>,
 ) {
     val totalTokensUsed: Long
-        get() = llmTokensByProvider.values.sum()
+        get() = llmTokensByInstance.values.sum()
 
     companion object {
         fun empty() = TelemetryMetrics(
@@ -266,10 +251,10 @@ data class TelemetryMetrics(
             ragRetrievalTotal = 0,
             ragAvgRetrievalTimeMs = 0L,
             ragAvgChunksRetrieved = 0.0,
-            llmCallsByProvider = emptyMap(),
-            llmTokensByProvider = emptyMap(),
-            llmAvgDurationMsByProvider = emptyMap(),
-            llmErrorsByProvider = emptyMap(),
+            llmCallsByInstance = emptyMap(),
+            llmTokensByInstance = emptyMap(),
+            llmAvgDurationMsByInstance = emptyMap(),
+            llmErrorsByInstance = emptyMap(),
         )
     }
 }


### PR DESCRIPTION
- Update TelemetryCollector and related UI to track LLM metrics per instance instead of per provider.
- Rename SettingsViewModel to AIProviderViewModel for better domain alignment.
- Remove deprecated embedding model validation logic and associated UI components.
- Standardize terminology in i18n messages from "Provider" to "Instance".
- Cleanup UI components in StarPromptDialog and ProviderSelectionDialog.