### PR TITLE
refactor(providers): Refactor OpenAI provider API delegates and settings structure

### DIFF
--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
@@ -508,8 +508,8 @@ private fun providerModelTypePickerDialog(
                             modifier = Modifier.fillMaxWidth().padding(Spacing.large),
                             verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
                         ) {
-                            Text(text = stringResource("settings.model.current"), style = AppTextStyles.fieldLabel)
-                            Text(text = currentValue, style = AppTextStyles.sectionTitle)
+                            Text(text = stringResource("settings.model.current"), style = AppTextStyles.fieldLabel, color = MaterialTheme.colorScheme.onSecondaryContainer)
+                            Text(text = currentValue, style = AppTextStyles.sectionTitle, color = MaterialTheme.colorScheme.onSecondaryContainer)
                         }
                     }
                 }
@@ -521,7 +521,7 @@ private fun providerModelTypePickerDialog(
                                 Text(text = stringResource("settings.model.new"), style = AppTextStyles.fieldLabel, color = MaterialTheme.colorScheme.onPrimaryContainer)
                                 Text(text = selectedModel ?: "", style = AppTextStyles.body, color = MaterialTheme.colorScheme.onPrimaryContainer)
                             }
-                            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = AppTextStyles.primaryContent)
+                            Icon(Icons.Default.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimaryContainer)
                         }
                     }
                 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/GroupedModelList.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/GroupedModelList.kt
