### PR TITLE
feat(openai): add HTTP protocol version configuration

### DIFF
--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1007,6 +1007,11 @@ provider.openai_compatible.apimode.label=API Format
 provider.openai_compatible.apimode.description=Which OpenAI API endpoint this provider uses
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=HTTP Version
+provider.openai_compatible.httpversion.description=HTTP protocol version for connections to this endpoint
+provider.openai_compatible.httpversion.http1_1=Compatible with most servers; use if HTTP/2 causes issues
+provider.openai_compatible.httpversion.http2=Faster for endpoints that fully support HTTP/2
+
 
 # System Resources
 system.share.feedback=Share feedback

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1,4 +1,4 @@
-﻿# Askimo Desktop Application - German Strings (Comments Preserved)
+# Askimo Desktop Application - English Strings
 
 # Application
 
@@ -31,6 +31,7 @@ menu.view.appearance.system=System
 menu.view.appearance.light=Hell
 menu.view.appearance.dark=Dunkel
 menu.view.fullscreen=Vollbildmodus aktivieren
+menu.view.bookmarks=Lesezeichen anzeigen
 menu.terminal=Terminal
 menu.terminal.new=Neues Terminal
 menu.help=Hilfe
@@ -483,6 +484,7 @@ user.interest.environment=Umwelt
 
 # Actions
 action.delete=Löschen
+action.remove=Entfernen
 action.edit=Bearbeiten
 action.pin=An Seitenleiste anheften
 action.unpin=Von Seitenleiste lösen
@@ -503,7 +505,6 @@ action.next=Weiter
 action.retry=Erneut versuchen
 action.done=Fertig
 action.refresh=Aktualisieren
-
 
 # Happiness Gate (shown before Star Prompt)
 happiness.gate.title=Wie gefällt Ihnen Askimo?
@@ -584,10 +585,8 @@ file.overwrite.message=Diese Datei existiert bereits. Möchten Sie sie überschr
 file.overwrite.confirm=Überschreiben
 file.name.too.long=Der Dateiname ist zu lang. Bitte verwenden Sie einen kürzeren Namen (maximal 255 Zeichen).
 
-
 # About
 about.title=Über {0}
-action.remove=Entfernen
 about.version=Version
 about.buildDate=Build-Datum
 about.buildJdk=Build-JDK
@@ -627,7 +626,6 @@ shortcut.previous.search.result=Vorheriges Suchergebnis
 shortcut.attach.file=Datei anhängen
 shortcut.send.message=Nachricht senden
 shortcut.new.line=Neue Zeile
-
 
 # Chat View
 chat.welcome=Willkommen bei Askimo!\nBeginnen Sie eine Unterhaltung, indem Sie unten eine Nachricht eingeben.
@@ -681,12 +679,11 @@ chat.create.image.mode.cancel=Bild-Erstellungsmodus beenden
 chat.rag.web_search.chip=Web
 chat.rag.web_search.tooltip.off=Live-Webergebnisse in den RAG-Kontext einbeziehen (klicken zum Aktivieren)
 chat.rag.web_search.tooltip.on=Live-Webergebnisse im RAG-Kontext (klicken zum Deaktivieren)
-chat.rag.web_search.chip=Web
-chat.rag.web_search.tooltip.off=Live-Webergebnisse in den RAG-Kontext einbeziehen (klicken zum Aktivieren)
-chat.rag.web_search.tooltip.on=Live-Webergebnisse im RAG-Kontext einbezogen (klicken zum Deaktivieren)
 chat.image.model.missing.title=Bildmodell nicht konfiguriert
 chat.image.model.missing.message=Für {0} ist kein Bildmodell festgelegt. Öffnen Sie Einstellungen > KI-Anbieter > Modelle zur Bilderzeugung und legen Sie zuerst einen Modellnamen fest.
 chat.tools.button=Verfügbare Tools
+chat.tools.button.disabled=Verfügbare Tools ({0} deaktiviert)
+chat.tools.button.model.no.support=Tools werden von diesem Modell nicht unterstützt
 chat.tools.popup.title=Verfügbare Tools
 chat.tools.popup.loading=Server werden geladen...
 chat.tools.popup.no.servers.global=Keine globalen MCP-Server konfiguriert.
@@ -695,8 +692,6 @@ chat.tools.server.scope.global=Global
 chat.tools.server.scope.project=Projekt
 chat.tools.server.scope.builtin=Integriert
 chat.tools.tool.no.description=Keine Beschreibung verfügbar
-chat.tools.button.disabled=Verfügbare Tools ({0} deaktiviert)
-chat.tools.button.model.no.support=Tools werden von diesem Modell nicht unterstützt
 chat.reasoning.effort.label=Denken
 chat.reasoning.effort.tooltip=Denkaufwand — steuert, wie tief das Modell nachdenkt, bevor es antwortet
 chat.reasoning.effort.off=Aus
@@ -730,7 +725,7 @@ sessions.empty.hint=💡 Starten Sie eine neue Unterhaltung, um Ihre erste Sitzu
 sessions.search.placeholder=Nach Titel suchen…
 sessions.search.empty=Keine Sitzungen entsprechen "{0}".
 
-# Allgemeine Tabellen-Paginierungssteuerelemente
+# Generic table pagination controls
 table.page.size.label=Zeilen pro Seite:
 table.page=Seite {0} von {1}
 table.page.previous=Vorherige Seite
@@ -745,7 +740,6 @@ sessions.error.not.found=Sitzung nicht gefunden.
 sessions.error.rename.failed=Umbenennen fehlgeschlagen.
 
 # ChatSessionService Errors
-
 # Update Check
 update.dialog.title=Software-Update
 update.dialog.new.version.available=Eine neue Version von Askimo ist verfügbar!
@@ -884,11 +878,27 @@ message.ai.fork=Session von hier aus forken
 message.ai.fork.description=Diese Unterhaltung in eine neue, unabhängige Session forken
 message.ai.export.pdf=Als PDF exportieren
 message.ai.export.pdf.dialog.title=KI-Antwort als PDF speichern
+message.bookmark=Nachricht als Lesezeichen speichern
+message.bookmark.remove=Lesezeichen entfernen
+message.bookmark.description=Diese Nachricht als Lesezeichen speichern
 message.edited.indicator=(bearbeitet)
 message.date.today=Heute
 message.date.yesterday=Gestern
 message.token.usage={0} Tokens · {1} in / {2} out
 message.token.usage.tooltip=Von dieser Antwort verwendete Tokens.\nEingabe: Ihr Prompt + Kontext, der an die KI gesendet wurde.\nAusgabe: die KI-generierte Antwort.
+
+# Bookmarks
+chat.bookmarks.button.tooltip=Lesezeichen
+chat.bookmarks.popover.title=Angeheftete Nachrichten
+chat.bookmarks.popover.empty.title=Noch keine Lesezeichen
+chat.bookmarks.popover.empty.hint=Hefte eine Nachricht mit dem Lesezeichen-Symbol darunter an
+bookmarks.title=Lesezeichen
+bookmarks.empty.title=Noch keine Lesezeichen
+bookmarks.empty.hint=Speichere Nachrichten als Lesezeichen über das Heft-Symbol darunter
+bookmarks.session.untitled=Unbenanntes Gespräch
+bookmarks.message.count={0} angeheftet
+bookmarks.role.user=Du
+bookmarks.role.ai=KI
 
 # Tool call display
 tool.call.header.running=Tool wird ausgeführt...
@@ -997,6 +1007,11 @@ provider.openai_compatible.apimode.label=API-Format
 provider.openai_compatible.apimode.description=Welchen OpenAI API-Endpunkt dieser Anbieter verwendet
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=HTTP-Version
+provider.openai_compatible.httpversion.description=HTTP-Protokollversion für Verbindungen zu diesem Endpunkt
+provider.openai_compatible.httpversion.http1_1=Kompatibel mit den meisten Servern; verwenden, falls HTTP/2 Probleme verursacht
+provider.openai_compatible.httpversion.http2=Schneller für Endpunkte, die HTTP/2 vollständig unterstützen
+
 
 # System Resources
 system.share.feedback=Feedback teilen
@@ -1045,7 +1060,6 @@ developer.session.memory.summary=Memory Summary
 developer.session.memory.messages=Memory Messages
 developer.session.memory.word.count={0} words
 developer.session.memory.empty=(Empty)
-
 
 # Export Format - Markdown
 export.format.markdown.name=Markdown
@@ -1100,7 +1114,6 @@ error.app.message=Ein unerwarteter Fehler ist aufgetreten: {0}
 # Send Message Errors
 error.send_message.title=Nachricht konnte nicht gesendet werden
 
-
 # Indexing Errors
 error.indexing.model_not_found.title=Einbettungsmodell nicht gefunden
 error.indexing.model_not_found.message=Das Einbettungsmodell ''{0}'' wurde nicht gefunden. Bitte laden oder aktivieren Sie dieses Einbettungsmodell von {1}, bevor Sie mit der Indexierung beginnen.
@@ -1144,7 +1157,7 @@ settings.rag.indexing.binary.extensions.hint=Kommagetrennte Dateierweiterungen, 
 settings.rag.indexing.embedding.batch.size=Embedding-Batchgröße
 settings.rag.indexing.embedding.batch.size.hint=Anzahl der Textsegmente, die pro Anfrage an das Embedding-Modell gesendet werden. Wenn die Indizierung langsam ist und Sie einen Remote-Anbieter (OpenAI, Gemini) verwenden, versuchen Sie, den Wert auf 100–500 zu erhöhen. Bei einem lokalen Modell (Ollama, LM Studio) sollte der Wert niedrig bleiben, um Timeouts zu vermeiden.
 
-# Settings - Models
+## Settings - Models
 settings.models.title=Modelle
 settings.models.description=Konfigurieren Sie das globale KI-Modellverhalten, das über alle Anbieter hinweg geteilt wird.
 settings.models.max.tool.calling.round.trips=Maximale Tool-Aufruf-Runden
@@ -1164,7 +1177,7 @@ settings.memory.mode.detail=Detailliert
 settings.memory.mode.detail.hint=Hohe Wiedergabetreue, mehr Tokens
 settings.memory.mode.detail.description=Minimales Zusammenfassen. Behält mehr wörtliche Gesprächsrunden und reichhaltigere Zusammenfassungen bei. Ideal für kurze Sitzungen oder wenn präziser Abruf wichtig ist.
 
-# Settings - Utility Models
+## Settings - Utility Models
 settings.utility.models.title=Hilfsmodelle
 settings.utility.models.uses.selected=(verwendet das ausgewählte Modell)
 settings.utility.models.local.note={0} ist ein lokaler Anbieter — das aktuell aktive Chat-Modell wird automatisch für Hilfsaufgaben verwendet.
@@ -1175,7 +1188,7 @@ settings.vision.models.title=Vision-Modelle
 ## Settings - Image Models
 settings.image.models.title=Bildgenerierungsmodelle
 
-# Settings - Provider Model Config
+## Settings - Provider Model Config
 settings.provider.model.config.title=Modellkonfiguration
 settings.provider.model.config.description=Überschreiben Sie die Standardmodelle für bestimmte Aufgaben. Lassen Sie ein Feld leer, um das Standardmodell des Anbieters zu verwenden.
 settings.provider.model.config.guide=KI-Modellkonfigurationsanleitung anzeigen
@@ -1185,7 +1198,6 @@ settings.provider.model.image.hint=Modell zur Generierung von Bildern aus Textbe
 settings.provider.model.embedding.hint=Modell zur Erzeugung von Vektor-Embeddings für die RAG-Wissensdatenbanksuche
 
 settings.model.placeholder.enter={0}-Modell eingeben
-
 
 # File Viewer Dialog
 file.viewer.title=Dateibetrachter
@@ -1417,7 +1429,6 @@ rag.empty.title=Keine Wissensquellen
 rag.empty.description=Fügen Sie Dateien oder Ordner hinzu,\num RAG für dieses Projekt zu aktivieren
 rag.empty.button.add=Quellen hinzufügen
 
-
 # Plans
 plans.nav.title=Pläne
 plans.title=Pläne
@@ -1622,20 +1633,3 @@ persona.developer=💻 Code schreiben und überprüfen
 persona.researcher=🔬 Recherchieren und analysieren
 persona.manager=📋 Schreiben und organisieren
 persona.everything=⚡ Ich mache eine Mischung aus Dingen
-
-# Bookmarks
-menu.view.bookmarks=Lesezeichen anzeigen
-message.bookmark=Nachricht als Lesezeichen speichern
-message.bookmark.remove=Lesezeichen entfernen
-message.bookmark.description=Diese Nachricht als Lesezeichen speichern
-chat.bookmarks.button.tooltip=Lesezeichen
-chat.bookmarks.popover.title=Angeheftete Nachrichten
-chat.bookmarks.popover.empty.title=Noch keine Lesezeichen
-chat.bookmarks.popover.empty.hint=Hefte eine Nachricht mit dem Lesezeichen-Symbol darunter an
-bookmarks.title=Lesezeichen
-bookmarks.empty.title=Noch keine Lesezeichen
-bookmarks.empty.hint=Speichere Nachrichten als Lesezeichen über das Heft-Symbol darunter
-bookmarks.session.untitled=Unbenanntes Gespräch
-bookmarks.message.count={0} angeheftet
-bookmarks.role.user=Du
-bookmarks.role.ai=KI

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1,4 +1,4 @@
-﻿# Askimo Desktop Application - Spanish Strings (Comments Preserved)
+# Askimo Desktop Application - English Strings
 
 # Application
 
@@ -31,6 +31,7 @@ menu.view.appearance.system=Sistema
 menu.view.appearance.light=Claro
 menu.view.appearance.dark=Oscuro
 menu.view.fullscreen=Entrar en pantalla completa
+menu.view.bookmarks=Ver marcadores
 menu.terminal=Terminal
 menu.terminal.new=Nuevo terminal
 menu.help=Ayuda
