### PR TITLE
feat(i18n): localize OpenAI-Compatible template taglines and help text

### DIFF
--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -944,6 +944,19 @@ provider.other.description=Connect any provider that supports the OpenAI-compati
 provider.template.apikey.required=Required
 provider.template.apikey.optional=Not required
 provider.template.get.apikey=Get API key →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=Run AI models on Cloudflare's global edge network with Workers AI.
+provider.template.cloudflare_ai.help=💡 To use Cloudflare AI:\n\n1. Find your Account ID in your Cloudflare dashboard\n2. Replace {ACCOUNT_ID} in the Base URL with it\n3. Create an API token with 'Workers AI' permission at:\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=Ultra-fast inference for open-source models — Llama, Mixtral, Gemma and more.
+provider.template.groq.help=💡 To use Groq:\n\n1. Get your free API key at: console.groq.com/keys\n2. Enter a model name, e.g. llama-3.1-8b-instant\n3. Click Next to browse all available models
+provider.template.nvidia_nim.tagline=Run optimized AI models on NVIDIA's cloud GPU infrastructure.
+provider.template.nvidia_nim.help=💡 To use NVIDIA NIM:\n\n1. Get your API key at: build.nvidia.com\n2. Enter a model name, e.g. meta/llama-3.1-8b-instruct\n3. Click Next to browse all available models
+provider.template.openrouter.tagline=Access 300+ models — GPT, Claude, Llama, Gemini, Mistral and more via one API.
+provider.template.openrouter.help=💡 To use OpenRouter:\n\n1. Get your free API key at: openrouter.ai/keys\n2. Click Next to browse 300+ available models\n3. Many models have a free tier — no credit card needed
+provider.template.together_ai.tagline=Fast, affordable inference for 100+ open-source models.
+provider.template.together_ai.help=💡 To use Together AI:\n\n1. Get your API key at: api.together.ai/settings/api-keys\n2. Click Next to browse available models,\n   e.g. meta-llama/Llama-3-8b-chat-hf
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=Add Provider

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -943,6 +943,19 @@ provider.other.description=Verbinden Sie jeden Anbieter, der die OpenAI-kompatib
 provider.template.apikey.required=Erforderlich
 provider.template.apikey.optional=Nicht erforderlich
 provider.template.get.apikey=API-Schlüssel abrufen →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=Führen Sie KI-Modelle in Cloudflares globalem Edge-Netzwerk mit Workers AI aus.
+provider.template.cloudflare_ai.help=💡 So verwenden Sie Cloudflare AI:\n\n1. Suchen Sie Ihre Account-ID in Ihrem Cloudflare-Dashboard\n2. Ersetzen Sie {ACCOUNT_ID} in der Basis-URL damit\n3. Erstellen Sie ein API-Token mit der Berechtigung „Workers AI“ unter:\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=Ultraschnelle Inferenz für Open-Source-Modelle — Llama, Mixtral, Gemma und mehr.
+provider.template.groq.help=💡 So verwenden Sie Groq:\n\n1. Holen Sie sich Ihren kostenlosen API-Schlüssel unter: console.groq.com/keys\n2. Geben Sie einen Modellnamen ein, z. B. llama-3.1-8b-instant\n3. Klicken Sie auf Weiter, um alle verfügbaren Modelle zu durchsuchen
+provider.template.nvidia_nim.tagline=Führen Sie optimierte KI-Modelle auf NVIDIAs Cloud-GPU-Infrastruktur aus.
+provider.template.nvidia_nim.help=💡 So verwenden Sie NVIDIA NIM:\n\n1. Holen Sie sich Ihren API-Schlüssel unter: build.nvidia.com\n2. Geben Sie einen Modellnamen ein, z. B. meta/llama-3.1-8b-instruct\n3. Klicken Sie auf Weiter, um alle verfügbaren Modelle zu durchsuchen
+provider.template.openrouter.tagline=Zugriff auf über 300 Modelle — GPT, Claude, Llama, Gemini, Mistral und mehr über eine API.
+provider.template.openrouter.help=💡 So verwenden Sie OpenRouter:\n\n1. Holen Sie sich Ihren kostenlosen API-Schlüssel unter: openrouter.ai/keys\n2. Klicken Sie auf Weiter, um über 300 verfügbare Modelle zu durchsuchen\n3. Viele Modelle bieten eine kostenlose Stufe — keine Kreditkarte erforderlich
+provider.template.together_ai.tagline=Schnelle, erschwingliche Inferenz für über 100 Open-Source-Modelle.
+provider.template.together_ai.help=💡 So verwenden Sie Together AI:\n\n1. Holen Sie sich Ihren API-Schlüssel unter: api.together.ai/settings/api-keys\n2. Klicken Sie auf Weiter, um verfügbare Modelle zu durchsuchen,\n   z. B. meta-llama/Llama-3-8b-chat-hf
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=Anbieter hinzufügen

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -943,6 +943,19 @@ provider.other.description=Conecte cualquier proveedor que admita la API compati
 provider.template.apikey.required=Requerido
 provider.template.apikey.optional=No requerido
 provider.template.get.apikey=Obtener clave de API →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=Ejecuta modelos de IA en la red perimetral global de Cloudflare con Workers AI.
