### PR TITLE
feat(core): prevent automatic session title updates

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/config/AppConfigTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/config/AppConfigTest.kt
@@ -25,53 +25,22 @@ import java.nio.file.Files
 class AppConfigTest {
 
     @Test
-    fun `DEFAULT_YAML snake_case fields are correctly deserialized for all providers`() {
+    fun `DEFAULT_YAML snake_case fields are correctly deserialized`() {
         // @AskimoTestHome writes DEFAULT_YAML and resets AppConfig — so all fields
-        // should reflect the YAML defaults, not the empty ProviderModelConfig() defaults.
+        // should reflect the YAML defaults.
         val models = AppConfig.models
 
         assertEquals(10, models.maxToolCallingRoundTrips)
 
-        // Ollama — the field that was failing in EmbeddingModelFactoryOllamaTest
-        assertEquals("", models[ModelProvider.OLLAMA].embeddingModel)
-        assertEquals("", models[ModelProvider.OLLAMA].visionModel)
-        assertEquals("", models[ModelProvider.OLLAMA].imageModel)
-
-        // Anthropic
-        assertEquals("", models[ModelProvider.ANTHROPIC].utilityModel)
-        assertEquals("claude-sonnet-4-6", models[ModelProvider.ANTHROPIC].visionModel)
-        assertEquals("claude-sonnet-4-6", models[ModelProvider.ANTHROPIC].imageModel)
-
         // Global timeouts
         assertEquals(45L, models.timeouts.utilityModelTimeoutSeconds)
         assertEquals(300L, models.timeouts.defaultModelTimeoutSeconds)
-
-        // Gemini
-        assertEquals("", models[ModelProvider.GEMINI].utilityModel)
-        assertEquals("gemini-embedding-001", models[ModelProvider.GEMINI].embeddingModel)
-        assertEquals("gemini-1.5-pro", models[ModelProvider.GEMINI].visionModel)
-        assertEquals("gemini-2.0-flash-exp", models[ModelProvider.GEMINI].imageModel)
-
-        // OpenAI
-        assertEquals("", models[ModelProvider.OPENAI].utilityModel)
-        assertEquals("text-embedding-3-small", models[ModelProvider.OPENAI].embeddingModel)
-        assertEquals("gpt-4o", models[ModelProvider.OPENAI].visionModel)
-        assertEquals("dall-e-3", models[ModelProvider.OPENAI].imageModel)
-
-        // XAI
-        assertEquals("", models[ModelProvider.XAI].utilityModel)
-        assertEquals("grok-2-vision-latest", models[ModelProvider.XAI].visionModel)
-        assertEquals("grok-2-vision-latest", models[ModelProvider.XAI].imageModel)
     }
 
     @Test
-    fun `YAML round-trip preserves snake_case field values after updateField`() {
-        // Mutate a field, then verify the in-memory value is correct
-        AppConfig.updateField("models.ollama.embeddingModel", "mxbai-embed-large:latest")
-        assertEquals("mxbai-embed-large:latest", AppConfig.models[ModelProvider.OLLAMA].embeddingModel)
-
-        AppConfig.updateField("models.anthropic.utilityModel", "claude-haiku-4")
-        assertEquals("claude-haiku-4", AppConfig.models[ModelProvider.ANTHROPIC].utilityModel)
+    fun `YAML round-trip preserves timeout values after updateField`() {
+        AppConfig.updateField("models.timeouts.utilityModelTimeoutSeconds", "120")
+        assertEquals(120L, AppConfig.models.timeouts.utilityModelTimeoutSeconds)
     }
 
     @Test
@@ -112,60 +81,6 @@ class AppConfigTest {
 
         val withInvalid = updateModelsFieldHelper(config, "maxToolCallingRoundTrips", "invalid")
         assertEquals(config.maxToolCallingRoundTrips, withInvalid.maxToolCallingRoundTrips)
-    }
-
-    @Test
-    fun `updateModelsField should handle all provider vision models`() {
-        val config = ModelsConfig()
-
-        // Test OpenAI
-        var updated = updateModelsFieldHelper(config, "openai.visionModel", "gpt-4-vision-preview")
-        assertEquals("gpt-4-vision-preview", updated.openai.visionModel)
-
-        // Test Anthropic
-        updated = updateModelsFieldHelper(config, "anthropic.visionModel", "claude-3-opus-20240229")
-        assertEquals("claude-3-opus-20240229", updated.anthropic.visionModel)
-
-        // Test Gemini
-        updated = updateModelsFieldHelper(config, "gemini.visionModel", "gemini-pro-vision")
-        assertEquals("gemini-pro-vision", updated.gemini.visionModel)
-
-        // Test XAI
-        updated = updateModelsFieldHelper(config, "xai.visionModel", "grok-vision-beta")
-        assertEquals("grok-vision-beta", updated.xai.visionModel)
-
-        // Test Ollama
-        updated = updateModelsFieldHelper(config, "ollama.visionModel", "llava:13b")
-        assertEquals("llava:13b", updated.ollama.visionModel)
-
-        // Test Docker
-        updated = updateModelsFieldHelper(config, "docker.visionModel", "llava:latest")
-        assertEquals("llava:latest", updated.docker.visionModel)
-
-        // Test LocalAI
-        updated = updateModelsFieldHelper(config, "localai.visionModel", "bakllava")
-        assertEquals("bakllava", updated.localai.visionModel)
-
-        // Test LMStudio
-        updated = updateModelsFieldHelper(config, "lmstudio.visionModel", "llava-v1.6-mistral-7b")
-        assertEquals("llava-v1.6-mistral-7b", updated.lmstudio.visionModel)
-    }
-
-    @Test
-    fun `updateModelsField should handle embedding models`() {
-        val config = ModelsConfig()
-
-        // Test OpenAI
-        var updated = updateModelsFieldHelper(config, "openai.embeddingModel", "text-embedding-3-large")
-        assertEquals("text-embedding-3-large", updated.openai.embeddingModel)
-
-        // Test Gemini
-        updated = updateModelsFieldHelper(config, "gemini.embeddingModel", "text-embedding-004")
-        assertEquals("text-embedding-004", updated.gemini.embeddingModel)
-
-        // Test Ollama
-        updated = updateModelsFieldHelper(config, "ollama.embeddingModel", "mxbai-embed-large")
-        assertEquals("mxbai-embed-large", updated.ollama.embeddingModel)
     }
 
     @Test
@@ -525,7 +440,7 @@ class AppConfigTest {
     @Test
     fun `saveContext preserves existing config fields after save`() {
         // Verify that saving context does not wipe out unrelated config sections
-        val originalEmbeddingModel = AppConfig.models[ModelProvider.OLLAMA].embeddingModel
+        val originalMaxRoundTrips = AppConfig.models.maxToolCallingRoundTrips
 
         val instance = ProviderInstance.create(
             displayName = "OpenAI",
@@ -538,7 +453,7 @@ class AppConfigTest {
 
         AppConfig.saveContext(params)
 
-        assertEquals(originalEmbeddingModel, AppConfig.models[ModelProvider.OLLAMA].embeddingModel)
+        assertEquals(originalMaxRoundTrips, AppConfig.models.maxToolCallingRoundTrips)
     }
 
     @Test

--- a/cli/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
@@ -496,8 +496,6 @@ class TokenAwareSummarizingMemoryTest {
         assertEquals(100, memory.messages().size, "All concurrent messages should be added")
     }
 
-    // ── Misc ─────────────────────────────────────────────────────────────────
-
     @Test
     fun `should extract text content from different message types`() {
         memory = createMemory()

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -262,9 +262,7 @@ fun chatInputField(
         )
     }
 
-    val configuredImageModel = resolvedProvider?.let { provider ->
-        AppConfig.models[provider].imageModel
-    }.orEmpty()
+    val configuredImageModel = appParams.activeInstance?.settings?.imageModel.orEmpty()
     val hasConfiguredImageModel = configuredImageModel.isNotBlank()
     val providerNotSetLabel = stringResource("provider.not.set")
     val missingImageModelTitle = stringResource("chat.image.model.missing.title")

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/ErrorDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/ErrorDialog.kt
@@ -8,16 +8,20 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -53,13 +57,21 @@ fun errorDialog(
 ) {
     val linkColor = MaterialTheme.colorScheme.onSurface
     var showDetails by remember { mutableStateOf(false) }
+    var messageExpanded by remember { mutableStateOf(false) }
+
+    // Collapse long messages at 4 lines; user can expand to see the full text
+    val messageCollapsedMaxLines = 4
+    val isMessageLong = message.lines().size > messageCollapsedMaxLines ||
+        message.length > 300
 
     AppComponents.alertDialog(
         onDismissRequest = onDismiss,
+        modifier = Modifier.width(800.dp),
         title = {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.small),
                 verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Icon(
                     imageVector = Icons.Default.Warning,
@@ -70,6 +82,14 @@ fun errorDialog(
                     text = title,
                     style = MaterialTheme.typography.headlineSmall,
                 )
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Close",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         },
         text = {
@@ -100,12 +120,47 @@ fun errorDialog(
                     Text(
                         text = annotatedString,
                         style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                        maxLines = if (messageExpanded || !isMessageLong) Int.MAX_VALUE else messageCollapsedMaxLines,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .then(
+                                if (messageExpanded) {
+                                    Modifier.heightIn(max = 300.dp).verticalScroll(rememberScrollState())
+                                } else {
+                                    Modifier
+                                },
+                            )
+                            .pointerHoverIcon(PointerIcon.Hand),
                     )
                 } else {
                     Text(
                         text = message,
                         style = MaterialTheme.typography.bodyMedium,
+                        maxLines = if (messageExpanded || !isMessageLong) Int.MAX_VALUE else messageCollapsedMaxLines,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .then(
+                                if (messageExpanded) {
+                                    Modifier.heightIn(max = 300.dp).verticalScroll(rememberScrollState())
+                                } else {
+                                    Modifier
+                                },
+                            ),
+                    )
+                }
+
+                // Show more / Show less toggle for long messages
+                if (isMessageLong) {
+                    Text(
+                        text = if (messageExpanded) stringResource("action.show.less") else stringResource("action.show.more"),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier
+                            .clickable { messageExpanded = !messageExpanded }
+                            .pointerHoverIcon(PointerIcon.Hand)
+                            .padding(top = Spacing.extraSmall),
                     )
                 }
 
@@ -147,11 +202,13 @@ fun errorDialog(
             }
         },
         confirmButton = {
-            primaryButton(
-                onClick = onDismiss,
+            Row(
                 modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
             ) {
-                Text(stringResource("action.ok"))
+                primaryButton(onClick = onDismiss) {
+                    Text(stringResource("action.ok"))
+                }
             }
         },
     )

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -232,7 +232,6 @@ class ChatSessionService(
             sessionMemoryRepository = sessionMemoryRepository,
             userMemoryRepository = DatabaseManager.getInstance().getUserMemoryRepository(),
             summarizationTimeoutSeconds = AppConfig.chat.summarizationTimeoutSeconds,
-            onTitleSuggested = { candidate -> handleTitleSuggestion(sessionId, candidate) },
         )
     }
 
@@ -563,80 +562,6 @@ class ChatSessionService(
      * @return true if the session was updated, false if it didn't exist
      */
     fun updateSessionDirective(sessionId: String, directiveId: String?): Boolean = sessionRepository.updateSessionDirective(sessionId, directiveId)
-
-    /**
-     * Called from the summarization background thread each time a new structured summary
-     * is produced. Applies the suggested title if all guards pass:
-     *
-     * 1. The user has not manually renamed the session ([ChatSession.isUserRenamed] == false).
-     * 2. The candidate differs from the current title by more than 20 % Levenshtein distance
-     *    (avoids flickering on minor rewordings).
-     *
-     * No message-count guard needed — [TokenAwareSummarizingMemory.onTitleSuggested] only fires
-     * after structured summarization, which itself requires the token threshold to be exceeded
-     * (i.e. a sufficiently long conversation).
-     */
-    private fun handleTitleSuggestion(sessionId: String, candidate: String) {
-        val trimmed = candidate.trim().take(256)
-        if (trimmed.isBlank()) return
-
-        try {
-            val session = sessionRepository.getSession(sessionId) ?: return
-
-            // Guard 1 — suppress for user-renamed sessions
-            if (session.isUserRenamed) {
-                log.debug("Skipping title refresh for session {} — user has manually renamed it", sessionId)
-                return
-            }
-
-            // Guard 2 — candidate must differ meaningfully from current title
-            val currentTitle = session.title
-            val distance = levenshteinDistance(currentTitle, trimmed)
-            val threshold = (currentTitle.length * 0.20).toInt().coerceAtLeast(3)
-            if (distance <= threshold) {
-                log.debug("Skipping title refresh for session {} — Levenshtein distance {} <= threshold {}", sessionId, distance, threshold)
-                return
-            }
-
-            // All guards passed — apply the new title
-            sessionRepository.updateSessionTitle(sessionId, trimmed)
-            log.info("Auto-refreshed title for session {}: '{}' → '{}'", sessionId, currentTitle, trimmed)
-
-            eventScope.launch {
-                EventBus.emit(
-                    SessionTitleUpdatedEvent(
-                        sessionId = sessionId,
-                        newTitle = trimmed,
-                    ),
-                )
-            }
-        } catch (e: Exception) {
-            log.warn("handleTitleSuggestion failed for session {}: {}", sessionId, e.message)
-        }
-    }
-
-    /**
-     * Computes the Levenshtein edit distance between two strings.
-     * Used by [handleTitleSuggestion] to decide whether a title candidate differs
-     * enough from the current title to justify an update.
-     */
-    private fun levenshteinDistance(s1: String, s2: String): Int {
-        val m = s1.length
-        val n = s2.length
-        val dp = Array(m + 1) { IntArray(n + 1) }
-        for (i in 0..m) dp[i][0] = i
-        for (j in 0..n) dp[0][j] = j
-        for (i in 1..m) {
-            for (j in 1..n) {
-                dp[i][j] = if (s1[i - 1] == s2[j - 1]) {
-                    dp[i - 1][j - 1]
-                } else {
-                    minOf(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1]) + 1
-                }
-            }
-        }
-        return dp[m][n]
-    }
 
     /**
      * Add a message to a session and update the session's timestamp.

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -381,14 +381,6 @@ data class RagConfig(
     val useAbsolutePathInCitations: Boolean = true,
 )
 
-data class ProviderModelConfig(
-    val defaultModel: String = "",
-    val utilityModel: String = "",
-    val embeddingModel: String = "",
-    val visionModel: String = "",
-    val imageModel: String = "",
-)
-
 /**
  * Global AI model timeouts shared across all providers.
  *
@@ -398,52 +390,26 @@ data class ProviderModelConfig(
  *   accommodate slow local models and cloud reasoning models with extended thinking.
  */
 data class ModelTimeoutsConfig(
-    val utilityModelTimeoutSeconds: Long = 600,
-    val defaultModelTimeoutSeconds: Long = 600,
+    @field:JsonAlias("utilityModelTimeoutSeconds") val utilityModelTimeoutSeconds: Long = 600,
+    @field:JsonAlias("defaultModelTimeoutSeconds") val defaultModelTimeoutSeconds: Long = 600,
 )
 
+/**
+ * Global model execution settings.
+ *
+ * Per-provider model names (utility, embedding, image, vision) are now stored directly on each
+ * [ProviderInstance]'s [ProviderSettings]. This class intentionally no longer contains
+ * per-provider fields — they were removed in favour of instance-level configuration so that
+ * multiple instances of the same provider type can each have independent model assignments.
+ *
+ * Existing `askimo.yml` files that still contain per-provider sub-keys (e.g.
+ * `models.ollama.embedding_model`) will deserialize silently — the unknown fields are ignored
+ * by Jackson (`FAIL_ON_UNKNOWN_PROPERTIES = false`). No migration or data loss occurs.
+ */
 data class ModelsConfig(
     val maxToolCallingRoundTrips: Int = 10,
     val timeouts: ModelTimeoutsConfig = ModelTimeoutsConfig(),
-    val anthropic: ProviderModelConfig = ProviderModelConfig(),
-    val gemini: ProviderModelConfig = ProviderModelConfig(),
-    val openai: ProviderModelConfig = ProviderModelConfig(),
-    val ollama: ProviderModelConfig = ProviderModelConfig(),
-    val docker: ProviderModelConfig = ProviderModelConfig(),
-    val localai: ProviderModelConfig = ProviderModelConfig(),
-    val lmstudio: ProviderModelConfig = ProviderModelConfig(),
-    val xai: ProviderModelConfig = ProviderModelConfig(),
-    val openai_compatible: ProviderModelConfig = ProviderModelConfig(),
-    val askimo_pro: ProviderModelConfig = ProviderModelConfig(),
-) {
-    operator fun get(provider: ModelProvider): ProviderModelConfig = when (provider) {
-        ModelProvider.OPENAI -> openai
-        ModelProvider.ANTHROPIC -> anthropic
-        ModelProvider.GEMINI -> gemini
-        ModelProvider.XAI -> xai
-        ModelProvider.OLLAMA -> ollama
-        ModelProvider.DOCKER -> docker
-        ModelProvider.LOCALAI -> localai
-        ModelProvider.LMSTUDIO -> lmstudio
-        ModelProvider.OPENAI_COMPATIBLE -> openai_compatible
-        ModelProvider.ASKIMO_PRO -> askimo_pro
-        ModelProvider.UNKNOWN -> ProviderModelConfig()
-    }
-
-    fun update(provider: ModelProvider, updated: ProviderModelConfig): ModelsConfig = when (provider) {
-        ModelProvider.OPENAI -> copy(openai = updated)
-        ModelProvider.ANTHROPIC -> copy(anthropic = updated)
-        ModelProvider.GEMINI -> copy(gemini = updated)
-        ModelProvider.XAI -> copy(xai = updated)
-        ModelProvider.OLLAMA -> copy(ollama = updated)
-        ModelProvider.DOCKER -> copy(docker = updated)
-        ModelProvider.LOCALAI -> copy(localai = updated)
-        ModelProvider.LMSTUDIO -> copy(lmstudio = updated)
-        ModelProvider.OPENAI_COMPATIBLE -> copy(openai_compatible = updated)
-        ModelProvider.ASKIMO_PRO -> copy(askimo_pro = updated)
-        ModelProvider.UNKNOWN -> this
-    }
-}
+)
 
 /**
  * Configuration for the Askimo business analytics system.
@@ -713,56 +679,6 @@ object AppConfig {
           timeouts:
             utility_model_timeout_seconds: ${'$'}{ASKIMO_UTILITY_MODEL_TIMEOUT:45}
             default_model_timeout_seconds: ${'$'}{ASKIMO_DEFAULT_MODEL_TIMEOUT:300}
-          anthropic:
-            utility_model: ${'$'}{ASKIMO_ANTHROPIC_UTILITY_MODEL:}
-            embedding_model: ${'$'}{ASKIMO_ANTHROPIC_EMBEDDING_MODEL:}
-            vision_model: ${'$'}{ASKIMO_ANTHROPIC_VISION_MODEL:claude-sonnet-4-6}
-            image_model: ${'$'}{ASKIMO_ANTHROPIC_IMAGE_MODEL:claude-sonnet-4-6}
-            # Extended thinking settings — only applied when the selected model supports thinking.
-            # Increase thinking_budget_tokens for deeper reasoning (max varies by model, up to 64000 for claude-sonnet-4-6+).
-            # thinking_max_tokens must always be greater than thinking_budget_tokens.
-            thinking_budget_tokens: ${'$'}{ASKIMO_ANTHROPIC_THINKING_BUDGET_TOKENS:16000}
-            thinking_max_tokens: ${'$'}{ASKIMO_ANTHROPIC_THINKING_MAX_TOKENS:32000}
-          gemini:
-            utility_model: ${'$'}{ASKIMO_GEMINI_UTILITY_MODEL:}
-            embedding_model: ${'$'}{ASKIMO_GEMINI_EMBEDDING_MODEL:gemini-embedding-001}
-            vision_model: ${'$'}{ASKIMO_GEMINI_VISION_MODEL:gemini-1.5-pro}
-            image_model: ${'$'}{ASKIMO_GEMINI_IMAGE_MODEL:gemini-2.0-flash-exp}
-          openai:
-            utility_model: ${'$'}{ASKIMO_OPENAI_UTILITY_MODEL:}
-            embedding_model: ${'$'}{ASKIMO_OPENAI_EMBEDDING_MODEL:text-embedding-3-small}
-            vision_model: ${'$'}{ASKIMO_OPENAI_VISION_MODEL:gpt-4o}
-            image_model: ${'$'}{ASKIMO_OPENAI_IMAGE_MODEL:dall-e-3}
-          ollama:
-            utility_model: ${'$'}{ASKIMO_OLLAMA_UTILITY_MODEL:}
-            embedding_model: ${'$'}{ASKIMO_OLLAMA_EMBEDDING_MODEL:}
-            vision_model: ${'$'}{ASKIMO_OLLAMA_VISION_MODEL:}
-            image_model: ${'$'}{ASKIMO_OLLAMA_IMAGE_MODEL:}
-          docker:
-            utility_model: ${'$'}{ASKIMO_DOCKER_UTILITY_MODEL:}
-            embedding_model: ${'$'}{ASKIMO_DOCKER_EMBEDDING_MODEL:}
-            vision_model: ${'$'}{ASKIMO_DOCKER_VISION_MODEL:}
-            image_model: ${'$'}{ASKIMO_DOCKER_IMAGE_MODEL:}
-          localai:
-            utility_model: ${'$'}{ASKIMO_LOCALAI_UTILITY_MODEL:}
-            embedding_model: ${'$'}{ASKIMO_LOCALAI_EMBEDDING_MODEL:}
-            vision_model: ${'$'}{ASKIMO_LOCALAI_VISION_MODEL:}
-            image_model: ${'$'}{ASKIMO_LOCALAI_IMAGE_MODEL:}
-          lmstudio:
-            utility_model: ${'$'}{ASKIMO_LMSTUDIO_UTILITY_MODEL:}
-            embedding_model: ${'$'}{ASKIMO_LMSTUDIO_EMBEDDING_MODEL:}
-            vision_model: ${'$'}{ASKIMO_LMSTUDIO_VISION_MODEL:}
-            image_model: ${'$'}{ASKIMO_LMSTUDIO_IMAGE_MODEL:stable-diffusion}
-          xai:
-            utility_model: ${'$'}{ASKIMO_XAI_UTILITY_MODEL:}
-            embedding_model: ${'$'}{ASKIMO_XAI_EMBEDDING_MODEL:}
-            vision_model: ${'$'}{ASKIMO_XAI_VISION_MODEL:grok-2-vision-latest}
-            image_model: ${'$'}{ASKIMO_XAI_IMAGE_MODEL:grok-2-vision-latest}
-          openai_compatible:
-            utility_model:
-            embedding_model:
-            vision_model:
-            image_model:
 
         proxy:
           type: ${'$'}{ASKIMO_PROXY_TYPE:NONE}
@@ -1003,60 +919,6 @@ object AppConfig {
                 utilityModelTimeoutSeconds = envLong("ASKIMO_UTILITY_MODEL_TIMEOUT", 600L),
                 defaultModelTimeoutSeconds = envLong("ASKIMO_DEFAULT_MODEL_TIMEOUT", 600L),
             ),
-            anthropic = ProviderModelConfig(
-                utilityModel = env("ASKIMO_ANTHROPIC_UTILITY_MODEL", ""),
-                embeddingModel = env("ASKIMO_ANTHROPIC_EMBEDDING_MODEL", ""),
-                visionModel = env("ASKIMO_ANTHROPIC_VISION_MODEL", "claude-sonnet-4-6"),
-                imageModel = env("ASKIMO_ANTHROPIC_IMAGE_MODEL", "claude-sonnet-4-6"),
-            ),
-            gemini = ProviderModelConfig(
-                utilityModel = env("ASKIMO_GEMINI_UTILITY_MODEL", "gemini-2.5-flash-lite"),
-                embeddingModel = env("ASKIMO_GEMINI_EMBEDDING_MODEL", "gemini-embedding-001"),
-                visionModel = env("ASKIMO_GEMINI_VISION_MODEL", "gemini-1.5-pro"),
-                imageModel = env("ASKIMO_GEMINI_IMAGE_MODEL", "gemini-2.0-flash-exp"),
-            ),
-            openai = ProviderModelConfig(
-                utilityModel = env("ASKIMO_OPENAI_UTILITY_MODEL", "gpt-3.5-turbo"),
-                embeddingModel = env("ASKIMO_OPENAI_EMBEDDING_MODEL", "text-embedding-3-small"),
-                visionModel = env("ASKIMO_OPENAI_VISION_MODEL", "gpt-4o"),
-                imageModel = env("ASKIMO_OPENAI_IMAGE_MODEL", "dall-e-3"),
-            ),
-            ollama = ProviderModelConfig(
-                utilityModel = env("ASKIMO_OLLAMA_UTILITY_MODEL", ""),
-                embeddingModel = env("ASKIMO_OLLAMA_EMBEDDING_MODEL", ""),
-                visionModel = env("ASKIMO_OLLAMA_VISION_MODEL", ""),
-                imageModel = env("ASKIMO_OLLAMA_IMAGE_MODEL", ""),
-            ),
-            docker = ProviderModelConfig(
-                utilityModel = env("ASKIMO_DOCKER_UTILITY_MODEL", ""),
-                embeddingModel = env("ASKIMO_DOCKER_EMBEDDING_MODEL", ""),
-                visionModel = env("ASKIMO_DOCKER_VISION_MODEL", ""),
-                imageModel = env("ASKIMO_DOCKER_IMAGE_MODEL", ""),
-            ),
-            localai = ProviderModelConfig(
-                utilityModel = env("ASKIMO_LOCALAI_UTILITY_MODEL", ""),
-                embeddingModel = env("ASKIMO_LOCALAI_EMBEDDING_MODEL", ""),
-                visionModel = env("ASKIMO_LOCALAI_VISION_MODEL", ""),
-                imageModel = env("ASKIMO_LOCALAI_IMAGE_MODEL", ""),
-            ),
-            lmstudio = ProviderModelConfig(
-                utilityModel = env("ASKIMO_LMSTUDIO_UTILITY_MODEL", ""),
-                embeddingModel = env("ASKIMO_LMSTUDIO_EMBEDDING_MODEL", ""),
-                visionModel = env("ASKIMO_LMSTUDIO_VISION_MODEL", ""),
-                imageModel = env("ASKIMO_LMSTUDIO_IMAGE_MODEL", ""),
-            ),
-            xai = ProviderModelConfig(
-                utilityModel = env("ASKIMO_XAI_UTILITY_MODEL", "grok-3-mini"),
-                embeddingModel = env("ASKIMO_XAI_EMBEDDING_MODEL", ""),
-                visionModel = env("ASKIMO_XAI_VISION_MODEL", "grok-2-vision-latest"),
-                imageModel = env("ASKIMO_XAI_IMAGE_MODEL", "grok-2-vision-latest"),
-            ),
-            openai_compatible = ProviderModelConfig(
-                utilityModel = "",
-                embeddingModel = "",
-                visionModel = "",
-                imageModel = "",
-            ),
         )
 
         val proxy =
@@ -1114,28 +976,13 @@ object AppConfig {
 
             val current = cached ?: loadOnce()
 
-            // If any ASKIMO_PRO instance carries a defaultModel, persist it into
-            // models.askimo_pro.default_model so the model selection survives restarts.
-            val askimoProModel = params.providerInstances
-                .firstOrNull { it.providerType == ModelProvider.ASKIMO_PRO }
-                ?.settings?.defaultModel
-                ?.takeIf { it.isNotBlank() }
-            val updatedModels = if (askimoProModel != null) {
-                current.models.update(
-                    ModelProvider.ASKIMO_PRO,
-                    current.models[ModelProvider.ASKIMO_PRO].copy(defaultModel = askimoProModel),
-                )
-            } else {
-                current.models
-            }
-
-            cached = current.copy(context = sanitized, models = updatedModels)
+            cached = current.copy(context = sanitized)
 
             val configPath = resolveOrCreateConfigPath()
             if (configPath != null && configPath.exists()) {
                 try {
                     val updatedYaml = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(
-                        current.copy(context = persistable, models = updatedModels),
+                        current.copy(context = persistable),
                     )
                     Files.writeString(configPath, updatedYaml)
                     log.info("Saved context to $configPath")
@@ -1223,7 +1070,7 @@ object AppConfig {
                     val updatedYaml = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(cached)
                     Files.writeString(configPath, updatedYaml)
 
-                    log.debug("Updated $path=$value in $configPath")
+                    log.debug("Updated {}={} in {}", path, value, configPath)
                 } catch (e: Exception) {
                     log.displayError("Failed to persist $path to config file", e)
                 }
@@ -1370,30 +1217,8 @@ object AppConfig {
             return config.copy(timeouts = updated)
         }
 
-        val provider = ModelProvider.entries.firstOrNull { it.name.lowercase() == providerKey }
-            ?: run {
-                log.displayError("Unknown provider: $providerKey", null)
-                return config
-            }
-
-        val current = config[provider]
-        val updated = when (modelField) {
-            "defaultModel" -> current.copy(defaultModel = stringValue)
-
-            "utilityModel" -> current.copy(utilityModel = stringValue)
-
-            "embeddingModel" -> current.copy(embeddingModel = stringValue)
-
-            "visionModel" -> current.copy(visionModel = stringValue)
-
-            "imageModel" -> current.copy(imageModel = stringValue)
-
-            else -> {
-                log.displayError("Unknown model field '$modelField' for provider $providerKey", null)
-                return config
-            }
-        }
-        return config.update(provider, updated)
+        log.displayError("Unknown models config path '$field'. Per-provider model fields are now configured per-instance in Settings > AI Provider.", null)
+        return config
     }
 
     private fun updateProxyField(config: ProxyConfig, field: String, value: Any): ProxyConfig = when (field) {

--- a/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
@@ -151,15 +151,6 @@ class TokenAwareSummarizingMemory(
     private val tokenEstimator: (ChatMessage) -> Int = defaultTokenEstimator(),
     asyncSummarization: Boolean = true,
     private val summarizationTimeoutSeconds: Long = 300,
-    /**
-     * Optional callback invoked after each successful structured summarization cycle
-     * with a suggested title derived from the new summary. The caller decides whether
-     * to apply the title (change-detection guard lives in [ChatSessionService]).
-     *
-     * Invoked on the summarizer background thread — implementations must be thread-safe.
-     * Only fires when summarization used the structured (AI) path, not the basic fallback.
-     */
-    private val onTitleSuggested: ((String) -> Unit)? = null,
 ) : ChatMemory,
     AutoCloseable {
 
@@ -488,45 +479,11 @@ class TokenAwareSummarizingMemory(
             structuredSummary = mergeWithExistingSummary(newSummary)
             log.info("Generated structured summary with ${newSummary.keyFacts.size} facts, ${newSummary.mainTopics.size} topics")
 
-            // Derive a title candidate from the merged summary — no extra AI call needed.
-            // Priority: first sentence of recentContext → top-2 mainTopics joined with " · "
-            if (onTitleSuggested != null) {
-                val candidate = deriveTitleFromSummary(structuredSummary)
-                if (candidate.isNotBlank()) {
-                    try {
-                        onTitleSuggested.invoke(candidate)
-                    } catch (e: Exception) {
-                        log.warn("onTitleSuggested callback failed for session {}: {}", sessionId, e.message)
-                    }
-                }
-            }
-
             // Merge stable user facts into the persistent user memory store
             mergeIntoUserMemory(conversationText)
         } catch (e: Exception) {
             log.error("Structured summarization failed for session $sessionId", e)
         }
-    }
-
-    /**
-     * Derives a short title candidate from an existing [SessionConversationSummary] without
-     * any additional AI call.
-     *
-     * Priority:
-     * 1. First sentence of [SessionConversationSummary.recentContext], truncated to 60 chars.
-     * 2. Top-2 [SessionConversationSummary.mainTopics] joined with " · ", truncated to 60 chars.
-     * 3. Empty string if neither yields anything useful.
-     */
-    private fun deriveTitleFromSummary(summary: SessionConversationSummary?): String {
-        if (summary == null) return ""
-        val fromContext = summary.recentContext
-            .split(Regex("[.!?]\\s+"))
-            .firstOrNull { it.isNotBlank() }
-            ?.trim()
-            ?.take(60)
-            .orEmpty()
-        if (fromContext.isNotBlank()) return fromContext
-        return summary.mainTopics.take(2).joinToString(" · ").take(60)
     }
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
@@ -259,7 +259,6 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
     override fun createSecondaryModel(settings: T): ChatModel {
         val listener = createTelemetryListener()
         val modelName = settings.utilityModel
-            .ifBlank { AppConfig.models[getProvider()].utilityModel }
             .ifBlank { utilityModelFallback(settings) }
         return OpenAiResponsesChatModel.builder()
             .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener))
@@ -291,7 +290,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
     override fun createImageModel(settings: T): ImageModel = OpenAiImageModel.builder()
         .baseUrl(settings.baseUrl)
         .apiKey(resolveApiKey(settings))
-        .modelName(settings.imageModel.ifBlank { AppConfig.models[getProvider()].imageModel })
+        .modelName(settings.imageModel)
         .build()
 
     override fun createUtilityClient(settings: T): ChatClient = AiServices.builder(ChatClient::class.java)
@@ -302,7 +301,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
 
     override fun createEmbeddingModel(settings: T): EmbeddingModel {
         val baseUrl = settings.baseUrl.removeSuffix("/")
-        val modelName = settings.embeddingModel.ifBlank { AppConfig.models[getProvider()].embeddingModel }
+        val modelName = settings.embeddingModel
         check(modelName.isNotBlank()) {
             "No embedding model is configured for ${getProvider().name}. " +
                 "Go to Settings > AI Provider and select an embedding model under the provider configuration card."
@@ -318,6 +317,6 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
     }
 
     override fun getEmbeddingTokenLimit(settings: T): Int = LocalEmbeddingTokenLimits.resolve(
-        settings.embeddingModel.ifBlank { AppConfig.models[getProvider()].embeddingModel },
+        settings.embeddingModel,
     )
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -221,7 +221,6 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
             .supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA)
             .modelName(
                 settings.utilityModel
-                    .ifBlank { AppConfig.models[ANTHROPIC].utilityModel }
                     .ifBlank { settings.defaultModel },
             )
             .baseUrl(settings.baseUrl)

--- a/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/docker/DockerAiModelFactory.kt
@@ -8,7 +8,6 @@ import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import io.askimo.core.config.AppConfig
 import io.askimo.core.context.AppContext
 import io.askimo.core.providers.ModelCapabilitiesCache
 import io.askimo.core.providers.ModelProvider
@@ -53,7 +52,6 @@ class DockerAiModelFactory : OpenAiCompatibleChatModelFactory<DockerAiSettings>(
         .apiKey(resolveApiKey(settings))
         .modelName(
             settings.utilityModel
-                .ifBlank { AppConfig.models[getProvider()].utilityModel }
                 .ifBlank { utilityModelFallback(settings) },
         )
         .logRequests(log.isDebugEnabled)

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -164,7 +164,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
     ): ImageModel = GoogleAiGeminiImageModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
         .baseUrl(settings.baseUrl)
-        .modelName(settings.imageModel.ifBlank { AppConfig.models[GEMINI].imageModel })
+        .modelName(settings.imageModel)
         .build()
 
     override fun createStreamingModel(settings: GeminiSettings): StreamingChatModel {
@@ -210,7 +210,6 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
             .apiKey(safeApiKey(settings.apiKey))
             .modelName(
                 settings.utilityModel
-                    .ifBlank { AppConfig.models[GEMINI].utilityModel }
                     .ifBlank { settings.defaultModel },
             )
             .timeout(Duration.ofSeconds(AppConfig.models.timeouts.utilityModelTimeoutSeconds))
@@ -239,11 +238,11 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
 
     override fun createEmbeddingModel(settings: GeminiSettings): EmbeddingModel = GoogleAiEmbeddingModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
-        .modelName(settings.embeddingModel.ifBlank { AppConfig.models[GEMINI].embeddingModel })
+        .modelName(settings.embeddingModel)
         .build()
 
     override fun getEmbeddingTokenLimit(settings: GeminiSettings): Int {
-        val modelName = settings.embeddingModel.ifBlank { AppConfig.models[GEMINI].embeddingModel }.lowercase()
+        val modelName = settings.embeddingModel.lowercase()
         return when {
             modelName.contains("embedding-001") -> 2048
             modelName.contains("text-embedding-004") -> 2048

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
@@ -10,7 +10,6 @@ import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.openai.OpenAiChatModel
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import io.askimo.core.config.AppConfig
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.util.ApiKeyUtils.safeApiKey
@@ -56,7 +55,6 @@ internal class OpenAiCompatibleCompletionsModelFactory : OpenAiCompatibleDelegat
     override fun createSecondaryModel(settings: OpenAiCompatibleSettings): ChatModel {
         val listener = createTelemetryListener()
         val modelName = settings.utilityModel
-            .ifBlank { AppConfig.models[getProvider()].utilityModel }
             .ifBlank { utilityModelFallback(settings) }
         return OpenAiChatModel.builder()
             .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener))
@@ -127,7 +125,7 @@ class OpenAiCompatibleModelFactory : OpenAiCompatibleChatModelFactory<OpenAiComp
     """.trimIndent()
 
     override fun createEmbeddingModel(settings: OpenAiCompatibleSettings): EmbeddingModel {
-        val modelName = AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel
+        val modelName = settings.embeddingModel
         check(modelName.isNotBlank()) {
             "No embedding model is configured for ${ModelProvider.OPENAI_COMPATIBLE.name}. " +
                 "Go to Settings > AI Provider and select an embedding model under the provider configuration card."
@@ -140,7 +138,7 @@ class OpenAiCompatibleModelFactory : OpenAiCompatibleChatModelFactory<OpenAiComp
     }
 
     override fun getEmbeddingTokenLimit(settings: OpenAiCompatibleSettings): Int {
-        val modelName = AppConfig.models[ModelProvider.OPENAI_COMPATIBLE].embeddingModel.lowercase()
+        val modelName = settings.embeddingModel.lowercase()
         return when {
             modelName.contains("text-embedding-3") -> 8191
             modelName.contains("ada-002") -> 8191


### PR DESCRIPTION
- Remove automatic title suggestion handling from ChatSessionService.
- Decouples session title updating from the summarization process.
- Simplifies the lifecycle management of session metadata.
- This change prepares the system to allow manual control over session titles.