@@ -483,6 +484,7 @@ user.interest.environment=Medio ambiente
 
 # Actions
 action.delete=Eliminar
+action.remove=Eliminar
 action.edit=Editar
 action.pin=Fijar en la barra lateral
 action.unpin=Desfijar de la barra lateral
@@ -583,10 +585,8 @@ file.overwrite.message=Este archivo ya existe. ¿Quieres sobrescribirlo?
 file.overwrite.confirm=Sobrescribir
 file.name.too.long=El nombre del archivo es demasiado largo. Usa un nombre más corto (máximo 255 caracteres).
 
-
 # About
 about.title=Acerca de {0}
-action.remove=Eliminar
 about.version=Versión
 about.buildDate=Fecha de compilación
 about.buildJdk=JDK de compilación
@@ -682,6 +682,8 @@ chat.rag.web_search.tooltip.on=Resultados web en tiempo real incluidos en el con
 chat.image.model.missing.title=Modelo de imagen no configurado
 chat.image.model.missing.message=No hay ningún modelo de imagen configurado para {0}. Abre Configuración > Proveedor de IA > Modelos de generación de imágenes y establece primero un nombre de modelo.
 chat.tools.button=Herramientas disponibles
+chat.tools.button.disabled=Herramientas disponibles ({0} deshabilitadas)
+chat.tools.button.model.no.support=Las herramientas no son compatibles con este modelo
 chat.tools.popup.title=Herramientas disponibles
 chat.tools.popup.loading=Cargando servidores...
 chat.tools.popup.no.servers.global=No hay servidores MCP globales configurados.
@@ -690,8 +692,6 @@ chat.tools.server.scope.global=Global
 chat.tools.server.scope.project=Proyecto
 chat.tools.server.scope.builtin=Integrado
 chat.tools.tool.no.description=No hay descripción disponible
-chat.tools.button.disabled=Herramientas disponibles ({0} deshabilitadas)
-chat.tools.button.model.no.support=Las herramientas no son compatibles con este modelo
 chat.reasoning.effort.label=Pensando
 chat.reasoning.effort.tooltip=Esfuerzo de razonamiento — controla qué tan profundo piensa el modelo antes de responder
 chat.reasoning.effort.off=Desactivado
@@ -725,7 +725,7 @@ sessions.empty.hint=💡 ¡Inicia un chat nuevo para crear tu primera sesión!
 sessions.search.placeholder=Buscar por título…
 sessions.search.empty=Ninguna sesión coincide con "{0}".
 
-# Controles genéricos de paginación de tablas
+# Generic table pagination controls
 table.page.size.label=Filas por página:
 table.page=Página {0} de {1}
 table.page.previous=Página anterior
@@ -740,7 +740,6 @@ sessions.error.not.found=Sesión no encontrada.
 sessions.error.rename.failed=Fallo al renombrar sesión.
 
 # ChatSessionService Errors
-
 # Update Check
 update.dialog.title=Actualización de software
 update.dialog.new.version.available=¡Hay una nueva versión de Askimo disponible!
@@ -879,11 +878,27 @@ message.ai.fork=Fork session from here
 message.ai.fork.description=Fork this conversation into a new independent session
 message.ai.export.pdf=Exportar como PDF
 message.ai.export.pdf.dialog.title=Guardar respuesta de IA como PDF
+message.bookmark=Marcar mensaje
+message.bookmark.remove=Quitar marcador
+message.bookmark.description=Marcar este mensaje
 message.edited.indicator=(editado)
 message.date.today=Hoy
 message.date.yesterday=Ayer
 message.token.usage={0} tokens · {1} de entrada / {2} de salida
 message.token.usage.tooltip=Tokens utilizados por esta respuesta.\nEntrada: su prompt + contexto enviado a la IA.\nSalida: la respuesta generada por la IA.
+
+# Bookmarks
+chat.bookmarks.button.tooltip=Marcadores
+chat.bookmarks.popover.title=Mensajes fijados
+chat.bookmarks.popover.empty.title=Aún no hay marcadores
+chat.bookmarks.popover.empty.hint=Fija cualquier mensaje con el icono de marcador debajo de él
+bookmarks.title=Marcadores
+bookmarks.empty.title=Aún no hay marcadores
+bookmarks.empty.hint=Marca mensajes con el icono de anclaje debajo de ellos
+bookmarks.session.untitled=Conversación sin título
+bookmarks.message.count={0} fijados
+bookmarks.role.user=Tú
+bookmarks.role.ai=IA
 
 # Tool call display
 tool.call.header.running=Ejecutando herramienta...
@@ -992,6 +1007,11 @@ provider.openai_compatible.apimode.label=Formato de API
 provider.openai_compatible.apimode.description=Qué endpoint de la API de OpenAI utiliza este proveedor
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=Versión HTTP
+provider.openai_compatible.httpversion.description=Versión del protocolo HTTP para conexiones a este endpoint
+provider.openai_compatible.httpversion.http1_1=Compatible con la mayoría de los servidores; úselo si HTTP/2 causa problemas
+provider.openai_compatible.httpversion.http2=Más rápido para endpoints que soportan HTTP/2 completamente
+
 
 # System Resources
 system.share.feedback=Compartir comentarios
@@ -1137,7 +1157,7 @@ settings.rag.indexing.binary.extensions.hint=Extensiones de archivo separadas po
 settings.rag.indexing.embedding.batch.size=Tamaño del lote de embeddings
 settings.rag.indexing.embedding.batch.size.hint=Número de segmentos de texto enviados al modelo de embeddings por solicitud. Si la indexación es lenta y usas un proveedor remoto (OpenAI, Gemini), intenta aumentarlo a 100–500. Si usas un modelo local (Ollama, LM Studio), mantenlo bajo para evitar tiempos de espera.
 
-# Settings - Models
+## Settings - Models
 settings.models.title=Modelos
 settings.models.description=Configura el comportamiento global de los modelos de IA compartido entre todos los proveedores.
 settings.models.max.tool.calling.round.trips=Máximo de rondas de llamadas a herramientas
@@ -1157,7 +1177,7 @@ settings.memory.mode.detail=Detallado
 settings.memory.mode.detail.hint=Alta fidelidad, más tokens
 settings.memory.mode.detail.description=Resumen mínimo. Conserva más turnos literales y resúmenes más ricos. Ideal para sesiones cortas o cuando el recuerdo preciso es importante.
 
-# Settings - Utility Models
+## Settings - Utility Models
 settings.utility.models.title=Modelos de utilidad
 settings.utility.models.uses.selected=(usa el modelo seleccionado)
 settings.utility.models.local.note={0} es un proveedor local — el modelo de chat activo se utiliza automáticamente para las tareas de utilidad.
@@ -1168,7 +1188,7 @@ settings.vision.models.title=Modelos de visión
 ## Settings - Image Models
 settings.image.models.title=Modelos de generación de imágenes
 
-# Settings - Provider Model Config
+## Settings - Provider Model Config
 settings.provider.model.config.title=Configuración del modelo
 settings.provider.model.config.description=Anule los modelos predeterminados utilizados para tareas específicas. Deje un campo vacío para usar el modelo predeterminado del proveedor.
 settings.provider.model.config.guide=Ver guía de configuración del modelo de IA
@@ -1178,7 +1198,6 @@ settings.provider.model.image.hint=Modelo utilizado para generar imágenes a par
 settings.provider.model.embedding.hint=Modelo utilizado para generar embeddings vectoriales para la búsqueda en la base de conocimiento RAG
 
 settings.model.placeholder.enter=Introducir modelo {0}
-
 
 # File Viewer Dialog
 file.viewer.title=Visor de archivos
@@ -1614,20 +1633,3 @@ persona.developer=💻 Escribir y revisar código
 persona.researcher=🔬 Investigar y analizar
 persona.manager=📋 Escribir y organizar
 persona.everything=⚡ Hago una mezcla de cosas
-
-# Bookmarks
-menu.view.bookmarks=Ver marcadores
-message.bookmark=Marcar mensaje
-message.bookmark.remove=Quitar marcador
-message.bookmark.description=Marcar este mensaje
-chat.bookmarks.button.tooltip=Marcadores
-chat.bookmarks.popover.title=Mensajes fijados
-chat.bookmarks.popover.empty.title=Aún no hay marcadores
-chat.bookmarks.popover.empty.hint=Fija cualquier mensaje con el icono de marcador debajo de él
-bookmarks.title=Marcadores
-bookmarks.empty.title=Aún no hay marcadores
-bookmarks.empty.hint=Marca mensajes con el icono de anclaje debajo de ellos
-bookmarks.session.untitled=Conversación sin título
-bookmarks.message.count={0} fijados
-bookmarks.role.user=Tú
-bookmarks.role.ai=IA

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1,4 +1,4 @@
-﻿# Askimo Desktop Application - French Strings (Comments Preserved)
+# Askimo Desktop Application - English Strings
 
 # Application
 
@@ -31,6 +31,7 @@ menu.view.appearance.system=Système
 menu.view.appearance.light=Clair
 menu.view.appearance.dark=Sombre
 menu.view.fullscreen=Entrer en plein écran
+menu.view.bookmarks=Voir les signets
 menu.terminal=Terminal
 menu.terminal.new=Nouveau terminal
 menu.help=Aide
@@ -483,6 +484,7 @@ user.interest.environment=Environnement
 
 # Actions
 action.delete=Supprimer
+action.remove=Supprimer
 action.edit=Modifier
 action.pin=Épingler à la barre latérale
 action.unpin=Détacher de la barre latérale
@@ -583,10 +585,8 @@ file.overwrite.message=Ce fichier existe déjà. Voulez-vous le remplacer ?
 file.overwrite.confirm=Remplacer
 file.name.too.long=Le nom du fichier est trop long. Veuillez utiliser un nom plus court (255 caractères maximum).
 
-
 # About
 about.title=À propos de {0}
-action.remove=Supprimer
 about.version=Version
 about.buildDate=Date de compilation
 about.buildJdk=JDK de compilation
@@ -682,6 +682,8 @@ chat.rag.web_search.tooltip.on=Résultats web en direct inclus dans le contexte 
 chat.image.model.missing.title=Modèle d'image non configuré
 chat.image.model.missing.message=Aucun modèle d'image n'est défini pour {0}. Ouvrez Paramètres > Fournisseur d'IA > Modèles de génération d'images et définissez d'abord un nom de modèle.
 chat.tools.button=Outils disponibles
+chat.tools.button.disabled=Outils disponibles ({0} désactivés)
+chat.tools.button.model.no.support=Les outils ne sont pas pris en charge par ce modèle
 chat.tools.popup.title=Outils disponibles
 chat.tools.popup.loading=Chargement des serveurs...
 chat.tools.popup.no.servers.global=Aucun serveur MCP global configuré.
@@ -690,8 +692,6 @@ chat.tools.server.scope.global=Global
 chat.tools.server.scope.project=Projet
 chat.tools.server.scope.builtin=Intégré
 chat.tools.tool.no.description=Aucune description disponible
-chat.tools.button.disabled=Outils disponibles ({0} désactivés)
-chat.tools.button.model.no.support=Les outils ne sont pas pris en charge par ce modèle
 chat.reasoning.effort.label=Réflexion
 chat.reasoning.effort.tooltip=Effort de raisonnement — contrôle la profondeur de réflexion du modèle avant de répondre
 chat.reasoning.effort.off=Désactivé
@@ -725,7 +725,7 @@ sessions.empty.hint=💡 Démarrez une nouvelle conversation pour créer votre p
 sessions.search.placeholder=Rechercher par titre…
 sessions.search.empty=Aucune session ne correspond à "{0}".
 
-# Commandes génériques de pagination des tableaux
+# Generic table pagination controls
 table.page.size.label=Lignes par page:
 table.page=Page {0} sur {1}
 table.page.previous=Page précédente
@@ -740,7 +740,6 @@ sessions.error.not.found=Session introuvable.
 sessions.error.rename.failed=Renommage impossible.
 
 # ChatSessionService Errors
-
 # Update Check
 update.dialog.title=Mise à jour du logiciel
 update.dialog.new.version.available=Une nouvelle version d’Askimo est disponible !
@@ -879,11 +878,27 @@ message.ai.fork=Hacer fork de la sesión desde aquí
 message.ai.fork.description=Dividir esta conversación en una nueva sesión independiente
 message.ai.export.pdf=Exporter en PDF
 message.ai.export.pdf.dialog.title=Enregistrer la reponse IA en PDF
+message.bookmark=Mettre en signet
+message.bookmark.remove=Supprimer le signet
+message.bookmark.description=Mettre ce message en signet
 message.edited.indicator=(modifié)
 message.date.today=Aujourd'hui
 message.date.yesterday=Hier
 message.token.usage={0} tokens · {1} en entrée / {2} en sortie
 message.token.usage.tooltip=Tokens utilisés par cette réponse.\nEntrée: votre prompt + contexte envoyé à l'IA.\nSortie: la réponse générée par l'IA.
+
+# Bookmarks
+chat.bookmarks.button.tooltip=Signets
+chat.bookmarks.popover.title=Messages épinglés
+chat.bookmarks.popover.empty.title=Aucun signet pour l’instant
+chat.bookmarks.popover.empty.hint=Épingle un message avec l’icône signet en dessous
+bookmarks.title=Signets
+bookmarks.empty.title=Aucun signet pour l’instant
+bookmarks.empty.hint=Ajoute un signet via l’icône d’épingle sous chaque message
+bookmarks.session.untitled=Conversation sans titre
+bookmarks.message.count={0} épinglés
+bookmarks.role.user=Vous
+bookmarks.role.ai=IA
 
 # Tool call display
 tool.call.header.running=Exécution de l'outil...