+provider.template.cloudflare_ai.help=💡 Para usar Cloudflare AI:\n\n1. Busca tu ID de cuenta en tu panel de Cloudflare\n2. Reemplaza {ACCOUNT_ID} en la URL base con él\n3. Crea un token de API con permiso 'Workers AI' en:\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=Inferencia ultrarrápida para modelos de código abierto — Llama, Mixtral, Gemma y más.
+provider.template.groq.help=💡 Para usar Groq:\n\n1. Consigue tu clave API gratuita en: console.groq.com/keys\n2. Ingresa un nombre de modelo, p. ej. llama-3.1-8b-instant\n3. Haz clic en Siguiente para explorar todos los modelos disponibles
+provider.template.nvidia_nim.tagline=Ejecuta modelos de IA optimizados en la infraestructura de GPU en la nube de NVIDIA.
+provider.template.nvidia_nim.help=💡 Para usar NVIDIA NIM:\n\n1. Consigue tu clave API en: build.nvidia.com\n2. Ingresa un nombre de modelo, p. ej. meta/llama-3.1-8b-instruct\n3. Haz clic en Siguiente para explorar todos los modelos disponibles
+provider.template.openrouter.tagline=Accede a más de 300 modelos — GPT, Claude, Llama, Gemini, Mistral y más a través de una sola API.
+provider.template.openrouter.help=💡 Para usar OpenRouter:\n\n1. Consigue tu clave API gratuita en: openrouter.ai/keys\n2. Haz clic en Siguiente para explorar más de 300 modelos disponibles\n3. Muchos modelos tienen un nivel gratuito — no se requiere tarjeta de crédito
+provider.template.together_ai.tagline=Inferencia rápida y económica para más de 100 modelos de código abierto.
+provider.template.together_ai.help=💡 Para usar Together AI:\n\n1. Consigue tu clave API en: api.together.ai/settings/api-keys\n2. Haz clic en Siguiente para explorar los modelos disponibles,\n   p. ej. meta-llama/Llama-3-8b-chat-hf
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=Añadir proveedor

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -943,6 +943,19 @@ provider.other.description=Connectez n'importe quel fournisseur prenant en charg
 provider.template.apikey.required=Requis
 provider.template.apikey.optional=Non requis
 provider.template.get.apikey=Obtenir une clé API →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=Exécutez des modèles d'IA sur le réseau périphérique mondial de Cloudflare avec Workers AI.
