### PR TITLE
refactor(core): standardize user input to use Content list

### DIFF
--- a/cli/src/main/kotlin/io/askimo/cli/ChatCli.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/ChatCli.kt
@@ -4,7 +4,8 @@
  */
 package io.askimo.cli
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.Content
+import dev.langchain4j.data.message.TextContent
 import io.askimo.cli.autocompleter.CliCommandCompleter
 import io.askimo.cli.commands.CommandHandler
 import io.askimo.cli.commands.ConfigCommandHandler
@@ -213,7 +214,7 @@ fun main(args: Array<String>) {
             val prompt = buildPrompt(promptText, stdinText)
             sendNonInteractiveChatMessage(
                 appContext.getStatelessChatClient(),
-                UserMessage(prompt),
+                listOf(TextContent(prompt)),
                 TerminalBuilder.builder().system(true).build(),
             )
             return
@@ -339,9 +340,9 @@ fun main(args: Array<String>) {
 
 private fun sendNonInteractiveChatMessage(
     chatClient: ChatClient,
-    userMessage: UserMessage,
+    userMessages: List<Content>,
     terminal: Terminal,
-): String = streamChatResponse(chatClient, userMessage, terminal)
+): String = streamChatResponse(chatClient, userMessages, terminal)
 
 private fun sendChatMessage(
     prompt: String,
@@ -376,7 +377,7 @@ private fun sendChatMessage(
  */
 private fun streamChatResponse(
     chatClient: ChatClient,
-    userMessage: UserMessage,
+    userMessage: List<Content>,
     terminal: Terminal,
 ): String {
     val indicator = LoadingIndicator(terminal, "Thinking…").apply { start() }

--- a/cli/src/main/kotlin/io/askimo/cli/ChatCli.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/ChatCli.kt
@@ -385,7 +385,7 @@ private fun streamChatResponse(
     val mdSink = MarkdownStreamingSink(terminal, mdRenderer)
 
     val output = chatClient.sendStreamingMessageWithCallback(
-        userMessage = userMessage,
+        userContents = userMessage,
         onToken = { token ->
             if (firstTokenSeen.compareAndSet(false, true)) {
                 indicator.stopWithElapsed()

--- a/cli/src/main/kotlin/io/askimo/cli/recipes/RecipeExecutor.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/recipes/RecipeExecutor.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.cli.recipes
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import io.askimo.cli.LoadingIndicator
 import io.askimo.core.analytics.Analytics
 import io.askimo.core.analytics.AnalyticsEvent
@@ -89,7 +89,7 @@ class RecipeExecutor(
         val output =
             appContext
                 .getStatelessChatClient()
-                .sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
+                .sendStreamingMessageWithCallback(null, listOf(TextContent(prompt)), onToken = { _ ->
                     if (firstTokenSeen.compareAndSet(false, true)) {
                         indicator?.stopWithElapsed()
                         opts.terminal?.flush()

--- a/cli/src/test/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactoryTest.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers.anthropic
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.AppContextParams
 import io.askimo.core.context.ExecutionMode
@@ -64,7 +64,7 @@ class AnthropicModelFactoryTest {
             )
 
         val prompt = "Reply with a single short word."
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ -> }).trim()
+        val output = chatClient.sendStreamingMessageWithCallback(null, listOf(TextContent(prompt)), onToken = { _ -> }).trim()
 
         assertTrue(output.isNotBlank(), "Expected a non-empty response from Anthropic, but got blank: '$output'")
     }

--- a/cli/src/test/kotlin/io/askimo/core/providers/gemini/GeminiModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/gemini/GeminiModelFactoryTest.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers.gemini
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.providers.ChatClient
@@ -51,7 +51,7 @@ class GeminiModelFactoryTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, listOf(TextContent(prompt)), onToken = { _ ->
             print(".") // Show progress without overwhelming output
         }).trim()
 

--- a/cli/src/test/kotlin/io/askimo/core/providers/ollama/OllamaModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/ollama/OllamaModelFactoryTest.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers.ollama
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.providers.ChatClient
@@ -65,7 +65,7 @@ class OllamaModelFactoryTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, listOf(TextContent(prompt)), onToken = { _ ->
             print(".")
         }).trim()
 

--- a/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryProxyTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryProxyTest.kt
@@ -5,7 +5,7 @@
 package io.askimo.core.providers.openai
 
 import com.sun.net.httpserver.HttpServer
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import io.askimo.core.config.AppConfig
 import io.askimo.core.config.ProxyConfig
 import io.askimo.core.config.ProxyType
@@ -93,7 +93,7 @@ class OpenAiModelFactoryProxyTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt with proxy config: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, listOf(TextContent(prompt)), onToken = { _ ->
             print(".")
         }).trim()
 
@@ -292,7 +292,7 @@ class OpenAiModelFactoryProxyTest {
         // Test streaming with proxy
         var chunkCount = 0
         val output = chatClient.sendStreamingMessageWithCallback(
-            userContents = UserMessage("Count to 3."),
+            userContents = listOf(TextContent("Count to 3.")),
             onToken = { token ->
                 chunkCount++
                 print(token)

--- a/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryProxyTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryProxyTest.kt
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
-import kotlin.inc
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -293,7 +292,7 @@ class OpenAiModelFactoryProxyTest {
         // Test streaming with proxy
         var chunkCount = 0
         val output = chatClient.sendStreamingMessageWithCallback(
-            userMessage = UserMessage("Count to 3."),
+            userContents = UserMessage("Count to 3."),
             onToken = { token ->
                 chunkCount++
                 print(token)

--- a/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/openai/OpenAiModelFactoryTest.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers.openai
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.providers.ChatClient
@@ -51,7 +51,7 @@ class OpenAiModelFactoryTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, listOf(TextContent(prompt)), onToken = { _ ->
             print(".")
         }).trim()
 

--- a/cli/src/test/kotlin/io/askimo/core/providers/xai/XAiModelFactoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/xai/XAiModelFactoryTest.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers.xai
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ExecutionMode
 import io.askimo.core.providers.ChatClient
@@ -52,7 +52,7 @@ class XAiModelFactoryTest {
     private fun sendPromptAndGetResponse(chatClient: ChatClient, prompt: String): String {
         println("Sending prompt: '$prompt'")
 
-        val output = chatClient.sendStreamingMessageWithCallback(null, UserMessage(prompt), onToken = { _ ->
+        val output = chatClient.sendStreamingMessageWithCallback(null, listOf(TextContent(prompt)), onToken = { _ ->
             print(".")
         }).trim()
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
@@ -299,7 +299,7 @@ class SessionManager(
                         .getOrCreateClientForSession(sessionId)
                         .sendStreamingMessageWithCallback(
                             projectId = projectId,
-                            userMessage = promptWithContext,
+                            userContents = promptWithContext,
                             enabledServerIds = enabledServerIds,
                             onToken = { token ->
                                 streamingScope.launch {

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -6,7 +6,7 @@ package io.askimo.core.chat.service
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.Content
 import dev.langchain4j.rag.content.retriever.ContentRetriever
 import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever
 import io.askimo.core.chat.domain.ChatMessage
@@ -834,7 +834,7 @@ class ChatSessionService(
         sessionId: String,
         userMessage: ChatMessageDTO,
         willSaveUserMessage: Boolean,
-    ): UserMessage {
+    ): List<Content> {
         if (willSaveUserMessage) {
             messageRepository.addMessage(
                 ChatMessage(

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClient.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClient.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers
 
-import dev.langchain4j.model.chat.request.ChatRequestParameters
+import dev.langchain4j.data.message.Content
 import dev.langchain4j.service.TokenStream
 import dev.langchain4j.service.UserMessage
 
@@ -26,8 +26,7 @@ interface ChatClient {
      * @return A [TokenStream] that emits tokens as they are generated
      */
     fun sendMessageStreaming(
-        @UserMessage userMessage: dev.langchain4j.data.message.UserMessage,
-        chatRequestParameters: ChatRequestParameters? = null,
+        userContents: List<Content>,
     ): TokenStream
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -4,6 +4,7 @@
  */
 package io.askimo.core.providers
 
+import dev.langchain4j.data.message.Content
 import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.exception.InternalServerException
 import dev.langchain4j.exception.ModelNotFoundException
@@ -71,14 +72,14 @@ private fun Throwable.isUnsupportedSamplingError(): Boolean {
  *   - Stage 1 (Pre-request): Detect user intent to attach relevant tools
  *   - Stage 2 (Post-response): Detect follow-up opportunities from AI response
  *
- * @param userMessage The input text to send to the language model
+ * @param userContents the contents sent by user
  * @param onToken Optional callback function that is invoked for each token received from the model
  * @param onFollowUpSuggestion Optional callback for follow-up suggestions based on AI response
  * @return The complete response from the language model as a string
  */
 fun ChatClient.sendStreamingMessageWithCallback(
     projectId: String? = null,
-    userMessage: UserMessage,
+    userContents: List<Content>,
     enabledServerIds: Set<String> = emptySet(),
     onToken: (String) -> Unit = {},
     onFollowUpSuggestion: ((FollowUpSuggestion) -> Unit)? = null,
@@ -118,7 +119,7 @@ fun ChatClient.sendStreamingMessageWithCallback(
                     var capturedError: Throwable? = null
                     val streamStartTime = System.currentTimeMillis()
 
-                    sendMessageStreaming(userMessage)
+                    sendMessageStreaming(userContents)
                         .onPartialResponse { chunk ->
                             sb.append(chunk)
                             onToken(chunk)

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatModelFactory.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import dev.langchain4j.exception.InvalidRequestException
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.ChatModel
@@ -192,7 +192,7 @@ interface ChatModelFactory<T : ProviderSettings> {
             }
 
             val testClient = testClientBuilder.maxToolCallingRoundTrips(1).build()
-            testClient.sendStreamingMessageWithCallback(null, UserMessage("Capability tool probe — reply with 'ok'."))
+            testClient.sendStreamingMessageWithCallback(null, listOf(TextContent("Capability tool probe — reply with 'ok'.")))
             true
         } catch (e: Exception) {
             val errorMessage = e.message?.lowercase() ?: ""
@@ -255,7 +255,7 @@ interface ChatModelFactory<T : ProviderSettings> {
                 "Generate a tiny 64x64 PNG image of a red circle on white background. " +
                     "Return ONLY a single data URI in this exact format: data:image/png;base64,<base64>. " +
                     "Do not return SVG, markdown, code blocks, or explanations."
-            val response = testClient.sendStreamingMessageWithCallback(null, UserMessage(testPrompt)).trim()
+            val response = testClient.sendStreamingMessageWithCallback(null, listOf(TextContent(testPrompt))).trim()
 
             // Extract first data:image/*;base64,... token from raw or markdown text.
             val dataUriRegex = Regex("""data:image/([a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+)""")

--- a/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/anthropic/AnthropicModelFactory.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers.anthropic
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.anthropic.AnthropicChatModel
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel
@@ -141,7 +141,7 @@ class AnthropicModelFactory : ChatModelFactory<AnthropicSettings> {
             .streamingChatModel(testModel)
             .build()
 
-        testClient.sendStreamingMessageWithCallback(null, UserMessage("Capability probe — reply with 'ok'."))
+        testClient.sendStreamingMessageWithCallback(null, listOf(TextContent("Capability probe — reply with 'ok'.")))
         log.info("Model '${settings.defaultModel}' supports thinking — thinking enabled")
         true
     } catch (e: Exception) {

--- a/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/gemini/GeminiModelFactory.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers.gemini
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import dev.langchain4j.memory.ChatMemory
 import dev.langchain4j.model.chat.Capability
 import dev.langchain4j.model.chat.ChatModel
@@ -141,7 +141,7 @@ class GeminiModelFactory : ChatModelFactory<GeminiSettings> {
             .streamingChatModel(testModel)
             .build()
 
-        testClient.sendStreamingMessageWithCallback(null, UserMessage("Capability probe — reply with 'ok'."))
+        testClient.sendStreamingMessageWithCallback(null, listOf(TextContent("Capability probe — reply with 'ok'.")))
         log.info("Model '${settings.defaultModel}' supports thinking — thinking enabled")
         true
     } catch (e: Exception) {

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/ResponsesApiDelegate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/ResponsesApiDelegate.kt
@@ -4,7 +4,7 @@
  */
 package io.askimo.core.providers.openaicompatible
 
-import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.data.message.TextContent
 import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder
 import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.model.chat.StreamingChatModel
@@ -116,7 +116,7 @@ class ResponsesApiDelegate : OpenAiApiDelegate {
             .streamingChatModel(testModel)
             .build()
 
-        testClient.sendStreamingMessageWithCallback(null, UserMessage("Capability probe — reply with 'ok'."))
+        testClient.sendStreamingMessageWithCallback(null, listOf(TextContent("Capability probe — reply with 'ok'.")))
         log.info("Model '$modelName' supports thinking — thinking enabled")
         true
     } catch (e: Exception) {

--- a/shared/src/main/kotlin/io/askimo/core/vision/VisionExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/vision/VisionExtensions.kt
@@ -7,7 +7,6 @@ package io.askimo.core.vision
 import dev.langchain4j.data.message.Content
 import dev.langchain4j.data.message.ImageContent
 import dev.langchain4j.data.message.TextContent
-import dev.langchain4j.data.message.UserMessage
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.util.FileTypeSupport
@@ -40,10 +39,10 @@ fun ChatMessageDTO.needsVision(): Boolean = attachments.any { it.isImage() }
  * If the message contains images, creates a multi-modal message with both text and images.
  * Otherwise, creates a simple text-only message.
  */
-fun ChatMessageDTO.toUserMessage(): UserMessage {
+fun ChatMessageDTO.toUserMessage(): List<Content> {
     if (!needsVision()) {
         // Simple text message
-        return UserMessage.from(content)
+        return listOf(TextContent(content))
     }
 
     // Multi-modal message with text and images
@@ -92,10 +91,10 @@ fun ChatMessageDTO.toUserMessage(): UserMessage {
 
     // Ensure we have at least some content
     if (contents.isEmpty()) {
-        return UserMessage.from(content.ifBlank { "Please analyze this image" })
+        return listOf(TextContent(content.ifBlank { "Please analyze this image" }))
     }
 
-    return UserMessage.from(contents)
+    return contents
 }
 
 /**


### PR DESCRIPTION
- Replaces usage of `UserMessage` with `List<Content>` across core services.
- Aligns user input representation with LangChain4j's Content model.
- Updates provider interfaces and implementations accordingly.

BREAKING CHANGE: User input handling now expects `List<Content>` instead of a singular `UserMessage`. Consumers must adapt to this change.