@@ -992,6 +1007,11 @@ provider.openai_compatible.apimode.label=Format d'API
 provider.openai_compatible.apimode.description=Quel endpoint de l'API OpenAI ce fournisseur utilise
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=Version HTTP
+provider.openai_compatible.httpversion.description=Version du protocole HTTP pour les connexions à ce point de terminaison
+provider.openai_compatible.httpversion.http1_1=Compatible avec la plupart des serveurs ; à utiliser si HTTP/2 pose problème
+provider.openai_compatible.httpversion.http2=Plus rapide pour les points de terminaison qui prennent entièrement en charge HTTP/2
+
 
 # System Resources
 system.share.feedback=Partager vos commentaires
@@ -1094,7 +1114,6 @@ error.app.message=Une erreur inattendue s’est produite : {0}
 # Send Message Errors
 error.send_message.title=Échec de l’envoi du message
 
-
 # Indexing Errors
 error.indexing.model_not_found.title=Modèle d’embedding introuvable
 error.indexing.model_not_found.message=Le modèle d’embedding ''{0}'' est introuvable. Veuillez télécharger ou activer ce modèle depuis {1} avant l’indexation.
@@ -1138,7 +1157,7 @@ settings.rag.indexing.binary.extensions.hint=Extensions de fichiers séparées p
 settings.rag.indexing.embedding.batch.size=Taille du lot d'embeddings
 settings.rag.indexing.embedding.batch.size.hint=Nombre de segments de texte envoyés au modèle d'embeddings par requête. Si l'indexation est lente et que vous utilisez un fournisseur distant (OpenAI, Gemini), essayez d'augmenter à 100–500. Avec un modèle local (Ollama, LM Studio), gardez cette valeur basse pour éviter les délais d'attente.
 
-# Settings - Models
+## Settings - Models
 settings.models.title=Modèles
 settings.models.description=Configurez le comportement global du modèle IA partagé entre tous les fournisseurs.
 settings.models.max.tool.calling.round.trips=Nombre maximal d'allers-retours d'appel d'outils
@@ -1158,18 +1177,18 @@ settings.memory.mode.detail=Détaillé
 settings.memory.mode.detail.hint=Haute fidélité, plus de tokens
 settings.memory.mode.detail.description=Résumé minimal. Conserve plus de tours verbatim et des résumés plus riches. Idéal pour les sessions courtes ou lorsque le rappel précis est important.
 
-# Settings - Utility Models
+## Settings - Utility Models
 settings.utility.models.title=Modèles utilitaires
 settings.utility.models.uses.selected=(utilise le modèle sélectionné)
 settings.utility.models.local.note={0} est un fournisseur local — le modèle de chat actif est utilisé automatiquement pour les tâches utilitaires.
 
-# Settings - Vision Models
+## Settings - Vision Models
 settings.vision.models.title=Modèles de vision
 
 ## Settings - Image Models
 settings.image.models.title=Modèles de génération d’images
 
-# Settings - Provider Model Config
+## Settings - Provider Model Config
 settings.provider.model.config.title=Configuration du modèle
 settings.provider.model.config.description=Remplacez les modèles par défaut utilisés pour des tâches spécifiques. Laissez un champ vide pour utiliser le modèle par défaut du fournisseur.
 settings.provider.model.config.guide=Voir le guide de configuration du modèle d'IA
@@ -1179,7 +1198,6 @@ settings.provider.model.image.hint=Modèle utilisé pour générer des images à
 settings.provider.model.embedding.hint=Modèle utilisé pour générer des embeddings vectoriels pour la recherche dans la base de connaissances RAG
 
 settings.model.placeholder.enter=Saisir le modèle {0}
-
 
 # File Viewer Dialog
 file.viewer.title=Visionneuse de fichiers
@@ -1615,20 +1633,3 @@ persona.developer=💻 Écrire et réviser du code
 persona.researcher=🔬 Rechercher et analyser
 persona.manager=📋 Écrire et organiser
 persona.everything=⚡ Je fais un mélange de choses
-
-# Bookmarks
-menu.view.bookmarks=Voir les signets
-message.bookmark=Mettre en signet
-message.bookmark.remove=Supprimer le signet
-message.bookmark.description=Mettre ce message en signet
-chat.bookmarks.button.tooltip=Signets
-chat.bookmarks.popover.title=Messages épinglés
-chat.bookmarks.popover.empty.title=Aucun signet pour l’instant
-chat.bookmarks.popover.empty.hint=Épingle un message avec l’icône signet en dessous
-bookmarks.title=Signets
-bookmarks.empty.title=Aucun signet pour l’instant
-bookmarks.empty.hint=Ajoute un signet via l’icône d’épingle sous chaque message
-bookmarks.session.untitled=Conversation sans titre
-bookmarks.message.count={0} épinglés
-bookmarks.role.user=Vous
-bookmarks.role.ai=IA

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1,4 +1,4 @@
-﻿# Askimo Desktop Application - Japanese Strings (Comments Preserved)
+# Askimo Desktop Application - English Strings
 
 # Application
 
@@ -31,6 +31,7 @@ menu.view.appearance.system=システム
 menu.view.appearance.light=ライト
 menu.view.appearance.dark=ダーク
 menu.view.fullscreen=フルスクリーンにする
+menu.view.bookmarks=ブックマークを表示
 menu.terminal=ターミナル
 menu.terminal.new=新しいターミナル
 menu.help=ヘルプ
@@ -483,6 +484,7 @@ user.interest.environment=環境
 
 # Actions
 action.delete=削除
+action.remove=削除
 action.edit=編集
 action.pin=サイドバーに固定
 action.unpin=サイドバーから固定解除
@@ -583,10 +585,8 @@ file.overwrite.message=このファイルは既に存在しています。上書
 file.overwrite.confirm=上書きする
 file.name.too.long=ファイル名が長すぎます。より短いファイル名を使用してください（最大255文字）。
 
-
 # About
 about.title={0} について
-action.remove=削除
 about.version=バージョン
 about.buildDate=ビルド日
 about.buildJdk=ビルド JDK
@@ -682,6 +682,8 @@ chat.rag.web_search.tooltip.on=RAGコンテキストにライブウェブ結果�
 chat.image.model.missing.title=画像モデルが設定されていません
 chat.image.model.missing.message={0} に画像モデルが設定されていません。設定 > AI プロバイダー > 画像生成モデルを開き、まずモデル名を設定してください。
 chat.tools.button=利用可能なツール
+chat.tools.button.disabled=利用可能なツール（{0} 無効）
+chat.tools.button.model.no.support=ツールはこのモデルではサポートされていません
 chat.tools.popup.title=利用可能なツール
 chat.tools.popup.loading=サーバーを読み込み中...
 chat.tools.popup.no.servers.global=グローバル MCP サーバーが設定されていません。
@@ -690,8 +692,6 @@ chat.tools.server.scope.global=グローバル
 chat.tools.server.scope.project=プロジェクト
 chat.tools.server.scope.builtin=組み込み
 chat.tools.tool.no.description=説明はありません
-chat.tools.button.disabled=利用可能なツール（{0} 無効）
-chat.tools.button.model.no.support=ツールはこのモデルではサポートされていません
 chat.reasoning.effort.label=思考
 chat.reasoning.effort.tooltip=推論の労力 — 応答する前にモデルがどの程度深く思考するかを制御します
 chat.reasoning.effort.off=オフ
@@ -725,7 +725,7 @@ sessions.empty.hint=💡 新しいチャットを開始して最初のセッシ�
 sessions.search.placeholder=タイトルで検索…
 sessions.search.empty="{0}" に一致するセッションはありません。
 
-# 汎用テーブルページネーションコントロール
+# Generic table pagination controls
 table.page.size.label=1ページあたりの行数:
 table.page=ページ {0} / {1}
 table.page.previous=前のページ
@@ -740,7 +740,6 @@ sessions.error.not.found=セッションが見つかりません。
 sessions.error.rename.failed=セッション名の変更に失敗しました。
 
 # ChatSessionService Errors
-
 # Update Check
 update.dialog.title=ソフトウェアアップデート
 update.dialog.new.version.available=新しい Askimo バージョンがあります！
@@ -879,11 +878,27 @@ message.ai.fork=ここからセッションをフォーク
 message.ai.fork.description=この会話を新しい独立したセッションにフォークする
 message.ai.export.pdf=PDFとしてエクスポート
 message.ai.export.pdf.dialog.title=AIの回答をPDFとして保存
+message.bookmark=メッセージをブックマーク
+message.bookmark.remove=ブックマークを解除
+message.bookmark.description=このメッセージをブックマークする
 message.edited.indicator=(編集済み)
 message.date.today=今日
 message.date.yesterday=昨日
 message.token.usage={0} トークン · {1} 入力 / {2} 出力
 message.token.usage.tooltip=この応答で使用されたトークン。\n入力: AIに送信されたプロンプトとコンテキスト。\n出力: AIが生成した返信。
+
+# Bookmarks
+chat.bookmarks.button.tooltip=ブックマーク
+chat.bookmarks.popover.title=ピン留めしたメッセージ
+chat.bookmarks.popover.empty.title=ブックマークはまだありません
+chat.bookmarks.popover.empty.hint=メッセージ下のブックマークアイコンでピン留めできます
+bookmarks.title=ブックマーク
+bookmarks.empty.title=ブックマークはまだありません
+bookmarks.empty.hint=メッセージ下のピンアイコンでブックマークできます
+bookmarks.session.untitled=タイトルなしの会話
+bookmarks.message.count={0}件ピン留め
+bookmarks.role.user=あなた
+bookmarks.role.ai=AI
 
 # Tool call display
 tool.call.header.running=ツールを実行中...
@@ -992,6 +1007,11 @@ provider.openai_compatible.apimode.label=API形式
 provider.openai_compatible.apimode.description=このプロバイダーが使用するOpenAI APIエンドポイント
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=HTTPバージョン
+provider.openai_compatible.httpversion.description=このエンドポイントへの接続に使用するHTTPプロトコルバージョン
+provider.openai_compatible.httpversion.http1_1=ほとんどのサーバーと互換性があります。HTTP/2で問題が発生する場合に使用してください
+provider.openai_compatible.httpversion.http2=HTTP/2を完全にサポートしているエンドポイントでより高速です
+
 
 # System Resources
 system.share.feedback=フィードバックを共有
@@ -1065,7 +1085,6 @@ export.format.html.benefit.2=どのブラウザでも閲覧可能
 export.format.html.benefit.3=プロフェッショナルな外観
 export.format.html.benefit.4=共有が簡単
 
-
 # Error Messages
 error.network=⚠️ AI サービス{endpoint}に接続できません\n\n次をご確認ください：\n• インターネット接続\n• AI サービスの URL（設定を確認）\n• ファイアウォール設定\n• サービスの稼働状況
 error.authentication=⚠️ API キーが無効、または設定されていません{provider}\n\n設定画面で API キーを入力すると解決できます。
@@ -1094,7 +1113,6 @@ error.app.message=予期しないエラーが発生しました: {0}
 
 # Send Message Errors
 error.send_message.title=メッセージの送信に失敗しました
-
 
 # Indexing Errors
 error.indexing.model_not_found.title=埋め込みモデルが見つかりません
@@ -1139,7 +1157,7 @@ settings.rag.indexing.binary.extensions.hint=インデックス中にバイナ�
 settings.rag.indexing.embedding.batch.size=埋め込みバッチサイズ
 settings.rag.indexing.embedding.batch.size.hint=1回のリクエストで埋め込みモデルに送信するテキストセグメント数です。リモートプロバイダー（OpenAI、Gemini）を使用していてインデックスが遅い場合は、100〜500に増やすことを検討してください。ローカルモデル（Ollama、LM Studio）の場合はタイムアウトを避けるために低く保ってください。
 
-# Settings - Models
+## Settings - Models
 settings.models.title=モデル
 settings.models.description=すべてのプロバイダーで共有されるグローバル AI モデルの動作を設定します。
 settings.models.max.tool.calling.round.trips=最大ツール呼び出しラウンドトリップ数
@@ -1159,18 +1177,18 @@ settings.memory.mode.detail=詳細
 settings.memory.mode.detail.hint=高精度、より多くのトークン
 settings.memory.mode.detail.description=最小限の要約。より多くの原文の会話と豊富な要約を保持します。短いセッションや正確な記憶が重要な場合に最適です。
 
-# Settings - Utility Models
+## Settings - Utility Models
 settings.utility.models.title=ユーティリティモデル
 settings.utility.models.uses.selected=（選択されたモデルを使用）
 settings.utility.models.local.note={0} はローカルプロバイダーです — ユーティリティタスクには現在のチャットモデルが自動的に使用されます。
 
-#Settings - Vision Models
+## Settings - Vision Models
 settings.vision.models.title=ビジョンモデル
 
 ## Settings - Image Models
 settings.image.models.title=画像生成モデル
 
-# Settings - Provider Model Config
+## Settings - Provider Model Config
 settings.provider.model.config.title=モデル設定
 settings.provider.model.config.description=特定のタスクで使用されるデフォルトモデルを上書きします。空欄のままにすると、プロバイダーのデフォルトモデルが使用されます。
 settings.provider.model.config.guide=AIモデル設定ガイドを見る
@@ -1615,21 +1633,3 @@ persona.developer=💻 コードの作成とレビュー
 persona.researcher=🔬 調査と分析
 persona.manager=📋 作成と整理
 persona.everything=⚡ 色々なことを組み合わせています
-
-# Bookmarks
-menu.view.bookmarks=ブックマークを表示
-message.bookmark=メッセージをブックマーク
-message.bookmark.remove=ブックマークを解除
-message.bookmark.description=このメッセージをブックマークする
-chat.bookmarks.button.tooltip=ブックマーク
-chat.bookmarks.popover.title=ピン留めしたメッセージ
-chat.bookmarks.popover.empty.title=ブックマークはまだありません
-chat.bookmarks.popover.empty.hint=メッセージ下のブックマークアイコンでピン留めできます
-bookmarks.title=ブックマーク
-bookmarks.empty.title=ブックマークはまだありません
-bookmarks.empty.hint=メッセージ下のピンアイコンでブックマークできます
-bookmarks.session.untitled=タイトルなしの会話
-bookmarks.message.count={0}件ピン留め
-bookmarks.role.user=あなた
-bookmarks.role.ai=AI
-EOF#cat >> /Users/hainguyen/Projects/github/huynguyen-askimo/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties << 'EOF'

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1,4 +1,4 @@
-﻿# Askimo Desktop Application - Korean Strings (Comments Preserved)
+# Askimo Desktop Application - English Strings
 
 # Application
 