+provider.template.cloudflare_ai.help=💡 Pour utiliser Cloudflare AI :\n\n1. Trouvez votre ID de compte dans votre tableau de bord Cloudflare\n2. Remplacez {ACCOUNT_ID} dans l'URL de base par celui-ci\n3. Créez un jeton API avec l'autorisation « Workers AI » sur :\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=Inférence ultra-rapide pour les modèles open source — Llama, Mixtral, Gemma et plus encore.
+provider.template.groq.help=💡 Pour utiliser Groq :\n\n1. Obtenez votre clé API gratuite sur : console.groq.com/keys\n2. Saisissez un nom de modèle, par ex. llama-3.1-8b-instant\n3. Cliquez sur Suivant pour parcourir tous les modèles disponibles
+provider.template.nvidia_nim.tagline=Exécutez des modèles d'IA optimisés sur l'infrastructure GPU cloud de NVIDIA.
+provider.template.nvidia_nim.help=💡 Pour utiliser NVIDIA NIM :\n\n1. Obtenez votre clé API sur : build.nvidia.com\n2. Saisissez un nom de modèle, par ex. meta/llama-3.1-8b-instruct\n3. Cliquez sur Suivant pour parcourir tous les modèles disponibles
+provider.template.openrouter.tagline=Accédez à plus de 300 modèles — GPT, Claude, Llama, Gemini, Mistral et plus, via une seule API.
+provider.template.openrouter.help=💡 Pour utiliser OpenRouter :\n\n1. Obtenez votre clé API gratuite sur : openrouter.ai/keys\n2. Cliquez sur Suivant pour parcourir plus de 300 modèles disponibles\n3. De nombreux modèles offrent un niveau gratuit — aucune carte de crédit requise
+provider.template.together_ai.tagline=Inférence rapide et abordable pour plus de 100 modèles open source.
+provider.template.together_ai.help=💡 Pour utiliser Together AI :\n\n1. Obtenez votre clé API sur : api.together.ai/settings/api-keys\n2. Cliquez sur Suivant pour parcourir les modèles disponibles,\n   par ex. meta-llama/Llama-3-8b-chat-hf
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=Ajouter un fournisseur

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -943,6 +943,19 @@ provider.other.description=OpenAI互換API (/v1) をサポートする任意の�
 provider.template.apikey.required=必須
 provider.template.apikey.optional=不要
 provider.template.get.apikey=APIキーを取得 →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=Workers AI を使って、Cloudflare のグローバルエッジネットワークで AI モデルを実行。
+provider.template.cloudflare_ai.help=💡 Cloudflare AI の使い方:\n\n1. Cloudflare ダッシュボードでアカウント ID を確認\n2. ベース URL 内の {ACCOUNT_ID} をそれに置き換え\n3. 「Workers AI」権限を持つ API トークンを以下で作成:\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=オープンソースモデル向けの超高速推論 — Llama、Mixtral、Gemma など。
+provider.template.groq.help=💡 Groq の使い方:\n\n1. console.groq.com/keys で無料の API キーを取得\n2. モデル名を入力（例: llama-3.1-8b-instant）\n3. 「次へ」をクリックして利用可能なモデルを閲覧
+provider.template.nvidia_nim.tagline=NVIDIA のクラウド GPU インフラで最適化された AI モデルを実行。
+provider.template.nvidia_nim.help=💡 NVIDIA NIM の使い方:\n\n1. build.nvidia.com で API キーを取得\n2. モデル名を入力（例: meta/llama-3.1-8b-instruct）\n3. 「次へ」をクリックして利用可能なモデルを閲覧
+provider.template.openrouter.tagline=300 以上のモデルにアクセス — GPT、Claude、Llama、Gemini、Mistral などを 1 つの API で。
+provider.template.openrouter.help=💡 OpenRouter の使い方:\n\n1. openrouter.ai/keys で無料の API キーを取得\n2. 「次へ」をクリックして 300 以上の利用可能なモデルを閲覧\n3. 多くのモデルに無料プランあり — クレジットカード不要
+provider.template.together_ai.tagline=100 以上のオープンソースモデル向けの高速で手頃な推論。
+provider.template.together_ai.help=💡 Together AI の使い方:\n\n1. api.together.ai/settings/api-keys で API キーを取得\n2. 「次へ」をクリックして利用可能なモデルを閲覧\n   （例: meta-llama/Llama-3-8b-chat-hf）
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=プロバイダーを追加

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -943,6 +943,19 @@ provider.other.description=OpenAI 호환 API(/v1)를 지원하는 모든 공급�
 provider.template.apikey.required=필수
 provider.template.apikey.optional=필수 아님
 provider.template.get.apikey=API 키 가져오기 →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=Workers AI로 Cloudflare의 글로벌 엣지 네트워크에서 AI 모델을 실행하세요.