@@ -78,12 +78,13 @@ fun groupedModelListAsCards(
                     Text(
                         text = dto.displayName,
                         style = AppTextStyles.body,
+                        color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
                     )
                     if (isSelected) {
                         Icon(
                             Icons.Default.CheckCircle,
                             contentDescription = "Selected model",
-                            tint = MaterialTheme.colorScheme.onSurface,
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
                         )
                     }
                 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderWizardViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderWizardViewModel.kt
@@ -347,7 +347,7 @@ class ProviderWizardViewModel(
         val prefilled = OpenAiCompatibleSettings(
             baseUrl = template.baseUrl,
             apiMode = template.apiMode,
-            httpVersionConfig = template.httpVersion,
+            httpVersion = template.httpVersion,
             isTemplate = true,
         )
         templateBaseSettings = prefilled

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -153,6 +153,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
         settings: GeminiSettings,
     ): ImageModel = GoogleAiGeminiImageModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
+        .httpClientBuilder(createJdkHttpClientBuilder())
         .baseUrl(settings.baseUrl)
         .modelName(settings.imageModel)
         .build()
@@ -217,6 +218,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
 
     override fun createEmbeddingModel(settings: GeminiSettings): EmbeddingModel = GoogleAiEmbeddingModel.builder()
         .apiKey(safeApiKey(settings.apiKey))
+        .httpClientBuilder(createJdkHttpClientBuilder())
         .modelName(settings.embeddingModel)
         .build()
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/lmstudio/LmStudioModelFactory.kt
@@ -4,7 +4,6 @@
  */
 package io.askimo.core.providers.lmstudio
 
-import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
 import io.askimo.core.context.AppContext
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ModelProvider.LMSTUDIO
@@ -12,7 +11,6 @@ import io.askimo.core.providers.ensureLocalEmbeddingModelAvailable
 import io.askimo.core.providers.openaicompatible.CompletionsApiDelegate
 import io.askimo.core.providers.openaicompatible.OpenAiCompatibleChatModelFactory
 import io.askimo.core.providers.openaicompatible.ResponsesApiDelegate
-import io.askimo.core.util.toJdkVersion
 
 /**
  * Model factory for LM Studio.
@@ -37,12 +35,4 @@ class LmStudioModelFactory :
     override fun utilityModelFallback(settings: LmStudioSettings): String = AppContext.getInstance().params.model
 
     override fun checkEmbeddingAvailability(baseUrl: String, modelName: String) = ensureLocalEmbeddingModelAvailable(getProvider(), baseUrl, modelName)
-
-    /** LM Studio requires an HTTP/1.1 client on the embedding builder as well. */
-    override fun customizeEmbeddingBuilder(
-        settings: LmStudioSettings,
-        builder: OpenAiEmbeddingModelBuilder,
-    ): OpenAiEmbeddingModelBuilder = builder.httpClientBuilder(
-        createHttpClientBuilder(settings.baseUrl, httpVersion = settings.httpVersion.toJdkVersion()),
-    )
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/CompletionsApiDelegate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/CompletionsApiDelegate.kt
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.providers.openaicompatible
+
+import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
+import dev.langchain4j.model.openai.OpenAiChatModel
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel
+import io.askimo.core.providers.ModelProvider
+import io.askimo.core.telemetry.TelemetryChatModelListener
+import org.slf4j.Logger
+
+/**
+ * Builds models using the standard `/v1/chat/completions` endpoint.
+ *
+ * Use for virtually every third-party OpenAI-compatible provider (NVIDIA NIM, OpenRouter,
+ * Groq, Together AI, Cloudflare AI, Ollama, LM Studio, Docker AI, LocalAI, etc.).
+ * Thinking is hard-wired to `false` — the Completions surface has no reasoning support.
+ */
+class CompletionsApiDelegate : OpenAiApiDelegate {
+
+    override fun createStreamingModel(
+        baseUrl: String,
+        apiKey: String,
+        modelName: String,
+        httpClientBuilder: JdkHttpClientBuilder,
+        listener: TelemetryChatModelListener,
+        provider: ModelProvider,
+    ): StreamingChatModel = OpenAiStreamingChatModel.builder()
+        .httpClientBuilder(httpClientBuilder)
+        .baseUrl(baseUrl)
+        .apiKey(apiKey)
+        .modelName(modelName)
+        .listeners(listOf(listener))
+        .build()
+
+    override fun createSecondaryModel(
+        baseUrl: String,
+        apiKey: String,
+        modelName: String,
+        httpClientBuilder: JdkHttpClientBuilder,
+        listener: TelemetryChatModelListener,
+    ): ChatModel = OpenAiChatModel.builder()
+        .httpClientBuilder(httpClientBuilder)
+        .baseUrl(baseUrl)
+        .apiKey(apiKey)
+        .modelName(modelName)
+        .listeners(listOf(listener))
+        .build()
+
+    override fun createModel(
+        baseUrl: String,
+        apiKey: String,
+        modelName: String,
+        httpClientBuilder: JdkHttpClientBuilder,
+        listener: TelemetryChatModelListener,
+        provider: ModelProvider,
+    ): ChatModel = OpenAiChatModel.builder()
+        .httpClientBuilder(httpClientBuilder)
+        .baseUrl(baseUrl)
+        .apiKey(apiKey)
+        .modelName(modelName)
+        .listeners(listOf(listener))
+        .build()
+
+    /** Chat Completions surface has no reasoning support — always returns `false`. */
+    override fun probeThinkingSupport(
+        baseUrl: String,
+        apiKey: String,
+        modelName: String,
+        httpClientBuilder: JdkHttpClientBuilder,
+        log: Logger,
+    ): Boolean = false
+}

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiApiDelegate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiApiDelegate.kt
@@ -4,20 +4,10 @@
  */
 package io.askimo.core.providers.openaicompatible
 
-import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
 import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.model.chat.StreamingChatModel
-import dev.langchain4j.model.openai.OpenAiChatModel
-import dev.langchain4j.model.openai.OpenAiResponsesChatModel
-import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel
-import dev.langchain4j.service.AiServices
-import io.askimo.core.providers.ChatClient
-import io.askimo.core.providers.ModelCapabilitiesCache
 import io.askimo.core.providers.ModelProvider
-import io.askimo.core.providers.ReasoningEffort
-import io.askimo.core.providers.sendStreamingMessageWithCallback
 import io.askimo.core.telemetry.TelemetryChatModelListener
 import org.slf4j.Logger
 
@@ -79,7 +69,7 @@ sealed interface OpenAiApiDelegate {
      *
      * [CompletionsApiDelegate] returns `false` immediately — the `/v1/chat/completions`
      * surface has no reasoning support. [ResponsesApiDelegate] fires a minimal HTTP probe
-     * against the `/v1/responses` endpoint, caching the result via [ModelCapabilitiesCache].
+     * against the `/v1/responses` endpoint, caching the result via `ModelCapabilitiesCache`.
      */
     fun probeThinkingSupport(
         baseUrl: String,
@@ -88,177 +78,4 @@ sealed interface OpenAiApiDelegate {
         httpClientBuilder: JdkHttpClientBuilder,
         log: Logger,
     ): Boolean
-}
-
-// ── Delegate: Chat Completions API (/v1/chat/completions) ────────────────────────────────
-
-/**
- * Builds models using the standard `/v1/chat/completions` endpoint.
- *
- * Use for virtually every third-party OpenAI-compatible provider (NVIDIA NIM, OpenRouter,
- * Groq, Together AI, Cloudflare AI, Ollama, LM Studio, Docker AI, LocalAI, etc.).
- * Thinking is hard-wired to `false` — the Completions surface has no reasoning support.
- */
-class CompletionsApiDelegate : OpenAiApiDelegate {
-
-    override fun createStreamingModel(
-        baseUrl: String,
-        apiKey: String,
-        modelName: String,
-        httpClientBuilder: JdkHttpClientBuilder,
-        listener: TelemetryChatModelListener,
-        provider: ModelProvider,
-    ): StreamingChatModel = OpenAiStreamingChatModel.builder()
-        .httpClientBuilder(httpClientBuilder)
-        .baseUrl(baseUrl)
-        .apiKey(apiKey)
-        .modelName(modelName)
-        .listeners(listOf(listener))
-        .build()
-
-    override fun createSecondaryModel(
-        baseUrl: String,
-        apiKey: String,
-        modelName: String,
-        httpClientBuilder: JdkHttpClientBuilder,
-        listener: TelemetryChatModelListener,
-    ): ChatModel = OpenAiChatModel.builder()
-        .httpClientBuilder(httpClientBuilder)
-        .baseUrl(baseUrl)
-        .apiKey(apiKey)
-        .modelName(modelName)
-        .listeners(listOf(listener))
-        .build()
-
-    override fun createModel(
-        baseUrl: String,
-        apiKey: String,
-        modelName: String,
-        httpClientBuilder: JdkHttpClientBuilder,
-        listener: TelemetryChatModelListener,
-        provider: ModelProvider,
-    ): ChatModel = OpenAiChatModel.builder()
-        .httpClientBuilder(httpClientBuilder)
-        .baseUrl(baseUrl)
-        .apiKey(apiKey)
-        .modelName(modelName)
-        .listeners(listOf(listener))
-        .build()
-
-    /** Chat Completions surface has no reasoning support — always returns `false`. */
-    override fun probeThinkingSupport(
-        baseUrl: String,
-        apiKey: String,
-        modelName: String,
-        httpClientBuilder: JdkHttpClientBuilder,
-        log: Logger,
-    ): Boolean = false
-}
-
-// ── Delegate: Responses API (/v1/responses) ─────────────────────────────────────────────
-
-/**
- * Builds models using the OpenAI Responses API (`/v1/responses`) with typed `input[]`
- * content parts and optional reasoning/thinking support.
- *
- * Use when the endpoint explicitly supports `/v1/responses` (native OpenAI, xAI/Grok,
- * or a compatible gateway). Most third-party providers do **not** support this endpoint.
- * This is the default for [OpenAiCompatibleChatModelFactory].
- */
-class ResponsesApiDelegate : OpenAiApiDelegate {
-
-    override fun createStreamingModel(
-        baseUrl: String,
-        apiKey: String,
-        modelName: String,
-        httpClientBuilder: JdkHttpClientBuilder,
-        listener: TelemetryChatModelListener,
-        provider: ModelProvider,
-    ): StreamingChatModel {
-        val supportsThinking = ModelCapabilitiesCache.supportsThinking(provider, modelName)
-        return OpenAiResponsesStreamingChatModel.builder()
-            .httpClientBuilder(httpClientBuilder)
-            .baseUrl(baseUrl)
-            .apiKey(apiKey)
-            .modelName(modelName)
-            .apply {
-                val reasoningLevel = ModelCapabilitiesCache.getReasoningLevel(provider, modelName)
-                if (supportsThinking && reasoningLevel.isEnabled) {
-                    reasoningEffort(reasoningLevel.value)
-                    reasoningSummary("detailed")
-                }
-            }
-            .strictTools(true)
-            .listeners(listOf(listener))
-            .build()
-    }
-
-    override fun createSecondaryModel(
-        baseUrl: String,
-        apiKey: String,
-        modelName: String,
-        httpClientBuilder: JdkHttpClientBuilder,
-        listener: TelemetryChatModelListener,
-    ): ChatModel = OpenAiResponsesChatModel.builder()
-        .httpClientBuilder(httpClientBuilder)
-        .baseUrl(baseUrl)
-        .apiKey(apiKey)
-        .modelName(modelName)
-        .listeners(listOf(listener))
-        .build()
-
-    override fun createModel(
-        baseUrl: String,
-        apiKey: String,
-        modelName: String,
-        httpClientBuilder: JdkHttpClientBuilder,
-        listener: TelemetryChatModelListener,
-        provider: ModelProvider,
-    ): ChatModel {
-        val supportsThinking = ModelCapabilitiesCache.supportsThinking(provider, modelName)
-        return OpenAiResponsesChatModel.builder()
-            .httpClientBuilder(httpClientBuilder)
-            .baseUrl(baseUrl)
-            .apiKey(apiKey)
-            .modelName(modelName)
-            .apply {
-                val reasoningLevel = ModelCapabilitiesCache.getReasoningLevel(provider, modelName)
-                if (supportsThinking && reasoningLevel.isEnabled) {
-                    reasoningEffort(reasoningLevel.value)
-                }
-            }
-            .listeners(listOf(listener))
-            .build()
-    }
-
-    /**
-     * Fires a minimal HTTP probe against the `/v1/responses` endpoint with
-     * `reasoning_effort: low` to test if the model accepts reasoning parameters.
-     */
-    override fun probeThinkingSupport(
-        baseUrl: String,
-        apiKey: String,
-        modelName: String,
-        httpClientBuilder: JdkHttpClientBuilder,
-        log: Logger,
-    ): Boolean = try {
-        val testModel = OpenAiResponsesStreamingChatModel.builder()
-            .httpClientBuilder(httpClientBuilder)
-            .baseUrl(baseUrl)
-            .apiKey(apiKey)
-            .modelName(modelName)
-            .reasoningEffort(ReasoningEffort.LOW.value)
-            .build()
-
-        val testClient = AiServices.builder(ChatClient::class.java)
-            .streamingChatModel(testModel)
-            .build()
-
-        testClient.sendStreamingMessageWithCallback(null, UserMessage("Capability probe — reply with 'ok'."))
-        log.info("Model '$modelName' supports thinking — thinking enabled")
-        true
-    } catch (e: Exception) {
-        log.info("Model '$modelName' does not support thinking: ${e.message} — thinking disabled", e)
-        false
-    }
 }

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleChatModelFactory.kt
@@ -4,7 +4,6 @@
  */
 package io.askimo.core.providers.openaicompatible
 
-import dev.langchain4j.http.client.jdk.JdkHttpClient
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.model.chat.StreamingChatModel
@@ -28,17 +27,14 @@ import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ProviderModelUtils
 import io.askimo.core.providers.ProviderSettings
 import io.askimo.core.telemetry.TelemetryChatModelListener
-import io.askimo.core.util.ProxyUtil
+import io.askimo.core.util.createJdkHttpClientBuilder
 import io.askimo.core.util.toJdkVersion
-import io.askimo.core.util.withLoggingIfDebug
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.net.http.HttpClient
-import java.time.Duration
 
 /**
  * Abstract base factory for all OpenAI-compatible API providers.
@@ -113,7 +109,7 @@ abstract class OpenAiCompatibleChatModelFactory<T>(
      *
      * The default is an identity transform (no changes).
      * Override when the provider needs extra builder settings for embeddings
-     * (e.g., LmStudio injects an HTTP/1.1 client via [createHttpClientBuilder]).
+     * (e.g., LmStudio injects an HTTP/1.1 client via [createJdkHttpClientBuilder]).
      */
     protected open fun customizeEmbeddingBuilder(
         settings: T,
@@ -130,34 +126,11 @@ abstract class OpenAiCompatibleChatModelFactory<T>(
         baseUrl = settings.baseUrl,
         apiKey = resolveApiKey(settings),
         modelName = settings.defaultModel,
-        httpClientBuilder = createHttpClientBuilder(settings.baseUrl, httpVersion = settings.httpVersion.toJdkVersion()),
+        httpClientBuilder = createJdkHttpClientBuilder(settings.baseUrl, settings.httpVersion),
         log = log,
     )
 
     // ── Shared helpers ─────────────────────────────────────────────────────────
-
-    /**
-     * Creates a [JdkHttpClient] builder configured with the correct HTTP version and proxy
-     * settings for this provider. Proxy is automatically bypassed for localhost URLs.
-     *
-     * [listener] is provided when the HTTP client should be wired to a specific
-     * [TelemetryChatModelListener] instance — e.g. to inject per-request headers that are
-     * derived from that listener. The default implementation ignores it.
-     *
-     * The HTTP version defaults to [HttpClient.Version.HTTP_2]; callers pass
-     * `settings.httpVersion.toJdkVersion()` to respect the per-provider/per-instance setting.
-     */
-    protected open fun createHttpClientBuilder(
-        baseUrl: String,
-        listener: TelemetryChatModelListener? = null,
-        httpVersion: HttpClient.Version = HttpClient.Version.HTTP_2,
-    ) = JdkHttpClient.builder().httpClientBuilder(
-        ProxyUtil.configureProxy(
-            HttpClient.newBuilder().version(httpVersion),
-            baseUrl,
-        ).withLoggingIfDebug(),
-    ).readTimeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
-        .connectTimeout(Duration.ofSeconds(AppConfig.models.timeouts.defaultModelTimeoutSeconds))
 
     /**
      * Creates the [TelemetryChatModelListener] attached to every model built by this factory.
@@ -241,7 +214,7 @@ abstract class OpenAiCompatibleChatModelFactory<T>(
             baseUrl = settings.baseUrl,
             apiKey = resolveApiKey(settings),
             modelName = settings.defaultModel,
-            httpClientBuilder = createHttpClientBuilder(settings.baseUrl, listener, settings.httpVersion.toJdkVersion()),
+            httpClientBuilder = createJdkHttpClientBuilder(settings.baseUrl, settings.httpVersion),
             listener = listener,
             provider = getProvider(),
         )
@@ -254,7 +227,7 @@ abstract class OpenAiCompatibleChatModelFactory<T>(
             baseUrl = settings.baseUrl,
             apiKey = resolveApiKey(settings),
             modelName = modelName,
-            httpClientBuilder = createHttpClientBuilder(settings.baseUrl, listener, settings.httpVersion.toJdkVersion()),
+            httpClientBuilder = createJdkHttpClientBuilder(settings.baseUrl, settings.httpVersion),
             listener = listener,
         )
     }
@@ -265,7 +238,7 @@ abstract class OpenAiCompatibleChatModelFactory<T>(
             baseUrl = settings.baseUrl,
             apiKey = resolveApiKey(settings),
             modelName = settings.defaultModel,
-            httpClientBuilder = createHttpClientBuilder(settings.baseUrl, listener, settings.httpVersion.toJdkVersion()),
+            httpClientBuilder = createJdkHttpClientBuilder(settings.baseUrl, settings.httpVersion),
             listener = listener,
             provider = getProvider(),
         )
@@ -275,6 +248,7 @@ abstract class OpenAiCompatibleChatModelFactory<T>(
         .baseUrl(settings.baseUrl)
         .apiKey(resolveApiKey(settings))
         .modelName(settings.imageModel)
+        .httpClientBuilder(createJdkHttpClientBuilder(settings.baseUrl, settings.httpVersion))
         .build()
 
     override fun createUtilityClient(settings: T): ChatClient = AiServices.builder(ChatClient::class.java)
@@ -296,6 +270,7 @@ abstract class OpenAiCompatibleChatModelFactory<T>(
             OpenAiEmbeddingModelBuilder()
                 .apiKey("not-needed")
                 .baseUrl(baseUrl)
+                .httpClientBuilder(createJdkHttpClientBuilder(baseUrl, settings.httpVersion))
                 .modelName(modelName),
         ).build()
     }

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
@@ -10,7 +10,7 @@ import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.util.ApiKeyUtils.safeApiKey
-import io.askimo.core.util.toJdkVersion
+import io.askimo.core.util.createJdkHttpClientBuilder
 
 /**
  * The registered factory for [ModelProvider.OPENAI_COMPATIBLE].
@@ -40,7 +40,7 @@ class OpenAiCompatibleModelFactory : OpenAiCompatibleChatModelFactory<OpenAiComp
         baseUrl = settings.baseUrl,
         apiKey = resolveApiKey(settings),
         modelName = settings.defaultModel,
-        httpClientBuilder = createHttpClientBuilder(settings.baseUrl, httpVersion = settings.httpVersion.toJdkVersion()),
+        httpClientBuilder = createJdkHttpClientBuilder(settings.baseUrl, settings.httpVersion),
         log = log,
     )
 
@@ -50,7 +50,7 @@ class OpenAiCompatibleModelFactory : OpenAiCompatibleChatModelFactory<OpenAiComp
             baseUrl = settings.baseUrl,
             apiKey = resolveApiKey(settings),
             modelName = settings.defaultModel,
-            httpClientBuilder = createHttpClientBuilder(settings.baseUrl, listener, settings.httpVersion.toJdkVersion()),
+            httpClientBuilder = createJdkHttpClientBuilder(settings.baseUrl, settings.httpVersion),
             listener = listener,
             provider = getProvider(),
         )
@@ -63,7 +63,7 @@ class OpenAiCompatibleModelFactory : OpenAiCompatibleChatModelFactory<OpenAiComp
             baseUrl = settings.baseUrl,
             apiKey = resolveApiKey(settings),
             modelName = modelName,
-            httpClientBuilder = createHttpClientBuilder(settings.baseUrl, listener, settings.httpVersion.toJdkVersion()),
+            httpClientBuilder = createJdkHttpClientBuilder(settings.baseUrl, settings.httpVersion),
             listener = listener,
         )
     }
@@ -74,7 +74,7 @@ class OpenAiCompatibleModelFactory : OpenAiCompatibleChatModelFactory<OpenAiComp
             baseUrl = settings.baseUrl,
             apiKey = resolveApiKey(settings),
             modelName = settings.defaultModel,
-            httpClientBuilder = createHttpClientBuilder(settings.baseUrl, listener, settings.httpVersion.toJdkVersion()),
+            httpClientBuilder = createJdkHttpClientBuilder(settings.baseUrl, settings.httpVersion),
             listener = listener,
             provider = getProvider(),
         )

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
@@ -35,10 +35,10 @@ data class OpenAiCompatibleSettings(
      * (uvicorn, vLLM, FastAPI). Switch to [HttpVersion.HTTP_2] for cloud endpoints.
      * Existing serialised configs without this field deserialise to the default safely.
      */
-    val httpVersionConfig: HttpVersion = HttpVersion.HTTP_1_1,
+    override val httpVersion: HttpVersion = HttpVersion.HTTP_1_1,
     /**
      * Whether this instance was created from a predefined [OpenAiCompatibleTemplate].
-     * When `true`, [apiMode] and [httpVersionConfig] are locked to the template's preset
+     * When `true`, [apiMode] and [httpVersion] are locked to the template's preset
      * values and the corresponding UI fields are hidden in the config screen.
      * Set once at creation time by the wizard; never mutated through the field-map path.
      * Existing serialised configs without this field deserialise to `false` safely.
@@ -48,16 +48,14 @@ data class OpenAiCompatibleSettings(
     HasApiKey,
     HasBaseUrl {
 
-    override val httpVersion: HttpVersion get() = httpVersionConfig
-
     override fun describe(): List<String> = listOf(
         "baseUrl: $baseUrl",
         "apiKey:  ${maskApiKey()}",
         "apiMode: $apiMode",
-        "httpVersion: $httpVersionConfig",
+        "httpVersion: $httpVersion",
     )
 
-    override fun toString(): String = "OpenAiCompatibleSettings(baseUrl=$baseUrl, apiKey=${maskApiKey()}, apiMode=$apiMode, httpVersion=$httpVersionConfig)"
+    override fun toString(): String = "OpenAiCompatibleSettings(baseUrl=$baseUrl, apiKey=${maskApiKey()}, apiMode=$apiMode, httpVersion=$httpVersion)"
 
     override fun getFields() = listOf(
         SettingField.TextField(
@@ -95,7 +93,7 @@ data class OpenAiCompatibleSettings(
         )
 
         SettingField.HTTP_VERSION -> copy(
-            httpVersionConfig = runCatching { HttpVersion.valueOf(value) }.getOrDefault(httpVersionConfig),
+            httpVersion = runCatching { HttpVersion.valueOf(value) }.getOrDefault(httpVersion),
         )
 
         else -> this
@@ -160,7 +158,7 @@ data class OpenAiCompatibleSettings(
                         name = SettingField.HTTP_VERSION,
                         label = messageResolver("provider.openai_compatible.httpversion.label"),
                         description = messageResolver("provider.openai_compatible.httpversion.description"),
-                        value = httpVersionConfig.name,
+                        value = httpVersion.name,
                         options = listOf(
                             SelectOption(
                                 value = HttpVersion.HTTP_1_1.name,
@@ -186,13 +184,13 @@ data class OpenAiCompatibleSettings(
             ?.let { runCatching { OpenAiApiMode.valueOf(it) }.getOrNull() }
             ?: apiMode
         val newHttpVersion = if (isTemplate) {
-            httpVersionConfig
+            httpVersion
         } else {
             fields[SettingField.HTTP_VERSION]
                 ?.let { runCatching { HttpVersion.valueOf(it) }.getOrNull() }
-                ?: httpVersionConfig
+                ?: httpVersion
         }
-        return copy(baseUrl = newBaseUrl, apiKey = newApiKey, apiMode = newApiMode, httpVersionConfig = newHttpVersion)
+        return copy(baseUrl = newBaseUrl, apiKey = newApiKey, apiMode = newApiMode, httpVersion = newHttpVersion)
     }
 
     override fun deepCopy(): ProviderSettings = copy()

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/ResponsesApiDelegate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/ResponsesApiDelegate.kt
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.providers.openaicompatible
+
+import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.chat.StreamingChatModel
+import dev.langchain4j.model.openai.OpenAiResponsesChatModel
+import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel
+import dev.langchain4j.service.AiServices
+import io.askimo.core.providers.ChatClient
+import io.askimo.core.providers.ModelCapabilitiesCache
+import io.askimo.core.providers.ModelProvider
+import io.askimo.core.providers.ReasoningEffort
+import io.askimo.core.providers.sendStreamingMessageWithCallback
+import io.askimo.core.telemetry.TelemetryChatModelListener
+import org.slf4j.Logger
+
+/**
+ * Builds models using the OpenAI Responses API (`/v1/responses`) with typed `input[]`
+ * content parts and optional reasoning/thinking support.
+ *
+ * Use when the endpoint explicitly supports `/v1/responses` (native OpenAI, xAI/Grok,
+ * or a compatible gateway). Most third-party providers do **not** support this endpoint.
+ * This is the default for [OpenAiCompatibleChatModelFactory].
+ */
+class ResponsesApiDelegate : OpenAiApiDelegate {
+
+    override fun createStreamingModel(
+        baseUrl: String,
+        apiKey: String,
+        modelName: String,
+        httpClientBuilder: JdkHttpClientBuilder,
+        listener: TelemetryChatModelListener,
+        provider: ModelProvider,
+    ): StreamingChatModel {
+        val supportsThinking = ModelCapabilitiesCache.supportsThinking(provider, modelName)
+        return OpenAiResponsesStreamingChatModel.builder()
+            .httpClientBuilder(httpClientBuilder)
+            .baseUrl(baseUrl)
+            .apiKey(apiKey)
+            .modelName(modelName)
+            .apply {
+                val reasoningLevel = ModelCapabilitiesCache.getReasoningLevel(provider, modelName)
+                if (supportsThinking && reasoningLevel.isEnabled) {
+                    reasoningEffort(reasoningLevel.value)
+                    reasoningSummary("detailed")
+                }
+            }
+            .strictTools(true)
+            .listeners(listOf(listener))
+            .build()
+    }
+
+    override fun createSecondaryModel(
+        baseUrl: String,
+        apiKey: String,
+        modelName: String,
+        httpClientBuilder: JdkHttpClientBuilder,
+        listener: TelemetryChatModelListener,
+    ): ChatModel = OpenAiResponsesChatModel.builder()
+        .httpClientBuilder(httpClientBuilder)
+        .baseUrl(baseUrl)
+        .apiKey(apiKey)
+        .modelName(modelName)
+        .listeners(listOf(listener))
+        .build()
+
+    override fun createModel(
+        baseUrl: String,
+        apiKey: String,
+        modelName: String,
+        httpClientBuilder: JdkHttpClientBuilder,
+        listener: TelemetryChatModelListener,
+        provider: ModelProvider,
+    ): ChatModel {
+        val supportsThinking = ModelCapabilitiesCache.supportsThinking(provider, modelName)
+        return OpenAiResponsesChatModel.builder()
+            .httpClientBuilder(httpClientBuilder)
+            .baseUrl(baseUrl)
+            .apiKey(apiKey)
+            .modelName(modelName)
+            .apply {
+                val reasoningLevel = ModelCapabilitiesCache.getReasoningLevel(provider, modelName)
+                if (supportsThinking && reasoningLevel.isEnabled) {
+                    reasoningEffort(reasoningLevel.value)
+                }
+            }
+            .listeners(listOf(listener))
+            .build()
+    }
+
+    /**
+     * Fires a minimal HTTP probe against the `/v1/responses` endpoint with
+     * `reasoning_effort: low` to test if the model accepts reasoning parameters.
+     */
+    override fun probeThinkingSupport(
+        baseUrl: String,
+        apiKey: String,
+        modelName: String,
+        httpClientBuilder: JdkHttpClientBuilder,
+        log: Logger,
+    ): Boolean = try {
+        val testModel = OpenAiResponsesStreamingChatModel.builder()
+            .httpClientBuilder(httpClientBuilder)
+            .baseUrl(baseUrl)
+            .apiKey(apiKey)
+            .modelName(modelName)
+            .reasoningEffort(ReasoningEffort.LOW.value)
+            .build()
+
+        val testClient = AiServices.builder(ChatClient::class.java)
+            .streamingChatModel(testModel)
+            .build()
+
+        testClient.sendStreamingMessageWithCallback(null, UserMessage("Capability probe — reply with 'ok'."))
+        log.info("Model '$modelName' supports thinking — thinking enabled")
+        true
+    } catch (e: Exception) {
+        log.info("Model '$modelName' does not support thinking: ${e.message} — thinking disabled", e)
+        false
+    }
+}


### PR DESCRIPTION
- Standardize HTTP client configuration across all OpenAI API delegates.
- Introduce dedicated API delegates for completions and responses functionality.
- Simplify settings by moving from `httpVersionConfig` to `httpVersion`.
- Apply minor UI styling adjustments in the desktop application.