@@ -31,6 +31,7 @@ menu.view.appearance.system=시스템
 menu.view.appearance.light=라이트
 menu.view.appearance.dark=다크
 menu.view.fullscreen=전체 화면으로 전환
+menu.view.bookmarks=북마크 보기
 menu.terminal=터미널
 menu.terminal.new=새 터미널
 menu.help=도움말
@@ -483,6 +484,7 @@ user.interest.environment=환경
 
 # Actions
 action.delete=삭제
+action.remove=삭제
 action.edit=편집
 action.pin=사이드바에 고정
 action.unpin=사이드바에서 고정 해제
@@ -583,10 +585,8 @@ file.overwrite.message=이 파일은 이미 존재합니다. 덮어쓰시겠습�
 file.overwrite.confirm=덮어쓰기
 file.name.too.long=파일 이름이 너무 깁니다. 더 짧은 이름을 사용해주세요 (최대 255자).
 
-
 # About
 about.title={0} 정보
-action.remove=삭제
 about.version=버전
 about.buildDate=빌드 날짜
 about.buildJdk=빌드 JDK
@@ -682,6 +682,8 @@ chat.rag.web_search.tooltip.on=RAG 컨텍스트에 실시간 웹 결과 포함�
 chat.image.model.missing.title=이미지 모델이 구성되지 않았습니다
 chat.image.model.missing.message={0}에 설정된 이미지 모델이 없습니다. 설정 > AI 제공업체 > 이미지 생성 모델을 열고 먼저 모델 이름을 설정하세요.
 chat.tools.button=사용 가능한 도구
+chat.tools.button.disabled=사용 가능한 도구 ({0} 비활성화됨)
+chat.tools.button.model.no.support=이 모델은 도구를 지원하지 않습니다
 chat.tools.popup.title=사용 가능한 도구
 chat.tools.popup.loading=서버 로딩 중...
 chat.tools.popup.no.servers.global=전역 MCP 서버가 설정되지 않았습니다.
@@ -690,8 +692,6 @@ chat.tools.server.scope.global=전역
 chat.tools.server.scope.project=프로젝트
 chat.tools.server.scope.builtin=내장
 chat.tools.tool.no.description=설명이 없습니다
-chat.tools.button.disabled=사용 가능한 도구 ({0} 비활성화됨)
-chat.tools.button.model.no.support=이 모델은 도구를 지원하지 않습니다
 chat.reasoning.effort.label=생각 중
 chat.reasoning.effort.tooltip=추론 노력 — 모델이 응답하기 전에 얼마나 깊이 생각할지 제어합니다
 chat.reasoning.effort.off=끄기
@@ -725,7 +725,7 @@ sessions.empty.hint=💡 새 대화를 시작해 첫 세션을 만들어 보세�
 sessions.search.placeholder=제목으로 검색…
 sessions.search.empty="{0}"과(와) 일치하는 세션이 없습니다.
 
-# 일반 테이블 페이지 매김 컨트롤
+# Generic table pagination controls
 table.page.size.label=페이지당 행 수:
 table.page=페이지 {0} / {1}
 table.page.previous=이전 페이지
@@ -740,7 +740,6 @@ sessions.error.not.found=세션을 찾을 수 없습니다.
 sessions.error.rename.failed=이름 변경 실패.
 
 # ChatSessionService Errors
-
 # Update Check
 update.dialog.title=소프트웨어 업데이트
 update.dialog.new.version.available=새로운 Askimo 버전 이용 가능!
@@ -879,11 +878,27 @@ message.ai.fork=여기서 세션 포크(Fork)
 message.ai.fork.description=이 대화를 새로운 독립 세션으로 포크(Fork)합니다
 message.ai.export.pdf=PDF로 내보내기
 message.ai.export.pdf.dialog.title=AI 응답을 PDF로 저장
+message.bookmark=메시지 북마크
+message.bookmark.remove=북마크 제거
+message.bookmark.description=이 메시지를 북마크합니다
 message.edited.indicator=(편집됨)
 message.date.today=오늘
 message.date.yesterday=어제
 message.token.usage={0} 토큰 · {1} 입력 / {2} 출력
 message.token.usage.tooltip=이 응답에 사용된 토큰입니다.\n입력: AI로 전송된 프롬프트 및 컨텍스트.\n출력: AI가 생성한 응답.
+
+# Bookmarks
+chat.bookmarks.button.tooltip=북마크
+chat.bookmarks.popover.title=고정된 메시지
+chat.bookmarks.popover.empty.title=아직 북마크가 없습니다
+chat.bookmarks.popover.empty.hint=메시지 아래의 북마크 아이콘으로 고정하세요
+bookmarks.title=북마크
+bookmarks.empty.title=아직 북마크가 없습니다
+bookmarks.empty.hint=메시지 아래의 핀 아이콘으로 북마크하세요
+bookmarks.session.untitled=제목 없는 대화
+bookmarks.message.count={0}개 고정됨
+bookmarks.role.user=나
+bookmarks.role.ai=AI
 
 # Tool call display
 tool.call.header.running=도구 실행 중...
@@ -992,6 +1007,11 @@ provider.openai_compatible.apimode.label=API 형식
 provider.openai_compatible.apimode.description=이 제공업체가 사용하는 OpenAI API 엔드포인트
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=HTTP 버전
+provider.openai_compatible.httpversion.description=이 엔드포인트 연결을 위한 HTTP 프로토콜 버전
+provider.openai_compatible.httpversion.http1_1=대부분의 서버와 호환됨; HTTP/2에서 문제가 발생할 경우 사용
+provider.openai_compatible.httpversion.http2=HTTP/2를 완전히 지원하는 엔드포인트에서 더 빠름
+
 
 # System Resources
 system.share.feedback=피드백 공유
@@ -1065,7 +1085,6 @@ export.format.html.benefit.2=어느 브라우저에서도 볼 수 있음
 export.format.html.benefit.3=전문적인 외관
 export.format.html.benefit.4=공유하기 쉬움
 
-
 # Error Messages
 error.network=⚠️ AI 서비스{endpoint}에 연결할 수 없습니다\n\n다음을 확인하세요:\n• 인터넷 연결 상태\n• AI 서비스 URL (설정 확인)\n• 방화벽 설정\n• 서비스 사용 가능 여부
 error.authentication=⚠️ API 키가 없거나 유효하지 않습니다{provider}\n\n설정에서 API 키를 입력하면 해결할 수 있습니다.
@@ -1138,7 +1157,7 @@ settings.rag.indexing.binary.extensions.hint=인덱싱 중 바이너리로 처�
 settings.rag.indexing.embedding.batch.size=임베딩 배치 크기
 settings.rag.indexing.embedding.batch.size.hint=요청당 임베딩 모델에 전송되는 텍스트 세그먼트 수입니다. 인덱싱이 느리고 원격 공급자(OpenAI, Gemini)를 사용하는 경우 100–500으로 늘려 보세요. 로컬 모델(Ollama, LM Studio)을 사용하는 경우 타임아웃을 방지하려면 낮게 유지하세요.
 
-# Settings - Models
+## Settings - Models
 settings.models.title=모델
 settings.models.description=모든 공급자에서 공유되는 전역 AI 모델 동작을 구성합니다.
 settings.models.max.tool.calling.round.trips=최대 도구 호출 라운드 트립
@@ -1158,18 +1177,18 @@ settings.memory.mode.detail=상세
 settings.memory.mode.detail.hint=높은 정확도, 더 많은 토큰
 settings.memory.mode.detail.description=최소 요약. 더 많은 원문 대화와 풍부한 요약을 유지합니다. 짧은 세션이나 정확한 기억이 중요할 때 적합합니다.
 
-# Settings - Utility Models
+## Settings - Utility Models
 settings.utility.models.title=유틸리티 모델
 settings.utility.models.uses.selected=(선택된 모델 사용)
 settings.utility.models.local.note={0}는 로컬 제공자입니다 — 유틸리티 작업에는 현재 활성화된 채팅 모델이 자동으로 사용됩니다.
 
-# Settings - Vision Models
+## Settings - Vision Models
 settings.vision.models.title=비전 모델
 
 ## Settings - Image Models
 settings.image.models.title=이미지 생성 모델
 
-# Settings - Provider Model Config
+## Settings - Provider Model Config
 settings.provider.model.config.title=모델 설정
 settings.provider.model.config.description=특정 작업에 사용되는 기본 모델을 재정의합니다. 필드를 비워두면 제공자의 기본 모델이 사용됩니다.
 settings.provider.model.config.guide=AI 모델 구성 가이드 보기
@@ -1614,20 +1633,3 @@ persona.developer=💻 코드 작성 및 검토
 persona.researcher=🔬 조사 및 분석
 persona.manager=📋 작성 및 정리
 persona.everything=⚡ 여러 가지 작업을 혼합하여 합니다
-
-# Bookmarks
-menu.view.bookmarks=북마크 보기
-message.bookmark=메시지 북마크
-message.bookmark.remove=북마크 제거
-message.bookmark.description=이 메시지를 북마크합니다
-chat.bookmarks.button.tooltip=북마크
-chat.bookmarks.popover.title=고정된 메시지
-chat.bookmarks.popover.empty.title=아직 북마크가 없습니다
-chat.bookmarks.popover.empty.hint=메시지 아래의 북마크 아이콘으로 고정하세요
-bookmarks.title=북마크
-bookmarks.empty.title=아직 북마크가 없습니다
-bookmarks.empty.hint=메시지 아래의 핀 아이콘으로 북마크하세요
-bookmarks.session.untitled=제목 없는 대화
-bookmarks.message.count={0}개 고정됨
-bookmarks.role.user=나
-bookmarks.role.ai=AI

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1,4 +1,4 @@
-﻿# Askimo Desktop Application - English Strings (Comments Preserved)
+# Askimo Desktop Application - English Strings
 
 # Application
 
@@ -31,6 +31,7 @@ menu.view.appearance.system=Sistema
 menu.view.appearance.light=Claro
 menu.view.appearance.dark=Escuro
 menu.view.fullscreen=Entrar em tela cheia
+menu.view.bookmarks=Ver favoritos
 menu.terminal=Terminal
 menu.terminal.new=Novo terminal
 menu.help=Ajuda
@@ -483,6 +484,7 @@ user.interest.environment=Meio ambiente
 
 # Actions
 action.delete=Excluir
+action.remove=Remover
 action.edit=Editar
 action.pin=Fixar na barra lateral
 action.unpin=Desafixar da barra lateral
@@ -503,8 +505,6 @@ action.next=Próximo
 action.retry=Tentar novamente
 action.done=Concluído
 action.refresh=Atualizar
-
-
 
 # Happiness Gate (shown before Star Prompt)
 happiness.gate.title=Como você está achando o Askimo?
@@ -585,10 +585,8 @@ file.overwrite.message=Este arquivo já existe. Deseja sobrescrevê-lo?
 file.overwrite.confirm=Sobrescrever
 file.name.too.long=O nome do arquivo é muito longo. Use um nome mais curto (máximo de 255 caracteres).
 
-
 # About
 about.title=Sobre {0}
-action.remove=Remover
 about.version=Versão
 about.buildDate=Data de compilação
 about.buildJdk=JDK de compilação
@@ -628,7 +626,6 @@ shortcut.previous.search.result=Resultado anterior da pesquisa
 shortcut.attach.file=Anexar arquivo
 shortcut.send.message=Enviar mensagem
 shortcut.new.line=Nova linha
-
 
 # Chat View
 chat.welcome=Bem-vindo ao Askimo!\nComece uma conversa digitando uma mensagem abaixo.
@@ -685,6 +682,8 @@ chat.rag.web_search.tooltip.on=Resultados web ao vivo incluídos no contexto RAG
 chat.image.model.missing.title=Modelo de imagem não configurado
 chat.image.model.missing.message=Nenhum modelo de imagem está definido para {0}. Abra Configurações > Provedor de IA > Modelos de geração de imagens e defina primeiro um nome de modelo.
 chat.tools.button=Ferramentas disponíveis
+chat.tools.button.disabled=Ferramentas disponíveis ({0} desativadas)
+chat.tools.button.model.no.support=As ferramentas não são suportadas por este modelo
 chat.tools.popup.title=Ferramentas disponíveis
 chat.tools.popup.loading=Carregando servidores...
 chat.tools.popup.no.servers.global=Nenhum servidor MCP global configurado.
@@ -693,8 +692,6 @@ chat.tools.server.scope.global=Global
 chat.tools.server.scope.project=Projeto
 chat.tools.server.scope.builtin=Integrado
 chat.tools.tool.no.description=Nenhuma descrição disponível
-chat.tools.button.disabled=Ferramentas disponíveis ({0} desativadas)
-chat.tools.button.model.no.support=As ferramentas não são suportadas por este modelo
 chat.reasoning.effort.label=Pensando
 chat.reasoning.effort.tooltip=Esforço de raciocínio — controla a profundidade com que o modelo pensa antes de responder
 chat.reasoning.effort.off=Desligado
@@ -728,7 +725,7 @@ sessions.empty.hint=💡 Inicie uma nova conversa para criar sua primeira sessã
 sessions.search.placeholder=Pesquisar por título…
 sessions.search.empty=Nenhuma sessão corresponde a "{0}".
 
-# Controles genéricos de paginação de tabelas
+# Generic table pagination controls
 table.page.size.label=Linhas por página:
 table.page=Página {0} de {1}
 table.page.previous=Página anterior
@@ -743,7 +740,6 @@ sessions.error.not.found=Sessão não encontrada.
 sessions.error.rename.failed=Falha ao renomear sessão.
 
 # ChatSessionService Errors