+provider.template.cloudflare_ai.help=💡 Cloudflare AI 사용 방법:\n\n1. Cloudflare 대시보드에서 계정 ID를 확인하세요\n2. 기본 URL의 {ACCOUNT_ID}를 해당 값으로 바꾸세요\n3. 'Workers AI' 권한이 있는 API 토큰을 아래에서 생성하세요:\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=오픈소스 모델을 위한 초고속 추론 — Llama, Mixtral, Gemma 등.
+provider.template.groq.help=💡 Groq 사용 방법:\n\n1. console.groq.com/keys 에서 무료 API 키를 받으세요\n2. 모델 이름을 입력하세요 (예: llama-3.1-8b-instant)\n3. '다음'을 클릭하여 사용 가능한 모든 모델을 둘러보세요
+provider.template.nvidia_nim.tagline=NVIDIA의 클라우드 GPU 인프라에서 최적화된 AI 모델을 실행하세요.
+provider.template.nvidia_nim.help=💡 NVIDIA NIM 사용 방법:\n\n1. build.nvidia.com 에서 API 키를 받으세요\n2. 모델 이름을 입력하세요 (예: meta/llama-3.1-8b-instruct)\n3. '다음'을 클릭하여 사용 가능한 모든 모델을 둘러보세요
+provider.template.openrouter.tagline=300개 이상의 모델에 액세스 — GPT, Claude, Llama, Gemini, Mistral 등을 하나의 API로.
+provider.template.openrouter.help=💡 OpenRouter 사용 방법:\n\n1. openrouter.ai/keys 에서 무료 API 키를 받으세요\n2. '다음'을 클릭하여 300개 이상의 사용 가능한 모델을 둘러보세요\n3. 많은 모델이 무료 티어를 제공합니다 — 신용카드 불필요
+provider.template.together_ai.tagline=100개 이상의 오픈소스 모델을 위한 빠르고 저렴한 추론.
+provider.template.together_ai.help=💡 Together AI 사용 방법:\n\n1. api.together.ai/settings/api-keys 에서 API 키를 받으세요\n2. '다음'을 클릭하여 사용 가능한 모델을 둘러보세요\n   (예: meta-llama/Llama-3-8b-chat-hf)
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=제공업체 추가

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -943,6 +943,19 @@ provider.other.description=Conecte qualquer provedor que suporte a API compatív
 provider.template.apikey.required=Obrigatório
 provider.template.apikey.optional=Não obrigatório
 provider.template.get.apikey=Obter chave de API →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=Execute modelos de IA na rede de borda global da Cloudflare com o Workers AI.
