### PR TITLE
fix(desktop): Allow new project creation during session move

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -1021,6 +1020,9 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                                         onShowSessionSummary = { sessionId ->
                                                             sessionMemorySessionId = sessionId
                                                             showSessionMemoryDialog = true
+                                                        },
+                                                        onMoveSessionToNewProject = {
+                                                            showNewProjectDialog = true
                                                         },
                                                         onEditProject = { projectId ->
                                                             editingProjectId = projectId
@@ -2017,7 +2019,6 @@ fun mainContent(
     onOpenSystemDiagnostics: () -> Unit = {},
     bookmarksViewModel: BookmarksViewModel? = null,
 ) {
-    val discoverRefresh by appContext.telemetry.refreshSignal.collectAsState()
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
@@ -78,6 +78,7 @@ fun navigationSidebar(
     onRenameSession: (String, String) -> Unit,
     onExportSession: (String) -> Unit,
     onShowSessionSummary: (String) -> Unit = {},
+    onMoveSessionToNewProject: (sessionId: String) -> Unit = {},
     onEditProject: (String) -> Unit = {},
     onDeleteProject: (String) -> Unit = {},
     onEditUserProfile: () -> Unit,
@@ -118,6 +119,7 @@ fun navigationSidebar(
         onRenameSession = onRenameSession,
         onExportSession = onExportSession,
         onShowSessionSummary = onShowSessionSummary,
+        onMoveSessionToNewProject = onMoveSessionToNewProject,
         onEditProject = onEditProject,
         onDeleteProject = onDeleteProject,
         userProfileContent = {


### PR DESCRIPTION
- Resolves the issue where project creation was blocked within session drop-down menus.