-
 # Update Check
 update.dialog.title=Atualização de Software
 update.dialog.new.version.available=Uma nova versão do Askimo está disponível!
@@ -882,11 +878,27 @@ message.ai.fork=Fazer fork da sessão a partir daqui
 message.ai.fork.description=Dividir esta conversa em uma nova sessão independente
 message.ai.export.pdf=Exportar como PDF
 message.ai.export.pdf.dialog.title=Salvar resposta da IA como PDF
+message.bookmark=Favoritar mensagem
+message.bookmark.remove=Remover favorito
+message.bookmark.description=Favoritar esta mensagem
 message.edited.indicator=(editado)
 message.date.today=Hoje
 message.date.yesterday=Ontem
 message.token.usage={0} tokens · {1} de entrada / {2} de saída
 message.token.usage.tooltip=Tokens usados por esta resposta.\nEntrada: seu prompt + contexto enviado à IA.\nSaída: a resposta gerada pela IA.
+
+# Bookmarks
+chat.bookmarks.button.tooltip=Favoritos
+chat.bookmarks.popover.title=Mensagens fixadas
+chat.bookmarks.popover.empty.title=Nenhum favorito ainda
+chat.bookmarks.popover.empty.hint=Fixe qualquer mensagem com o ícone de favorito abaixo dela
+bookmarks.title=Favoritos
+bookmarks.empty.title=Nenhum favorito ainda
+bookmarks.empty.hint=Favorite mensagens com o ícone de fixar abaixo delas
+bookmarks.session.untitled=Conversa sem título
+bookmarks.message.count={0} fixados
+bookmarks.role.user=Você
+bookmarks.role.ai=IA
 
 # Tool call display
 tool.call.header.running=Executando ferramenta...
@@ -995,6 +1007,11 @@ provider.openai_compatible.apimode.label=Formato de API
 provider.openai_compatible.apimode.description=Qual endpoint da API da OpenAI este provedor usa
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=Versão HTTP
+provider.openai_compatible.httpversion.description=Versão do protocolo HTTP para conexões com este endpoint
+provider.openai_compatible.httpversion.http1_1=Compatível com a maioria dos servidores; use se o HTTP/2 causar problemas
+provider.openai_compatible.httpversion.http2=Mais rápido para endpoints que suportam totalmente o HTTP/2
+
 
 # System Resources
 system.share.feedback=Compartilhar feedback
@@ -1068,7 +1085,6 @@ export.format.html.benefit.2=Visualizável em qualquer navegador
 export.format.html.benefit.3=Aparência profissional
 export.format.html.benefit.4=Fácil de compartilhar
 
-
 # Error Messages
 error.network=⚠️ Não foi possível conectar ao serviço de IA{endpoint}\n\nVerifique:\n• Sua conexão com a internet\n• A URL do serviço de IA (verifique as configurações)\n• As configurações do firewall\n• A disponibilidade do serviço
 error.authentication=⚠️ A chave de API está ausente ou é inválida{provider}\n\nCorrija isso configurando sua chave de API em Configurações.
@@ -1141,7 +1157,7 @@ settings.rag.indexing.binary.extensions.hint=Extensões de arquivo separadas por
 settings.rag.indexing.embedding.batch.size=Tamanho do lote de embeddings
 settings.rag.indexing.embedding.batch.size.hint=Número de segmentos de texto enviados ao modelo de embeddings por requisição. Se a indexação estiver lenta e você usar um provedor remoto (OpenAI, Gemini), tente aumentar para 100–500. Se usar um modelo local (Ollama, LM Studio), mantenha baixo para evitar timeouts.
 
-# Settings - Models
+## Settings - Models
 settings.models.title=Modelos
 settings.models.description=Configure o comportamento global do modelo de IA compartilhado entre todos os provedores.
 settings.models.max.tool.calling.round.trips=Máximo de rodadas de chamadas de ferramentas
@@ -1161,18 +1177,18 @@ settings.memory.mode.detail=Detalhado
 settings.memory.mode.detail.hint=Alta fidelidade, mais tokens
 settings.memory.mode.detail.description=Resumo mínimo. Mantém mais turnos verbatim e resumos mais ricos. Ideal para sessões curtas ou quando o recall preciso é importante.
 
-# Settings - Utility Models
+## Settings - Utility Models
 settings.utility.models.title=Modelos utilitários
 settings.utility.models.uses.selected=(usa o modelo selecionado)
 settings.utility.models.local.note={0} é um provedor local — o modelo de chat ativo é usado automaticamente para tarefas utilitárias.
 
-# Settings - Vision Models
+## Settings - Vision Models
 settings.vision.models.title=Modelos de visão
 
 ## Settings - Image Models
 settings.image.models.title=Modelos de geração de imagens
 
-# Settings - Provider Model Config
+## Settings - Provider Model Config
 settings.provider.model.config.title=Configuração do modelo
 settings.provider.model.config.description=Substitua os modelos padrão usados para tarefas específicas. Deixe um campo em branco para usar o modelo padrão do provedor.
 settings.provider.model.config.guide=Ver guia de configuração do modelo de IA
@@ -1617,20 +1633,3 @@ persona.developer=💻 Escrever e revisar código
 persona.researcher=🔬 Pesquisar e analisar
 persona.manager=📋 Escrever e organizar
 persona.everything=⚡ Eu faço uma mistura de coisas
-
-# Bookmarks
-menu.view.bookmarks=Ver favoritos
-message.bookmark=Favoritar mensagem
-message.bookmark.remove=Remover favorito
-message.bookmark.description=Favoritar esta mensagem
-chat.bookmarks.button.tooltip=Favoritos
-chat.bookmarks.popover.title=Mensagens fixadas
-chat.bookmarks.popover.empty.title=Nenhum favorito ainda
-chat.bookmarks.popover.empty.hint=Fixe qualquer mensagem com o ícone de favorito abaixo dela
-bookmarks.title=Favoritos
-bookmarks.empty.title=Nenhum favorito ainda
-bookmarks.empty.hint=Favorite mensagens com o ícone de fixar abaixo delas
-bookmarks.session.untitled=Conversa sem título
-bookmarks.message.count={0} fixados
-bookmarks.role.user=Você
-bookmarks.role.ai=IA

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1,4 +1,4 @@
-﻿# Askimo Desktop Application - English Strings
+# Askimo Desktop Application - English Strings
 
 # Application
 
@@ -31,6 +31,7 @@ menu.view.appearance.system=Hệ thống
 menu.view.appearance.light=Sáng
 menu.view.appearance.dark=Tối
 menu.view.fullscreen=Chuyển sang toàn màn hình
+menu.view.bookmarks=Xem dấu trang
 menu.terminal=Terminal
 menu.terminal.new=Terminal mới
 menu.help=Trợ giúp
@@ -45,16 +46,6 @@ menu.help.share.text=Khám phá Askimo — ứng dụng AI miễn phí chạy c�
 menu.help.share.hackernews=Bài đăng trên Hacker News
 menu.eventlog=Nhật ký sự kiện
 menu.help.model.capabilities=Mở tệp khả năng mô hình
-chat.reasoning.effort.label=Đang suy nghĩ
-chat.reasoning.effort.tooltip=Mức độ suy luận — kiểm soát mức độ mô hình suy nghĩ sâu như thế nào trước khi phản hồi
-chat.reasoning.effort.off=Tắt
-chat.reasoning.effort.off.description=Vô hiệu hóa suy luận mở rộng. Mô hình phản hồi trực tiếp mà không cần suy nghĩ sâu.
-chat.reasoning.effort.low=Thấp
-chat.reasoning.effort.low.description=Phản hồi nhanh hơn, chi phí thấp hơn. Tốt nhất cho các tác vụ đơn giản.
-chat.reasoning.effort.medium=Trung bình
-chat.reasoning.effort.medium.description=Cân bằng giữa độ sâu và tốc độ. Phù hợp cho hầu hết các tác vụ.
-chat.reasoning.effort.high=Cao
-chat.reasoning.effort.high.description=Suy luận kỹ lưỡng, chi phí cao hơn. Tốt nhất cho việc giải quyết các vấn đề phức tạp.
 menu.dev.clear.account.preferences=[Dev] Xóa cài đặt tài khoản
 menu.about=Giới thiệu Askimo
 menu.help.check.updates=Kiểm tra cập nhật...
@@ -333,6 +324,8 @@ settings.about=Giới thiệu
 settings.theme=Chủ đề
 settings.save=Lưu
 settings.cancel=Hủy
+settings.model.change.button=Đổi mô hình
+settings.change.button=Đổi cài đặt
 
 # Theme
 theme.light=Sáng
@@ -491,6 +484,7 @@ user.interest.environment=Môi trường
 
 # Actions
 action.delete=Xóa
+action.remove=Xóa
 action.edit=Chỉnh sửa
 action.pin=Ghim vào thanh bên
 action.unpin=Bỏ ghim khỏi thanh bên
@@ -591,10 +585,8 @@ file.overwrite.message=Tệp này đã tồn tại. Bạn có muốn ghi đè kh
 file.overwrite.confirm=Ghi đè
 file.name.too.long=Tên tệp quá dài. Vui lòng dùng tên ngắn hơn (tối đa 255 ký tự).
 
-
 # About
 about.title=Giới thiệu {0}
-action.remove=Xóa
 about.version=Phiên bản
 about.buildDate=Ngày build
 about.buildJdk=JDK build
@@ -690,6 +682,8 @@ chat.rag.web_search.tooltip.on=Đã bao gồm kết quả web trực tiếp tron
 chat.image.model.missing.title=Chưa cấu hình mô hình hình ảnh
 chat.image.model.missing.message=Chưa đặt mô hình hình ảnh cho {0}. Mở Cài đặt > Nhà cung cấp AI > Mô hình tạo hình ảnh và đặt tên mô hình trước.
 chat.tools.button=Công cụ khả dụng
+chat.tools.button.disabled=Công cụ khả dụng ({0} bị vô hiệu hóa)
+chat.tools.button.model.no.support=Các công cụ không được hỗ trợ bởi mô hình này
 chat.tools.popup.title=Công cụ khả dụng
 chat.tools.popup.loading=Đang tải máy chủ...
 chat.tools.popup.no.servers.global=Chưa cấu hình máy chủ MCP toàn cục.
@@ -698,8 +692,16 @@ chat.tools.server.scope.global=Toàn cục
 chat.tools.server.scope.project=Dự án
 chat.tools.server.scope.builtin=Tích hợp sẵn
 chat.tools.tool.no.description=Không có mô tả
-chat.tools.button.disabled=Công cụ khả dụng ({0} bị vô hiệu hóa)
-chat.tools.button.model.no.support=Các công cụ không được hỗ trợ bởi mô hình này
+chat.reasoning.effort.label=Đang suy nghĩ
+chat.reasoning.effort.tooltip=Mức độ suy luận — kiểm soát mức độ mô hình suy nghĩ sâu như thế nào trước khi phản hồi
+chat.reasoning.effort.off=Tắt
+chat.reasoning.effort.off.description=Vô hiệu hóa suy luận mở rộng. Mô hình phản hồi trực tiếp mà không cần suy nghĩ sâu.
+chat.reasoning.effort.low=Thấp
+chat.reasoning.effort.low.description=Phản hồi nhanh hơn, chi phí thấp hơn. Tốt nhất cho các tác vụ đơn giản.
+chat.reasoning.effort.medium=Trung bình
+chat.reasoning.effort.medium.description=Cân bằng giữa độ sâu và tốc độ. Phù hợp cho hầu hết các tác vụ.
+chat.reasoning.effort.high=Cao
+chat.reasoning.effort.high.description=Suy luận kỹ lưỡng, chi phí cao hơn. Tốt nhất cho việc giải quyết các vấn đề phức tạp.
 chat.input.placeholder=Nhập tin nhắn... (Enter để gửi, Shift+Enter để xuống dòng)
 chat.input.placeholder.hint.attach=Đính kèm tệp bằng {0}+A hoặc kéo và thả vào đây
 chat.select.file=Chọn tệp (nhiều tệp)
@@ -723,7 +725,7 @@ sessions.empty.hint=💡 Bắt đầu một cuộc trò chuyện mới để t�
 sessions.search.placeholder=Tìm kiếm theo tiêu đề…
 sessions.search.empty=Không có phiên nào khớp với "{0}".
 
-# Điều khiển phân trang bảng chung
+# Generic table pagination controls
 table.page.size.label=Số hàng mỗi trang:
 table.page=Trang {0} trên {1}
 table.page.previous=Trang trước
@@ -785,8 +787,6 @@ settings.ai.response.language.tooltip=AI tự động phát hiện ngôn ngữ, 
 settings.model.select=Chọn mô hình cho {0}:
 settings.model.loading=Đang tải mô hình...
 settings.model.none=Không có mô hình
-settings.model.change.button=Đổi mô hình
-settings.change.button=Đổi cài đặt
 settings.model.select.title=Chọn mô hình
 settings.model.current=Mô hình hiện tại
 settings.model.selected=Mô hình đã chọn
@@ -878,11 +878,27 @@ message.ai.fork=Fork phiên từ đây
 message.ai.fork.description=Fork cuộc trò chuyện này thành một phiên mới độc lập
 message.ai.export.pdf=Xuất ra PDF
 message.ai.export.pdf.dialog.title=Lưu phản hồi AI dưới dạng PDF
+message.bookmark=Đánh dấu tin nhắn
+message.bookmark.remove=Xóa dấu trang
+message.bookmark.description=Đánh dấu tin nhắn này
 message.edited.indicator=(đã chỉnh sửa)
 message.date.today=Hôm nay
 message.date.yesterday=Hôm qua
 message.token.usage={0} token · {1} vào / {2} ra
 message.token.usage.tooltip=Số token được sử dụng bởi phản hồi này.\nĐầu vào: prompt của bạn + ngữ cảnh được gửi đến AI.\nĐầu ra: phản hồi do AI tạo ra.