+provider.template.cloudflare_ai.help=💡 Para usar o Cloudflare AI:\n\n1. Encontre seu Account ID no painel da Cloudflare\n2. Substitua {ACCOUNT_ID} na URL base por ele\n3. Crie um token de API com permissão 'Workers AI' em:\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=Inferência ultrarrápida para modelos de código aberto — Llama, Mixtral, Gemma e mais.
+provider.template.groq.help=💡 Para usar o Groq:\n\n1. Obtenha sua chave API gratuita em: console.groq.com/keys\n2. Digite um nome de modelo, ex.: llama-3.1-8b-instant\n3. Clique em Avançar para explorar todos os modelos disponíveis
+provider.template.nvidia_nim.tagline=Execute modelos de IA otimizados na infraestrutura de GPU em nuvem da NVIDIA.
+provider.template.nvidia_nim.help=💡 Para usar o NVIDIA NIM:\n\n1. Obtenha sua chave API em: build.nvidia.com\n2. Digite um nome de modelo, ex.: meta/llama-3.1-8b-instruct\n3. Clique em Avançar para explorar todos os modelos disponíveis
+provider.template.openrouter.tagline=Acesse mais de 300 modelos — GPT, Claude, Llama, Gemini, Mistral e mais, em uma única API.
+provider.template.openrouter.help=💡 Para usar o OpenRouter:\n\n1. Obtenha sua chave API gratuita em: openrouter.ai/keys\n2. Clique em Avançar para explorar mais de 300 modelos disponíveis\n3. Muitos modelos têm um nível gratuito — sem necessidade de cartão de crédito
+provider.template.together_ai.tagline=Inferência rápida e acessível para mais de 100 modelos de código aberto.
+provider.template.together_ai.help=💡 Para usar o Together AI:\n\n1. Obtenha sua chave API em: api.together.ai/settings/api-keys\n2. Clique em Avançar para explorar os modelos disponíveis,\n   ex.: meta-llama/Llama-3-8b-chat-hf
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=Adicionar provedor

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -943,6 +943,19 @@ provider.other.description=Kết nối bất kỳ nhà cung cấp nào hỗ tr�
 provider.template.apikey.required=Bắt buộc
 provider.template.apikey.optional=Không bắt buộc
 provider.template.get.apikey=Lấy khóa API →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=Chạy các mô hình AI trên mạng biên toàn cầu của Cloudflare với Workers AI.
+provider.template.cloudflare_ai.help=💡 Để dùng Cloudflare AI:\n\n1. Tìm Account ID trong bảng điều khiển Cloudflare của bạn\n2. Thay {ACCOUNT_ID} trong URL cơ sở bằng ID đó\n3. Tạo API token với quyền 'Workers AI' tại:\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=Suy luận siêu nhanh cho các mô hình mã nguồn mở — Llama, Mixtral, Gemma và nhiều hơn nữa.
+provider.template.groq.help=💡 Để dùng Groq:\n\n1. Lấy API key miễn phí tại: console.groq.com/keys\n2. Nhập tên mô hình, ví dụ: llama-3.1-8b-instant\n3. Nhấp Tiếp theo để duyệt tất cả mô hình có sẵn
+provider.template.nvidia_nim.tagline=Chạy các mô hình AI được tối ưu hóa trên hạ tầng GPU đám mây của NVIDIA.
+provider.template.nvidia_nim.help=💡 Để dùng NVIDIA NIM:\n\n1. Lấy API key tại: build.nvidia.com\n2. Nhập tên mô hình, ví dụ: meta/llama-3.1-8b-instruct\n3. Nhấp Tiếp theo để duyệt tất cả mô hình có sẵn
+provider.template.openrouter.tagline=Truy cập hơn 300 mô hình — GPT, Claude, Llama, Gemini, Mistral và nhiều hơn nữa qua một API.
+provider.template.openrouter.help=💡 Để dùng OpenRouter:\n\n1. Lấy API key miễn phí tại: openrouter.ai/keys\n2. Nhấp Tiếp theo để duyệt hơn 300 mô hình có sẵn\n3. Nhiều mô hình có gói miễn phí — không cần thẻ tín dụng
+provider.template.together_ai.tagline=Suy luận nhanh, giá cả phải chăng cho hơn 100 mô hình mã nguồn mở.
+provider.template.together_ai.help=💡 Để dùng Together AI:\n\n1. Lấy API key tại: api.together.ai/settings/api-keys\n2. Nhấp Tiếp theo để duyệt các mô hình có sẵn,\n   ví dụ: meta-llama/Llama-3-8b-chat-hf
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=Thêm nhà cung cấp

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -943,6 +943,19 @@ provider.other.description=连接任何支持 OpenAI 兼容 API (/v1) 的提供�
 provider.template.apikey.required=必填
 provider.template.apikey.optional=无需
 provider.template.get.apikey=获取 API 密钥 →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=使用 Workers AI 在 Cloudflare 的全球边缘网络上运行 AI 模型。