+
+# Bookmarks
+chat.bookmarks.button.tooltip=Dấu trang
+chat.bookmarks.popover.title=Tin nhắn đã ghim
+chat.bookmarks.popover.empty.title=Chưa có dấu trang
+chat.bookmarks.popover.empty.hint=Ghim tin nhắn bằng biểu tượng dấu trang bên dưới
+bookmarks.title=Dấu trang
+bookmarks.empty.title=Chưa có dấu trang
+bookmarks.empty.hint=Đánh dấu tin nhắn bằng biểu tượng ghim bên dưới
+bookmarks.session.untitled=Cuộc trò chuyện chưa đặt tên
+bookmarks.message.count={0} đã ghim
+bookmarks.role.user=Bạn
+bookmarks.role.ai=AI
 
 # Tool call display
 tool.call.header.running=Đang chạy công cụ...
@@ -991,6 +1007,11 @@ provider.openai_compatible.apimode.label=Định dạng API
 provider.openai_compatible.apimode.description=Endpoint API OpenAI mà nhà cung cấp này sử dụng
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=Phiên bản HTTP
+provider.openai_compatible.httpversion.description=Phiên bản giao thức HTTP cho các kết nối đến điểm cuối này
+provider.openai_compatible.httpversion.http1_1=Tương thích với hầu hết các máy chủ; sử dụng nếu HTTP/2 gây ra sự cố
+provider.openai_compatible.httpversion.http2=Nhanh hơn cho các điểm cuối hỗ trợ đầy đủ HTTP/2
+
 
 # System Resources
 system.share.feedback=Chia sẻ phản hồi
@@ -1093,7 +1114,6 @@ error.app.message=Đã xảy ra lỗi không mong muốn: {0}
 # Send Message Errors
 error.send_message.title=Gửi tin nhắn thất bại
 
-
 # Indexing Errors
 error.indexing.model_not_found.title=Không tìm thấy mô hình embedding
 error.indexing.model_not_found.message=Không tìm thấy mô hình embedding ''{0}''. Vui lòng tải hoặc bật mô hình này từ {1} trước khi lập chỉ mục.
@@ -1137,7 +1157,7 @@ settings.rag.indexing.binary.extensions.hint=Phần mở rộng tệp cách nhau
 settings.rag.indexing.embedding.batch.size=Kích thước lô nhúng
 settings.rag.indexing.embedding.batch.size.hint=Số đoạn văn bản gửi đến mô hình nhúng mỗi yêu cầu. Nếu lập chỉ mục chậm và bạn dùng nhà cung cấp từ xa (OpenAI, Gemini), hãy thử tăng lên 100–500. Nếu dùng mô hình cục bộ (Ollama, LM Studio), hãy giữ thấp để tránh hết thời gian chờ.
 
-# Settings - Models
+## Settings - Models
 settings.models.title=Mô hình
 settings.models.description=Cấu hình hành vi mô hình AI toàn cục được chia sẻ trên tất cả các nhà cung cấp.
 settings.models.max.tool.calling.round.trips=Số lượt gọi công cụ tối đa
@@ -1157,18 +1177,18 @@ settings.memory.mode.detail=Chi tiết
 settings.memory.mode.detail.hint=Độ trung thực cao, nhiều token hơn
 settings.memory.mode.detail.description=Tóm tắt tối thiểu. Giữ lại nhiều lượt hội thoại nguyên văn và tóm tắt phong phú hơn. Phù hợp cho các phiên ngắn hoặc khi cần nhớ chính xác.
 
-# Settings - Utility Models
+## Settings - Utility Models
 settings.utility.models.title=Mô hình tiện ích
 settings.utility.models.uses.selected=(sử dụng mô hình đã chọn)
 settings.utility.models.local.note={0} là nhà cung cấp cục bộ — mô hình chat đang hoạt động sẽ tự động được sử dụng cho các tác vụ tiện ích.
 
-# Settings - Vision Models
+## Settings - Vision Models
 settings.vision.models.title=Mô hình thị giác
 
 ## Settings - Image Models
 settings.image.models.title=Mô hình tạo hình ảnh
 
-# Settings - Provider Model Config
+## Settings - Provider Model Config
 settings.provider.model.config.title=Cấu hình mô hình
 settings.provider.model.config.description=Ghi đè các mô hình mặc định được dùng cho các tác vụ cụ thể. Để trống trường nếu muốn sử dụng mô hình mặc định của nhà cung cấp.
 settings.provider.model.config.guide=Xem hướng dẫn cấu hình mô hình AI
@@ -1178,7 +1198,6 @@ settings.provider.model.image.hint=Mô hình dùng để tạo hình ảnh từ 
 settings.provider.model.embedding.hint=Mô hình dùng để tạo vector embedding phục vụ tìm kiếm trong cơ sở tri thức RAG
 
 settings.model.placeholder.enter=Nhập mô hình {0}
-
 
 # File Viewer Dialog
 file.viewer.title=Trình xem tệp
@@ -1614,20 +1633,3 @@ persona.developer=💻 Viết và đánh giá mã
 persona.researcher=🔬 Nghiên cứu và phân tích
 persona.manager=📋 Viết và tổ chức
 persona.everything=⚡ Tôi làm nhiều việc kết hợp
-
-# Bookmarks
-menu.view.bookmarks=Xem dấu trang
-message.bookmark=Đánh dấu tin nhắn
-message.bookmark.remove=Xóa dấu trang
-message.bookmark.description=Đánh dấu tin nhắn này
-chat.bookmarks.button.tooltip=Dấu trang
-chat.bookmarks.popover.title=Tin nhắn đã ghim
-chat.bookmarks.popover.empty.title=Chưa có dấu trang
-chat.bookmarks.popover.empty.hint=Ghim tin nhắn bằng biểu tượng dấu trang bên dưới
-bookmarks.title=Dấu trang
-bookmarks.empty.title=Chưa có dấu trang
-bookmarks.empty.hint=Đánh dấu tin nhắn bằng biểu tượng ghim bên dưới
-bookmarks.session.untitled=Cuộc trò chuyện chưa đặt tên
-bookmarks.message.count={0} đã ghim
-bookmarks.role.user=Bạn
-bookmarks.role.ai=AI

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1,4 +1,4 @@
-﻿# Askimo Desktop Application - English Strings
+# Askimo Desktop Application - English Strings
 
 # Application
 
@@ -31,6 +31,7 @@ menu.view.appearance.system=系统
 menu.view.appearance.light=浅色
 menu.view.appearance.dark=深色
 menu.view.fullscreen=进入全屏
+menu.view.bookmarks=查看书签
 menu.terminal=终端
 menu.terminal.new=新建终端
 menu.help=帮助
@@ -483,6 +484,7 @@ user.interest.environment=环境
 
 # Actions
 action.delete=删除
+action.remove=移除
 action.edit=编辑
 action.pin=固定到侧边栏
 action.unpin=从侧边栏取消固定
@@ -583,10 +585,8 @@ file.overwrite.message=该文件已存在。你要覆盖它吗？
 file.overwrite.confirm=覆盖
 file.name.too.long=文件名太长。请使用较短的文件名（最多 255 个字符）。
 
-
 # About
 about.title=关于 {0}
-action.remove=移除
 about.version=版本
 about.buildDate=构建日期
 about.buildJdk=构建 JDK
@@ -626,7 +626,6 @@ shortcut.previous.search.result=上一个搜索结果
 shortcut.attach.file=附加文件
 shortcut.send.message=发送消息
 shortcut.new.line=新行
-
 
 # Chat View
 chat.welcome=欢迎使用 Askimo！\n在下方输入消息开始对话。
@@ -683,6 +682,8 @@ chat.rag.web_search.tooltip.on=RAG 上下文已包含实时网络结果（点击
 chat.image.model.missing.title=未配置图像模型
 chat.image.model.missing.message=未为 {0} 设置图像模型。打开 设置 > AI 提供商 > 图像生成模型，并先设置模型名称。
 chat.tools.button=可用工具
+chat.tools.button.disabled=可用工具（{0} 已禁用）
+chat.tools.button.model.no.support=此模型不支持工具
 chat.tools.popup.title=可用工具
 chat.tools.popup.loading=正在加载服务器...
 chat.tools.popup.no.servers.global=未配置全局 MCP 服务器。
@@ -691,8 +692,6 @@ chat.tools.server.scope.global=全局
 chat.tools.server.scope.project=项目
 chat.tools.server.scope.builtin=内置
 chat.tools.tool.no.description=暂无描述
-chat.tools.button.disabled=可用工具（{0} 已禁用）
-chat.tools.button.model.no.support=此模型不支持工具
 chat.reasoning.effort.label=思考
 chat.reasoning.effort.tooltip=推理力度 — 控制模型在响应前思考的深度
 chat.reasoning.effort.off=关闭
@@ -726,7 +725,7 @@ sessions.empty.hint=💡 开始新的聊天以创建第一个会话！
 sessions.search.placeholder=按标题搜索…
 sessions.search.empty=没有与 "{0}" 匹配的会话。
 
-# 通用表格分页控件
+# Generic table pagination controls
 table.page.size.label=每页行数:
 table.page=第 {0} 页 共 {1} 页
 table.page.previous=上一页
@@ -879,11 +878,27 @@ message.ai.fork=从此处 Fork 会话
 message.ai.fork.description=将此对话 Fork 为一个新的独立会话
 message.ai.export.pdf=导出为 PDF
 message.ai.export.pdf.dialog.title=将 AI 回复保存为 PDF
+message.bookmark=收藏消息
+message.bookmark.remove=取消收藏
+message.bookmark.description=收藏此消息
 message.edited.indicator=(已编辑)
 message.date.today=今天
 message.date.yesterday=昨天
 message.token.usage={0} 个 token · {1} 进 / {2} 出
 message.token.usage.tooltip=此回复使用的 token。\n输入: 您的 prompt + 发送给 AI 的上下文。\n输出: AI 生成的回复。
+
+# Bookmarks
+chat.bookmarks.button.tooltip=书签
+chat.bookmarks.popover.title=已固定的消息
+chat.bookmarks.popover.empty.title=暂无书签
+chat.bookmarks.popover.empty.hint=点击消息下方的书签图标进行固定
+bookmarks.title=书签
+bookmarks.empty.title=暂无书签
+bookmarks.empty.hint=点击消息下方的固定图标添加书签
+bookmarks.session.untitled=未命名对话
+bookmarks.message.count=已固定 {0} 条
+bookmarks.role.user=你
+bookmarks.role.ai=AI
 
 # Tool call display
 tool.call.header.running=正在运行工具...
@@ -992,6 +1007,11 @@ provider.openai_compatible.apimode.label=API 格式
 provider.openai_compatible.apimode.description=此提供程序使用的 OpenAI API 端点
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=HTTP 版本
+provider.openai_compatible.httpversion.description=连接到此端点的 HTTP 协议版本
+provider.openai_compatible.httpversion.http1_1=与大多数服务器兼容；如果 HTTP/2 导致问题，请使用此选项
+provider.openai_compatible.httpversion.http2=对于完全支持 HTTP/2 的端点速度更快
+
 
 # System Resources
 system.share.feedback=分享反馈
@@ -1065,7 +1085,6 @@ export.format.html.benefit.2=可在任何浏览器查看
 export.format.html.benefit.3=专业外观
 export.format.html.benefit.4=易于分享
 
-
 # Error Messages
 error.network=⚠️ 无法连接到 AI 服务{endpoint}\n\n请检查：\n• 网络连接\n• AI 服务地址（检查设置）\n• 防火墙设置\n• 服务是否可用
 error.authentication=⚠️ API 密钥无效或缺失{provider}\n\n请在设置中配置您的 API 密钥以解决此问题。
@@ -1094,7 +1113,6 @@ error.app.message=发生了一个意外错误：{0}
 
 # Send Message Errors
 error.send_message.title=发送消息失败
-
 
 # Indexing Errors
 error.indexing.model_not_found.title=未找到嵌入模型
@@ -1139,7 +1157,7 @@ settings.rag.indexing.binary.extensions.hint=以逗号分隔的在索引时被�
 settings.rag.indexing.embedding.batch.size=嵌入批处理大小
 settings.rag.indexing.embedding.batch.size.hint=每次请求发送到嵌入模型的文本片段数量。如果索引速度较慢且您使用远程提供商（OpenAI、Gemini），可尝试增大至 100–500。如果使用本地模型（Ollama、LM Studio），请保持较低值以避免超时。
 
-# Settings - Models
+## Settings - Models
 settings.models.title=模型
 settings.models.description=配置所有提供商共享的全局 AI 模型行为。
 settings.models.max.tool.calling.round.trips=最大工具调用轮次
@@ -1159,18 +1177,18 @@ settings.memory.mode.detail=详细
 settings.memory.mode.detail.hint=高保真，更多 token
 settings.memory.mode.detail.description=最少摘要。保留更多原文对话和更丰富的摘要。适合短会话或需要精确记忆的场景。
 
-# Settings - Utility Models
+## Settings - Utility Models
 settings.utility.models.title=实用模型
 settings.utility.models.uses.selected=（使用所选模型）
 settings.utility.models.local.note={0} 是本地提供商 —— 实用任务会自动使用当前活动的聊天模型。
 
-# Vision Models
+## Settings - Vision Models
 settings.vision.models.title=视觉模型
 
 ## Settings - Image Models
 settings.image.models.title=图像生成模型
 
-# Settings - Provider Model Config
+## Settings - Provider Model Config
 settings.provider.model.config.title=模型配置
 settings.provider.model.config.description=为特定任务覆盖默认模型。若字段留空，则使用提供商的默认模型。
 settings.provider.model.config.guide=查看 AI 模型配置指南
@@ -1180,7 +1198,6 @@ settings.provider.model.image.hint=用于根据文本描述生成图像的模型
 settings.provider.model.embedding.hint=用于生成向量嵌入以支持 RAG 知识库搜索的模型
 
 settings.model.placeholder.enter=输入 {0} 模型
-
 
 # File Viewer Dialog
 file.viewer.title=文件查看器