+provider.template.cloudflare_ai.help=💡 使用 Cloudflare AI：\n\n1. 在 Cloudflare 控制台中找到您的 Account ID\n2. 用它替换基础 URL 中的 {ACCOUNT_ID}\n3. 在以下位置创建具有 'Workers AI' 权限的 API 令牌：\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=为开源模型提供超快推理 — Llama、Mixtral、Gemma 等。
+provider.template.groq.help=💡 使用 Groq：\n\n1. 在 console.groq.com/keys 获取免费 API 密钥\n2. 输入模型名称，例如 llama-3.1-8b-instant\n3. 点击"下一步"浏览所有可用模型
+provider.template.nvidia_nim.tagline=在 NVIDIA 的云 GPU 基础设施上运行优化的 AI 模型。
+provider.template.nvidia_nim.help=💡 使用 NVIDIA NIM：\n\n1. 在 build.nvidia.com 获取 API 密钥\n2. 输入模型名称，例如 meta/llama-3.1-8b-instruct\n3. 点击"下一步"浏览所有可用模型
+provider.template.openrouter.tagline=通过一个 API 访问 300 多个模型 — GPT、Claude、Llama、Gemini、Mistral 等。
+provider.template.openrouter.help=💡 使用 OpenRouter：\n\n1. 在 openrouter.ai/keys 获取免费 API 密钥\n2. 点击"下一步"浏览 300 多个可用模型\n3. 许多模型提供免费额度 — 无需信用卡
+provider.template.together_ai.tagline=为 100 多个开源模型提供快速、经济的推理。
+provider.template.together_ai.help=💡 使用 Together AI：\n\n1. 在 api.together.ai/settings/api-keys 获取 API 密钥\n2. 点击"下一步"浏览可用模型，\n   例如 meta-llama/Llama-3-8b-chat-hf
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=添加服务商

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -943,6 +943,19 @@ provider.other.description=連接任何支援 OpenAI 相容 API (/v1) 的提供�
 provider.template.apikey.required=必填
 provider.template.apikey.optional=無需
 provider.template.get.apikey=獲取 API 金鑰 →
+
+# OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
+provider.template.cloudflare_ai.tagline=使用 Workers AI 在 Cloudflare 的全球邊緣網路上執行 AI 模型。
+provider.template.cloudflare_ai.help=💡 若要使用 Cloudflare AI：\n\n1. 在您的 Cloudflare 儀表板中找到您的 Account ID\n2. 用它取代基本 URL 中的 {ACCOUNT_ID}\n3. 在以下位置建立具有「Workers AI」權限的 API 權杖：\n   dash.cloudflare.com/profile/api-tokens
+provider.template.groq.tagline=為開源模型提供超快速推論 — Llama、Mixtral、Gemma 等。
+provider.template.groq.help=💡 若要使用 Groq：\n\n1. 在 console.groq.com/keys 取得免費 API 金鑰\n2. 輸入模型名稱，例如 llama-3.1-8b-instant\n3. 按一下「下一步」以瀏覽所有可用模型
+provider.template.nvidia_nim.tagline=在 NVIDIA 的雲端 GPU 基礎架構上執行最佳化的 AI 模型。
+provider.template.nvidia_nim.help=💡 若要使用 NVIDIA NIM：\n\n1. 在 build.nvidia.com 取得 API 金鑰\n2. 輸入模型名稱，例如 meta/llama-3.1-8b-instruct\n3. 按一下「下一步」以瀏覽所有可用模型
+provider.template.openrouter.tagline=透過單一 API 存取 300 多個模型 — GPT、Claude、Llama、Gemini、Mistral 等。
+provider.template.openrouter.help=💡 若要使用 OpenRouter：\n\n1. 在 openrouter.ai/keys 取得免費 API 金鑰\n2. 按一下「下一步」以瀏覽 300 多個可用模型\n3. 許多模型提供免費方案 — 無需信用卡
+provider.template.together_ai.tagline=為 100 多個開源模型提供快速、實惠的推論。
+provider.template.together_ai.help=💡 若要使用 Together AI：\n\n1. 在 api.together.ai/settings/api-keys 取得 API 金鑰\n2. 按一下「下一步」以瀏覽可用模型，\n   例如 meta-llama/Llama-3-8b-chat-hf
+
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
 provider.add.new=新增服務商

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
@@ -473,7 +473,7 @@ private fun providerPickerDetail(
                     style = AppTextStyles.sectionTitle,
                 )
                 Text(
-                    text = entry.template.tagline,
+                    text = stringResource(entry.template.taglineKey),
                     style = AppTextStyles.bodySecondary,
                 )
 