@@ -1616,20 +1633,3 @@ persona.developer=💻 编写和审查代码
 persona.researcher=🔬 研究和分析
 persona.manager=📋 撰写和组织
 persona.everything=⚡ 我做各种混合的工作
-
-# Bookmarks
-menu.view.bookmarks=查看书签
-message.bookmark=收藏消息
-message.bookmark.remove=取消收藏
-message.bookmark.description=收藏此消息
-chat.bookmarks.button.tooltip=书签
-chat.bookmarks.popover.title=已固定的消息
-chat.bookmarks.popover.empty.title=暂无书签
-chat.bookmarks.popover.empty.hint=点击消息下方的书签图标进行固定
-bookmarks.title=书签
-bookmarks.empty.title=暂无书签
-bookmarks.empty.hint=点击消息下方的固定图标添加书签
-bookmarks.session.untitled=未命名对话
-bookmarks.message.count=已固定 {0} 条
-bookmarks.role.user=你
-bookmarks.role.ai=AI

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1,4 +1,4 @@
-﻿# Askimo Desktop Application - Traditional Chinese Strings (Comments Preserved)
+# Askimo Desktop Application - English Strings
 
 # Application
 
@@ -31,6 +31,7 @@ menu.view.appearance.system=系統
 menu.view.appearance.light=淺色
 menu.view.appearance.dark=深色
 menu.view.fullscreen=進入全螢幕
+menu.view.bookmarks=查看書籤
 menu.terminal=終端機
 menu.terminal.new=新增終端機
 menu.help=說明
@@ -483,6 +484,7 @@ user.interest.environment=環境
 
 # Actions
 action.delete=刪除
+action.remove=移除
 action.edit=編輯
 action.pin=釘選到側邊欄
 action.unpin=從側邊欄取消釘選
@@ -583,10 +585,8 @@ file.overwrite.message=此檔案已存在。你要覆寫它嗎？
 file.overwrite.confirm=覆寫
 file.name.too.long=檔名太長。請使用較短的檔名（最多 255 個字元）。
 
-
 # About
 about.title=關於 {0}
-action.remove=移除
 about.version=版本
 about.buildDate=建置日期
 about.buildJdk=建置 JDK
@@ -682,6 +682,8 @@ chat.rag.web_search.tooltip.on=RAG 內容已包含即時網路結果（點擊停
 chat.image.model.missing.title=尚未設定圖片模型
 chat.image.model.missing.message=尚未為 {0} 設定圖片模型。開啟 設定 > AI 提供者 > 圖片生成模型，並先設定模型名稱。
 chat.tools.button=可用工具
+chat.tools.button.disabled=可用工具（{0} 已停用）
+chat.tools.button.model.no.support=此模型不支援工具
 chat.tools.popup.title=可用工具
 chat.tools.popup.loading=正在載入伺服器...
 chat.tools.popup.no.servers.global=尚未設定全域 MCP 伺服器。
@@ -690,8 +692,6 @@ chat.tools.server.scope.global=全域
 chat.tools.server.scope.project=專案
 chat.tools.server.scope.builtin=內建
 chat.tools.tool.no.description=暫無描述
-chat.tools.button.disabled=可用工具（{0} 已停用）
-chat.tools.button.model.no.support=此模型不支援工具
 chat.reasoning.effort.label=思考
 chat.reasoning.effort.tooltip=推理力度 — 控制模型在回應前思考的深度
 chat.reasoning.effort.off=關閉
@@ -725,7 +725,7 @@ sessions.empty.hint=💡 開始新的對話即可建立第一個工作階段！
 sessions.search.placeholder=按標題搜尋…
 sessions.search.empty=沒有與 "{0}" 相符的會話。
 
-# 通用表格分頁控制項
+# Generic table pagination controls
 table.page.size.label=每頁列數:
 table.page=第 {0} 頁 共 {1} 頁
 table.page.previous=上一頁
@@ -740,7 +740,6 @@ sessions.error.not.found=找不到工作階段。
 sessions.error.rename.failed=重新命名失敗。
 
 # ChatSessionService Errors
-
 # Update Check
 update.dialog.title=軟體更新
 update.dialog.new.version.available=有可用的 Askimo 新版本！
@@ -879,11 +878,27 @@ message.ai.fork=從此處 Fork 會話
 message.ai.fork.description=將此對話 Fork 為一個新的獨立會話
 message.ai.export.pdf=匯出為 PDF
 message.ai.export.pdf.dialog.title=將 AI 回覆儲存為 PDF
+message.bookmark=收藏訊息
+message.bookmark.remove=取消收藏
+message.bookmark.description=收藏此訊息
 message.edited.indicator=(已編輯)
 message.date.today=今天
 message.date.yesterday=昨天
 message.token.usage={0} 個 token · {1} 進 / {2} 出
 message.token.usage.tooltip=此回覆使用的 token。\n輸入: 您的 prompt + 傳送給 AI 的上下文。\n輸出: AI 產生的回覆。
+
+# Bookmarks
+chat.bookmarks.button.tooltip=書籤
+chat.bookmarks.popover.title=已固定的訊息
+chat.bookmarks.popover.empty.title=尚無書籤
+chat.bookmarks.popover.empty.hint=點擊訊息下方的書籤圖示進行固定
+bookmarks.title=書籤
+bookmarks.empty.title=尚無書籤
+bookmarks.empty.hint=點擊訊息下方的固定圖示新增書籤
+bookmarks.session.untitled=未命名對話
+bookmarks.message.count=已固定 {0} 則
+bookmarks.role.user=你
+bookmarks.role.ai=AI
 
 # Tool call display
 tool.call.header.running=正在執行工具...
@@ -992,6 +1007,11 @@ provider.openai_compatible.apimode.label=API 格式
 provider.openai_compatible.apimode.description=此提供者使用的 OpenAI API 端點
 provider.openai_compatible.apimode.chat_completions=Chat Completions
 provider.openai_compatible.apimode.responses=Responses API
+provider.openai_compatible.httpversion.label=HTTP 版本
+provider.openai_compatible.httpversion.description=連接到此端點的 HTTP 協定版本
+provider.openai_compatible.httpversion.http1_1=與大多數伺服器相容；如果 HTTP/2 導致問題，請使用此選項
+provider.openai_compatible.httpversion.http2=對於完全支援 HTTP/2 的端點速度更快
+
 
 # System Resources
 system.share.feedback=分享回饋
@@ -1041,7 +1061,6 @@ developer.session.memory.messages=記憶訊息
 developer.session.memory.word.count={0} 個字
 developer.session.memory.empty=(空)
 
-
 # Export Format - Markdown
 export.format.markdown.name=Markdown
 export.format.markdown.description=易於閱讀的文字格式
@@ -1065,7 +1084,6 @@ export.format.html.benefit.1=漂亮的呈現
 export.format.html.benefit.2=可在任何瀏覽器檢視
 export.format.html.benefit.3=專業外觀
 export.format.html.benefit.4=容易分享
-
 
 # Error Messages
 error.network=⚠️ 無法連線至 AI 服務{endpoint}\n\n請檢查：\n• 網路連線\n• AI 服務位址（請確認設定）\n• 防火牆設定\n• 服務是否可用
@@ -1095,7 +1113,6 @@ error.app.message=發生未預期的錯誤：{0}
 
 # Send Message Errors
 error.send_message.title=傳送訊息失敗
-
 
 # Indexing Errors
 error.indexing.model_not_found.title=找不到嵌入模型
@@ -1140,7 +1157,7 @@ settings.rag.indexing.binary.extensions.hint=以逗號分隔的在索引時被�
 settings.rag.indexing.embedding.batch.size=嵌入批次大小
 settings.rag.indexing.embedding.batch.size.hint=每次請求傳送至嵌入模型的文字片段數量。若索引速度慢且使用遠端提供商（OpenAI、Gemini），可嘗試增大至 100–500。若使用本地模型（Ollama、LM Studio），請保持較低值以避免逾時。
 
-# Settings - Models
+## Settings - Models
 settings.models.title=模型
 settings.models.description=設定所有提供商共享的全域 AI 模型行為。
 settings.models.max.tool.calling.round.trips=最大工具呼叫來回次數
@@ -1160,18 +1177,18 @@ settings.memory.mode.detail=詳細
 settings.memory.mode.detail.hint=高保真，更多 token
 settings.memory.mode.detail.description=最少摘要。保留更多原文對話和更豐富的摘要。適合短會話或需要精確記憶的場景。
 
-# Settings - Utility Models
+## Settings - Utility Models
 settings.utility.models.title=工具模型
 settings.utility.models.uses.selected=（使用所選模型）
 settings.utility.models.local.note={0} 是本地提供者 —— 工具任務會自動使用目前啟用的聊天模型。
 
-# Vision Models
+## Settings - Vision Models
 settings.vision.models.title=視覺模型
 
 ## Settings - Image Models
 settings.image.models.title=影像生成模型
 
-# Settings - Provider Model Config
+## Settings - Provider Model Config
 settings.provider.model.config.title=模型設定
 settings.provider.model.config.description=覆寫特定任務所使用的預設模型。若欄位留空，則使用提供者的預設模型。
 settings.provider.model.config.guide=查看 AI 模型設定指南
@@ -1181,7 +1198,6 @@ settings.provider.model.image.hint=用於從文字描述生成影像的模型
 settings.provider.model.embedding.hint=用於產生向量嵌入以支援 RAG 知識庫搜尋的模型
 
 settings.model.placeholder.enter=輸入 {0} 模型
-
 
 # File Viewer Dialog
 file.viewer.title=檔案檢視器
@@ -1617,20 +1633,3 @@ persona.developer=💻 編寫和審查程式碼
 persona.researcher=🔬 研究和分析
 persona.manager=📋 撰寫和組織
 persona.everything=⚡ 我做各種混合的工作
-
-# Bookmarks
-menu.view.bookmarks=查看書籤
-message.bookmark=收藏訊息
-message.bookmark.remove=取消收藏
-message.bookmark.description=收藏此訊息
-chat.bookmarks.button.tooltip=書籤
-chat.bookmarks.popover.title=已固定的訊息
-chat.bookmarks.popover.empty.title=尚無書籤
-chat.bookmarks.popover.empty.hint=點擊訊息下方的書籤圖示進行固定
-bookmarks.title=書籤
-bookmarks.empty.title=尚無書籤
-bookmarks.empty.hint=點擊訊息下方的固定圖示新增書籤
-bookmarks.session.untitled=未命名對話
-bookmarks.message.count=已固定 {0} 則
-bookmarks.role.user=你
-bookmarks.role.ai=AI

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -2336,3 +2336,154 @@ tasks.register("customNotarizeMacApp") {
         logger.lifecycle("The app will launch without security warnings.")
     }
 }