@@ -501,7 +501,7 @@ private fun providerPickerDetail(
                         verticalAlignment = Alignment.Top,
                     ) {
                         Icon(Icons.Default.Info, contentDescription = null, modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
-                        Text(text = entry.template.helpText, style = AppTextStyles.caption)
+                        Text(text = stringResource(entry.template.helpTextKey), style = AppTextStyles.caption)
                     }
                 }
             }

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleTemplate.kt
@@ -9,7 +9,7 @@ import io.askimo.core.providers.HttpVersion
 /**
  * Predefined OpenAI-compatible cloud provider templates.
  *
- * Each entry pre-fills [baseUrl] and provides onboarding copy ([tagline], [helpText])
+ * Each entry pre-fills [baseUrl] and provides onboarding copy ([taglineKey], [helpTextKey])
  * so novice users can connect popular cloud providers without knowing the API URL.
  * All templates are wired through [io.askimo.core.providers.ModelProvider.OPENAI_COMPATIBLE]
  * under the hood — no separate factory or enum value is needed.
@@ -19,16 +19,16 @@ enum class OpenAiCompatibleTemplate(
     val displayName: String,
     /** Two-letter initials shown in the circular badge in the provider picker. */
     val initials: String,
-    /** One-sentence value proposition shown in the right-column detail panel. */
-    val tagline: String,
+    /** i18n key for the one-sentence value proposition shown in the right-column detail panel. */
+    val taglineKey: String,
     /** Pre-filled base URL for this provider's OpenAI-compatible endpoint. */
     val baseUrl: String,
     /** Whether the provider requires an API key. */
     val apiKeyRequired: Boolean,
     /** URL where the user can obtain an API key. Empty string if not applicable. */
     val apiKeyUrl: String,