+
+/*
+ * Reorders keys in all locale .properties files to match the order in the base messages.properties.
+ *
+ * Run with: ./gradlew sortI18nKeys
+ *
+ * The base file's structure (comments, blank lines, key order) is used as the template.
+ * Each locale file is rewritten with:
+ *   - The same structure and comments as the base
+ *   - Each key replaced with the locale's translation
+ *   - Keys missing in the locale file written with value "TBT" (To Be Translated)
+ *   - Any locale-only keys (not in base) appended at the end under a separator comment
+ */
+tasks.register("sortI18nKeys") {
+    group = "i18n"
+    description = "Reorders keys in all locale .properties files to match messages.properties key order"
+
+    doLast {
+        val i18nDir = file("$projectDir/../desktop-shared/src/main/resources/i18n")
+        val baseFile = File(i18nDir, "messages.properties")
+
+        check(baseFile.exists()) { "Base file not found: ${baseFile.absolutePath}" }
+
+        // ── Parsers ────────────────────────────────────────────────────────────────────────────
+
+        // Returns true when a physical line ends with an odd number of backslashes (line continuation).
+        fun isContinuation(line: String): Boolean {
+            var count = 0
+            var i = line.length - 1
+            while (i >= 0 && line[i] == '\\') {
+                count++
+                i--
+            }
+            return count % 2 == 1
+        }
+
+        // Joins physical lines into logical lines, respecting the .properties continuation syntax.
+        // The returned strings may contain embedded '\n' for multi-line values.
+        fun readLogicalLines(file: File): List<String> {
+            val physical = file.readLines(Charsets.UTF_8)
+            val result = mutableListOf<String>()
+            var i = 0
+            while (i < physical.size) {
+                val sb = StringBuilder(physical[i])
+                while (isContinuation(physical[i]) && i + 1 < physical.size) {
+                    i++
+                    sb.append('\n').append(physical[i])
+                }
+                result.add(sb.toString())
+                i++
+            }
+            return result
+        }
+
+        // Each element is Pair<key?, logicalLine>. key==null means a structural line (comment/blank).
+        // logicalLine may span multiple physical lines (embedded '\n') for multi-line values.
+        fun parseBaseLines(file: File): List<Pair<String?, String>> =
+            readLogicalLines(file).map { logical ->
+                val firstLine = logical.substringBefore('\n').trim()
+                if (firstLine.isEmpty() || firstLine.startsWith("#") || firstLine.startsWith("!")) {
+                    null to logical
+                } else {
+                    val eqIdx = firstLine.indexOfFirst { it == '=' || it == ':' }
+                    if (eqIdx > 0) {
+                        firstLine.substring(0, eqIdx).trim() to logical
+                    } else {
+                        null to logical
+                    }
+                }
+            }
+
+        // Maps key -> full raw logical line (verbatim, may be multi-line) so it can be written back as-is.
+        fun parseLocaleValues(file: File): LinkedHashMap<String, String> {
+            val map = LinkedHashMap<String, String>()
+            for (logical in readLogicalLines(file)) {
+                val firstLine = logical.substringBefore('\n').trim()
+                if (firstLine.isEmpty() || firstLine.startsWith("#") || firstLine.startsWith("!")) continue
+                val eqIdx = firstLine.indexOfFirst { it == '=' || it == ':' }
+                if (eqIdx > 0) map[firstLine.substring(0, eqIdx).trim()] = logical
+            }
+            return map
+        }
+
+        // ── Process ────────────────────────────────────────────────────────────────────────────
+        val baseLines = parseBaseLines(baseFile)
+
+        val localeFiles =
+            i18nDir
+                .listFiles { f ->
+                    f.name.startsWith("messages_") && f.name.endsWith(".properties")
+                }?.sortedBy { it.name } ?: emptyList()
+
+        var totalReordered = 0
+
+        for (localeFile in localeFiles) {
+            val localeValues = parseLocaleValues(localeFile)
+            val usedKeys = mutableSetOf<String>()
+            var tbtCount = 0
+            val output = StringBuilder()
+
+            for ((key, rawLine) in baseLines) {
+                if (key == null) {
+                    output.appendLine(rawLine)
+                } else {
+                    val rawLogical = localeValues[key]
+                    if (rawLogical != null) {
+                        output.appendLine(rawLogical) // verbatim — preserves multi-line continuations
+                    } else {
+                        output.appendLine("$key=TBT")
+                        tbtCount++
+                    }
+                    usedKeys += key
+                }
+            }
+
+            // Append locale-only keys not present in the base file
+            val extraKeys = localeValues.keys - usedKeys
+            if (extraKeys.isNotEmpty()) {
+                output.appendLine()
+                output.appendLine("# ── Keys not yet in base messages.properties ─────────────────────────")
+                for (key in extraKeys) {
+                    output.appendLine(localeValues[key]!!) // verbatim
+                }
+            }
+
+            val newContent = output.toString().trimEnd() + "\n"
+            val oldContent = localeFile.readText(Charsets.UTF_8)
+
+            if (newContent != oldContent) {
+                localeFile.writeText(newContent, Charsets.UTF_8)
+                val summary =
+                    buildString {
+                        append("reordered ${localeValues.size} keys")
+                        if (tbtCount > 0) append(", $tbtCount marked TBT")
+                        if (extraKeys.isNotEmpty()) append(", ${extraKeys.size} locale-only key(s) appended")
+                    }
+                logger.lifecycle("✅ ${localeFile.name} — $summary")
+                totalReordered++
+            } else {
+                logger.lifecycle("⬜ ${localeFile.name} — already in correct order, skipped")
+            }
+        }
+
+        logger.lifecycle("")
+        if (totalReordered == 0) {
+            logger.lifecycle("✅ All locale files already match the base key order.")
+        } else {
+            logger.lifecycle("✅ Reordered $totalReordered locale file(s).")
+        }
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/OpenAiCompatibleChatModelFactory.kt
@@ -70,8 +70,18 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
      *
      * Defaults to [HttpClient.Version.HTTP_2]. Override to [HttpClient.Version.HTTP_1_1]
      * for servers that do not support HTTP/2 (e.g., LmStudio, Docker AI).
+     *
+     * Prefer overriding [httpVersion] that takes [settings] when the version should be
+     * read from per-instance settings rather than being a class-level constant.
      */
     protected open fun httpVersion(): HttpClient.Version = HttpClient.Version.HTTP_2
+
+    /**
+     * Settings-aware variant of [httpVersion]. Called by the base class at every
+     * model-build and model-list site. The default delegates to [httpVersion] so all
+     * existing subclasses that override the no-arg form continue to work unchanged.
+     */
+    protected open fun httpVersion(settings: T): HttpClient.Version = httpVersion()
 
     /**
      * Fallback model name used for the secondary/utility model when no explicit utility model
@@ -120,7 +130,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
     protected open fun probeThinkingSupport(settings: T): Boolean = try {
         val testModel = OpenAiResponsesStreamingChatModel
             .builder()
-            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl))
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, httpVersion = httpVersion(settings)))
             .baseUrl(settings.baseUrl)
             .apiKey(resolveApiKey(settings))
             .modelName(settings.defaultModel)
@@ -152,9 +162,10 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
     protected open fun createHttpClientBuilder(
         baseUrl: String,
         listener: TelemetryChatModelListener? = null,
+        httpVersion: HttpClient.Version = httpVersion(),
     ) = JdkHttpClient.builder().httpClientBuilder(
         ProxyUtil.configureProxy(
-            HttpClient.newBuilder().version(httpVersion()),
+            HttpClient.newBuilder().version(httpVersion),
             baseUrl,
         ).withLoggingIfDebug(),
     ).readTimeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
@@ -173,7 +184,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
             apiKey = resolveApiKey(settings),
             url = "${settings.baseUrl.trimEnd('/')}/models",
             providerName = getProvider(),
-            httpVersion = httpVersion(),
+            httpVersion = httpVersion(settings),
         ).map { ModelDTO.of(getProvider(), it) }
     }
 
@@ -240,7 +251,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
         val listener = createTelemetryListener()
         val supportsThinking = ModelCapabilitiesCache.supportsThinking(getProvider(), settings.defaultModel)
         return OpenAiResponsesStreamingChatModel.builder()
-            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener))
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener, httpVersion(settings)))
             .baseUrl(settings.baseUrl)
             .apiKey(resolveApiKey(settings))
             .modelName(settings.defaultModel)
@@ -261,7 +272,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
         val modelName = settings.utilityModel
             .ifBlank { utilityModelFallback(settings) }
         return OpenAiResponsesChatModel.builder()
-            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener))
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener, httpVersion(settings)))
             .baseUrl(settings.baseUrl)
             .apiKey(resolveApiKey(settings))
             .modelName(modelName)
@@ -273,7 +284,7 @@ abstract class OpenAiCompatibleChatModelFactory<T> : ChatModelFactory<T>
         val listener = createTelemetryListener()
         val supportsThinking = ModelCapabilitiesCache.supportsThinking(getProvider(), settings.defaultModel)
         return OpenAiResponsesChatModel.builder()
-            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener))
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener, httpVersion(settings)))
             .baseUrl(settings.baseUrl)
             .apiKey(resolveApiKey(settings))
             .modelName(settings.defaultModel)

--- a/shared/src/main/kotlin/io/askimo/core/providers/SettingField.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/SettingField.kt
@@ -26,6 +26,7 @@ sealed class SettingField {
         const val THINKING_BUDGET_TOKENS = "thinkingBudgetTokens"
         const val THINKING_MAX_TOKENS = "thinkingMaxTokens"
         const val API_MODE = "apiMode"
+        const val HTTP_VERSION = "httpVersion"
     }
 
     data class TextField(

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiApiMode.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiApiMode.kt
@@ -21,3 +21,18 @@ enum class OpenAiApiMode {
     CHAT_COMPLETIONS,
     RESPONSES,
 }
+
+/**
+ * HTTP protocol version used for connections to an OpenAI-compatible endpoint.
+ *
+ * - [HTTP_1_1] — use for self-hosted servers running on uvicorn, Gunicorn, FastAPI, or vLLM.
+ *   These stacks commonly have incomplete HTTP/2 support that causes the request body to
+ *   arrive as null. **This is the safe default for the OpenAI-compatible provider.**
+ *
+ * - [HTTP_2] — use for production cloud endpoints (OpenAI, Groq, OpenRouter, etc.) that
+ *   fully support HTTP/2 multiplexing.
+ */
+enum class OpenAiHttpVersion {
+    HTTP_1_1,
+    HTTP_2,
+}

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
@@ -13,6 +13,7 @@ import dev.langchain4j.model.openai.OpenAiStreamingChatModel
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.OpenAiCompatibleChatModelFactory
 import io.askimo.core.util.ApiKeyUtils.safeApiKey
+import java.net.http.HttpClient
 
 /**
  * Intermediate base that adds [shouldProbeThinking] as a stable, non-protected surface so
@@ -23,6 +24,15 @@ internal abstract class OpenAiCompatibleDelegateFactory : OpenAiCompatibleChatMo
 
     /** Expose the protected [probeThinkingSupport] to the router as an internal method. */
     internal fun shouldProbeThinking(settings: OpenAiCompatibleSettings): Boolean = probeThinkingSupport(settings)
+
+    /**
+     * Read the HTTP version from per-instance [settings] rather than using a class-level constant.
+     * Maps [OpenAiHttpVersion] to the JDK [HttpClient.Version] enum.
+     */
+    override fun httpVersion(settings: OpenAiCompatibleSettings): HttpClient.Version = when (settings.httpVersion) {
+        OpenAiHttpVersion.HTTP_1_1 -> HttpClient.Version.HTTP_1_1
+        OpenAiHttpVersion.HTTP_2 -> HttpClient.Version.HTTP_2
+    }
 }
 
 // ── Delegate: Chat Completions API (/v1/chat/completions) ─────────────────────────────────
@@ -44,7 +54,7 @@ internal class OpenAiCompatibleCompletionsModelFactory : OpenAiCompatibleDelegat
     override fun createStreamingModel(settings: OpenAiCompatibleSettings): StreamingChatModel {
         val listener = createTelemetryListener()
         return OpenAiStreamingChatModel.builder()
-            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener))
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener, httpVersion(settings)))
             .baseUrl(settings.baseUrl)
             .apiKey(resolveApiKey(settings))
             .modelName(settings.defaultModel)
@@ -57,7 +67,7 @@ internal class OpenAiCompatibleCompletionsModelFactory : OpenAiCompatibleDelegat
         val modelName = settings.utilityModel
             .ifBlank { utilityModelFallback(settings) }
         return OpenAiChatModel.builder()
-            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener))
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener, httpVersion(settings)))
             .baseUrl(settings.baseUrl)
             .apiKey(resolveApiKey(settings))
             .modelName(modelName)
@@ -68,7 +78,7 @@ internal class OpenAiCompatibleCompletionsModelFactory : OpenAiCompatibleDelegat
     override fun createModel(settings: OpenAiCompatibleSettings): ChatModel {
         val listener = createTelemetryListener()
         return OpenAiChatModel.builder()
-            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener))
+            .httpClientBuilder(createHttpClientBuilder(settings.baseUrl, listener, httpVersion(settings)))
             .baseUrl(settings.baseUrl)
             .apiKey(resolveApiKey(settings))
             .modelName(settings.defaultModel)

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
@@ -28,6 +28,13 @@ data class OpenAiCompatibleSettings(
      * Existing serialised configs without this field deserialise to the default safely.
      */
     val apiMode: OpenAiApiMode = OpenAiApiMode.CHAT_COMPLETIONS,
+    /**
+     * HTTP protocol version for connections to this endpoint.
+     * Defaults to [OpenAiHttpVersion.HTTP_1_1] — the safe choice for self-hosted servers
+     * (uvicorn, vLLM, FastAPI). Switch to [OpenAiHttpVersion.HTTP_2] for cloud endpoints.
+     * Existing serialised configs without this field deserialise to the default safely.
+     */
+    val httpVersion: OpenAiHttpVersion = OpenAiHttpVersion.HTTP_1_1,
 ) : ProviderSettings,
     HasApiKey,
     HasBaseUrl {
@@ -36,9 +43,10 @@ data class OpenAiCompatibleSettings(
         "baseUrl: $baseUrl",
         "apiKey:  ${maskApiKey()}",
         "apiMode: $apiMode",
+        "httpVersion: $httpVersion",
     )
 
-    override fun toString(): String = "OpenAiCompatibleSettings(baseUrl=$baseUrl, apiKey=${maskApiKey()}, apiMode=$apiMode)"
+    override fun toString(): String = "OpenAiCompatibleSettings(baseUrl=$baseUrl, apiKey=${maskApiKey()}, apiMode=$apiMode, httpVersion=$httpVersion)"
 
     override fun getFields() = listOf(
         SettingField.TextField(
@@ -73,6 +81,10 @@ data class OpenAiCompatibleSettings(
 
         SettingField.API_MODE -> copy(
             apiMode = runCatching { OpenAiApiMode.valueOf(value) }.getOrDefault(apiMode),
+        )
+
+        SettingField.HTTP_VERSION -> copy(
+            httpVersion = runCatching { OpenAiHttpVersion.valueOf(value) }.getOrDefault(httpVersion),
         )
 
         else -> this
@@ -120,6 +132,24 @@ data class OpenAiCompatibleSettings(
                     ),
                 ),
             ),
+            ProviderConfigField.SelectField(
+                name = SettingField.HTTP_VERSION,
+                label = messageResolver("provider.openai_compatible.httpversion.label"),
+                description = messageResolver("provider.openai_compatible.httpversion.description"),
+                value = httpVersion.name,
+                options = listOf(
+                    SelectOption(
+                        value = OpenAiHttpVersion.HTTP_1_1.name,
+                        label = "HTTP/1.1",
+                        description = messageResolver("provider.openai_compatible.httpversion.http1_1"),
+                    ),
+                    SelectOption(
+                        value = OpenAiHttpVersion.HTTP_2.name,
+                        label = "HTTP/2",
+                        description = messageResolver("provider.openai_compatible.httpversion.http2"),
+                    ),
+                ),
+            ),
         )
     }
 
@@ -129,7 +159,10 @@ data class OpenAiCompatibleSettings(
         val newApiMode = fields[SettingField.API_MODE]
             ?.let { runCatching { OpenAiApiMode.valueOf(it) }.getOrNull() }
             ?: apiMode
-        return copy(baseUrl = newBaseUrl, apiKey = newApiKey, apiMode = newApiMode)
+        val newHttpVersion = fields[SettingField.HTTP_VERSION]
+            ?.let { runCatching { OpenAiHttpVersion.valueOf(it) }.getOrNull() }
+            ?: httpVersion
+        return copy(baseUrl = newBaseUrl, apiKey = newApiKey, apiMode = newApiMode, httpVersion = newHttpVersion)
     }
 
     override fun deepCopy(): ProviderSettings = copy()


### PR DESCRIPTION
- Enables users to specify HTTP/1.1 or HTTP/2 for OpenAI-compatible endpoints.
- Improves compatibility with various self-hosted and cloud API servers.
- Integrates the new setting into the API client factory logic.