-    /** Multi-line setup hint shown in the CONFIG step info card. */
-    val helpText: String,
+    /** i18n key for the multi-line setup hint shown in the CONFIG step info card. */
+    val helpTextKey: String,
     /** API mode pre-selected when the user connects via this template. */
     val apiMode: OpenAiApiMode = OpenAiApiMode.CHAT_COMPLETIONS,
     /**
@@ -42,69 +42,53 @@ enum class OpenAiCompatibleTemplate(
     CLOUDFLARE_AI(
         displayName = "Cloudflare AI",
         initials = "CF",
-        tagline = "Run AI models on Cloudflare's global edge network with Workers AI.",
+        taglineKey = "provider.template.cloudflare_ai.tagline",
         baseUrl = "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1",
         apiKeyRequired = true,
         apiKeyUrl = "https://dash.cloudflare.com/profile/api-tokens",
-        helpText = "💡 To use Cloudflare AI:\n\n" +
-            "1. Find your Account ID in your Cloudflare dashboard\n" +
-            "2. Replace {ACCOUNT_ID} in the Base URL with it\n" +
-            "3. Create an API token with 'Workers AI' permission at:\n" +
-            "   dash.cloudflare.com/profile/api-tokens",
+        helpTextKey = "provider.template.cloudflare_ai.help",
     ),
 
     GROQ(
         displayName = "Groq",
         initials = "GR",
-        tagline = "Ultra-fast inference for open-source models — Llama, Mixtral, Gemma and more.",
+        taglineKey = "provider.template.groq.tagline",
         baseUrl = "https://api.groq.com/openai/v1",
         apiKeyRequired = true,
         apiKeyUrl = "https://console.groq.com/keys",
         apiMode = OpenAiApiMode.RESPONSES,
-        helpText = "💡 To use Groq:\n\n" +
-            "1. Get your free API key at: console.groq.com/keys\n" +
-            "2. Enter a model name, e.g. llama-3.1-8b-instant\n" +
-            "3. Click Next to browse all available models",
+        helpTextKey = "provider.template.groq.help",
     ),
 
     NVIDIA_NIM(
         displayName = "NVIDIA NIM",
         initials = "NV",
-        tagline = "Run optimized AI models on NVIDIA's cloud GPU infrastructure.",
+        taglineKey = "provider.template.nvidia_nim.tagline",
         baseUrl = "https://integrate.api.nvidia.com/v1",
         apiKeyRequired = true,
         apiKeyUrl = "https://build.nvidia.com/",
-        helpText = "💡 To use NVIDIA NIM:\n\n" +
-            "1. Get your API key at: build.nvidia.com\n" +
-            "2. Enter a model name, e.g. meta/llama-3.1-8b-instruct\n" +
-            "3. Click Next to browse all available models",
+        helpTextKey = "provider.template.nvidia_nim.help",
     ),
 
     OPENROUTER(
         displayName = "OpenRouter",
         initials = "OR",
-        tagline = "Access 300+ models — GPT, Claude, Llama, Gemini, Mistral and more via one API.",
+        taglineKey = "provider.template.openrouter.tagline",
         baseUrl = "https://openrouter.ai/api/v1",
         apiKeyRequired = true,
         apiKeyUrl = "https://openrouter.ai/keys",
         apiMode = OpenAiApiMode.RESPONSES,
-        helpText = "💡 To use OpenRouter:\n\n" +
-            "1. Get your free API key at: openrouter.ai/keys\n" +
-            "2. Click Next to browse 300+ available models\n" +
-            "3. Many models have a free tier — no credit card needed",
+        helpTextKey = "provider.template.openrouter.help",
     ),
 
     TOGETHER_AI(
         displayName = "Together AI",
         initials = "TA",
-        tagline = "Fast, affordable inference for 100+ open-source models.",
+        taglineKey = "provider.template.together_ai.tagline",
         baseUrl = "https://api.together.xyz/v1",
         apiKeyRequired = true,
         apiKeyUrl = "https://api.together.ai/settings/api-keys",
         httpVersion = HttpVersion.HTTP_1_1,
-        helpText = "💡 To use Together AI:\n\n" +
-            "1. Get your API key at: api.together.ai/settings/api-keys\n" +
-            "2. Click Next to browse available models,\n" +
-            "   e.g. meta-llama/Llama-3-8b-chat-hf",
+        helpTextKey = "provider.template.together_ai.help",
     ),
 }


### PR DESCRIPTION
## Summary

Extracts the hardcoded English `tagline` and `helpText` strings on `OpenAiCompatibleTemplate` into the i18n resource bundle, for all 5 predefined templates (Cloudflare AI, Groq, NVIDIA NIM, OpenRouter, Together AI).

- Renamed `tagline`/`helpText` fields to `taglineKey`/`helpTextKey`, holding resource keys (`provider.template.<name>.tagline` / `.help`) instead of literal text
- Added the new keys to `messages.properties` and translated into all 9 supported locales (de, es, fr, ja, ko, pt, vi, zh, zh_TW)
- Updated `ProviderSelectionDialog.kt` to render both via `stringResource()` instead of the raw field

Closes #607

## Test plan

- [x] `./gradlew compileKotlin` — clean across `shared`, `desktop-shared`, `desktop`
- [x] `./gradlew spotlessApply` / `./gradlew detekt` — no new findings on changed files
- [x] `./gradlew test` — no regressions in `shared`/`desktop` test suites
- [x] Manual check in the running app: opened the provider wizard on English, German, and Korean locales and confirmed tagline + help card render correctly (no raw resource keys, `{ACCOUNT_ID}` placeholder and URLs preserved) for Cloudflare AI and Groq