### PR TITLE
feat(discover): Display token usage details in discover view

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/discover/DiscoverView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/discover/DiscoverView.kt
@@ -41,7 +41,10 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Token
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -49,6 +52,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -86,6 +91,9 @@ import java.awt.Desktop
 import java.net.URI
 import java.time.Instant
 import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 /**
  * Abbreviates a token count to a compact, locale-aware string.
@@ -357,10 +365,51 @@ private fun statCard(
 // ── Token Usage section ───────────────────────────────────────────────────────
 
 /**
- * Full-width section with a horizontal bar chart of the top 5 models by token
- * usage. All numbers are formatted via [LocalizationManager] so grouping separators
- * and decimal marks follow the active locale. Abbreviated counts (K/M) also use
- * [LocalizationManager.formatDouble] for locale-correct decimal separators.
+ * Represents the active time window for the token usage query.
+ *
+ * [Past24Hours], [PastWeek], and [PastMonth] use rolling windows ending at *now*.
+ * [Custom] carries explicit `from`/`to` [Instant] boundaries chosen by the user.
+ */
+private sealed class TokenUsagePeriod {
+    object Past24Hours : TokenUsagePeriod()
+    object PastWeek : TokenUsagePeriod()
+    object PastMonth : TokenUsagePeriod()
+    data class Custom(val from: Instant, val to: Instant) : TokenUsagePeriod()
+
+    /** Returns the [from, to) instant pair for this period. */
+    fun toTimeRange(): Pair<Instant, Instant> {
+        val now = Instant.now()
+        return when (this) {
+            is Past24Hours -> now.minus(24, ChronoUnit.HOURS) to now
+            is PastWeek -> now.minus(7, ChronoUnit.DAYS) to now
+            is PastMonth -> now.minus(30, ChronoUnit.DAYS) to now
+            is Custom -> from to to
+        }
+    }
+
+    val labelKey: String
+        get() = when (this) {
+            is Past24Hours -> "discover.tokens.period.24h"
+            is PastWeek -> "discover.tokens.period.week"
+            is PastMonth -> "discover.tokens.period.month"
+            is Custom -> "discover.tokens.period.custom"
+        }
+
+    val emptyKey: String
+        get() = when (this) {
+            is Past24Hours -> "discover.tokens.empty.24h"
+            is PastWeek -> "discover.tokens.empty.week"
+            is PastMonth -> "discover.tokens.empty.month"
+            is Custom -> "discover.tokens.empty.custom"
+        }
+}
+
+/**
+ * Full-width section with a time-scope selector (Past 24 h / Past 1 Week /
+ * Past 1 Month / Custom), a 3-column summary strip, and a horizontal bar chart
+ * of the top 5 models by token usage within the active period.
+ * All numbers are formatted via [LocalizationManager] so grouping separators
+ * and decimal marks follow the active locale.
  */
 @Composable
 private fun tokenUsageSection(
@@ -368,20 +417,146 @@ private fun tokenUsageSection(
     onOpenSystemDiagnostics: () -> Unit,
 ) {
     val refreshSignal by telemetry.refreshSignal.collectAsState()
+    var selectedPeriod by remember { mutableStateOf<TokenUsagePeriod>(TokenUsagePeriod.PastMonth) }
+    var showCustomDialog by remember { mutableStateOf(false) }
     var stats by remember { mutableStateOf<List<LlmInstanceStats>>(emptyList()) }
 
-    LaunchedEffect(refreshSignal) {
+    LaunchedEffect(refreshSignal, selectedPeriod) {
+        val (from, to) = selectedPeriod.toTimeRange()
         stats = withContext(Dispatchers.IO) {
-            telemetry.usageRepository.queryGroupedByInstance(telemetry.sessionStart, Instant.now())
+            telemetry.usageRepository.queryGroupedByInstance(from, to)
         }
     }
 
     val totalTokens = stats.sumOf { it.tokens }
+    val totalCalls = stats.sumOf { it.calls }
     val topModels = stats.take(5) // already ordered by tokens DESC from query
 
+    if (showCustomDialog) {
+        tokenUsageCustomDateDialog(
+            onConfirm = { from, to ->
+                selectedPeriod = TokenUsagePeriod.Custom(from, to)
+                showCustomDialog = false
+            },
+            onDismiss = { showCustomDialog = false },
+        )
+    }
+
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.medium)) {
-        tokenUsageSectionHeader(totalTokens = totalTokens, onOpenSystemDiagnostics = onOpenSystemDiagnostics)
-        tokenUsageChartCard(totalTokens = totalTokens, topModels = topModels)
+        tokenUsageSectionHeader(
+            totalTokens = totalTokens,
+            onOpenSystemDiagnostics = onOpenSystemDiagnostics,
+            selectedPeriod = selectedPeriod,
+            onSelectPreset = { selectedPeriod = it },
+            onSelectCustom = { showCustomDialog = true },
+        )
+        tokenUsageChartCard(
+            totalTokens = totalTokens,
+            totalCalls = totalCalls,
+            topModels = topModels,
+            selectedPeriod = selectedPeriod,
+        )
+    }
+}
+
+/**
+ * Two-step calendar date-range picker.
+ * Step 1 — user picks the *From* date; step 2 — user picks the *To* date.
+ * Dismissing at any point (ESC / click-outside) closes the flow entirely;
+ * the dismiss button on step 2 goes back to step 1.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun tokenUsageCustomDateDialog(
+    onConfirm: (from: Instant, to: Instant) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var step by remember { mutableStateOf(1) }
+    val fromState = rememberDatePickerState(
+        initialSelectedDateMillis = Instant.now().minus(30, ChronoUnit.DAYS).toEpochMilli(),
+    )
+    val toState = rememberDatePickerState(
+        initialSelectedDateMillis = Instant.now().toEpochMilli(),
+    )
+
+    if (step == 1) {
+        DatePickerDialog(
+            onDismissRequest = onDismiss,
+            confirmButton = {
+                TextButton(
+                    onClick = { if (fromState.selectedDateMillis != null) step = 2 },
+                    enabled = fromState.selectedDateMillis != null,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Text(stringResource("discover.tokens.custom.next"))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Text(stringResource("discover.tokens.custom.cancel"))
+                }
+            },
+        ) {
+            DatePicker(
+                state = fromState,
+                title = null,
+                headline = {
+                    Text(
+                        text = stringResource("discover.tokens.custom.from"),
+                        modifier = Modifier.padding(start = 24.dp, end = 12.dp, bottom = 12.dp),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                },
+                showModeToggle = true,
+            )
+        }
+    } else {
+        DatePickerDialog(
+            onDismissRequest = onDismiss,
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val fromMillis = fromState.selectedDateMillis
+                        val toMillis = toState.selectedDateMillis
+                        if (fromMillis != null && toMillis != null) {
+                            onConfirm(
+                                Instant.ofEpochMilli(fromMillis),
+                                // advance by one day so the full "to" day is included in the query
+                                Instant.ofEpochMilli(toMillis).plus(1, ChronoUnit.DAYS),
+                            )
+                        }
+                    },
+                    enabled = toState.selectedDateMillis != null,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Text(stringResource("discover.tokens.custom.apply"))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { step = 1 },
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Text(stringResource("discover.tokens.custom.back"))
+                }
+            },
+        ) {
+            DatePicker(
+                state = toState,
+                title = null,
+                headline = {
+                    Text(
+                        text = stringResource("discover.tokens.custom.to"),
+                        modifier = Modifier.padding(start = 24.dp, end = 12.dp, bottom = 12.dp),
+                        style = MaterialTheme.typography.labelLarge,
+                    )
+                },
+                showModeToggle = true,
+            )
+        }
     }
 }
 
@@ -389,12 +564,32 @@ private fun tokenUsageSection(
 private fun tokenUsageSectionHeader(
     totalTokens: Long,
     onOpenSystemDiagnostics: () -> Unit,
+    selectedPeriod: TokenUsagePeriod,
+    onSelectPreset: (TokenUsagePeriod) -> Unit,
+    onSelectCustom: () -> Unit,
 ) {
+    var showMenu by remember { mutableStateOf(false) }
+
+    // Build the button label: formatted date range for Custom, i18n key for presets
+    val zone = ZoneId.systemDefault()
+    val shortFmt = DateTimeFormatter.ofPattern("MMM d")
+    val periodLabel = when (selectedPeriod) {
+        is TokenUsagePeriod.Custom -> {
+            val fromStr = selectedPeriod.from.atZone(zone).format(shortFmt)
+            // "to" was advanced by +1 day for inclusive querying — display the original selected day
+            val toStr = selectedPeriod.to.minus(1, ChronoUnit.DAYS).atZone(zone).format(shortFmt)
+            "$fromStr – $toStr"
+        }
+
+        else -> stringResource(selectedPeriod.labelKey)
+    }
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        // Left: icon + title
         Row(
             horizontalArrangement = Arrangement.spacedBy(Spacing.small),
             verticalAlignment = Alignment.CenterVertically,
@@ -411,13 +606,49 @@ private fun tokenUsageSectionHeader(
             )
         }
 
-        if (totalTokens > 0) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
+        // Right: period dropdown + optional total-tokens badge
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box {
+                TextButton(
+                    onClick = { showMenu = true },
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Text("$periodLabel ▾", style = AppTextStyles.caption)
+                }
+                AppComponents.dropdownMenu(
+                    expanded = showMenu,
+                    onDismissRequest = { showMenu = false },
+                ) {
+                    listOf(
+                        TokenUsagePeriod.Past24Hours,
+                        TokenUsagePeriod.PastWeek,
+                        TokenUsagePeriod.PastMonth,
+                    ).forEach { period ->
+                        DropdownMenuItem(
+                            text = { Text(stringResource(period.labelKey), style = AppTextStyles.body) },
+                            onClick = {
+                                onSelectPreset(period)
+                                showMenu = false
+                            },
+                            modifier = Modifier.widthIn(min = 220.dp).pointerHoverIcon(PointerIcon.Hand),
+                        )
+                    }
+                    DropdownMenuItem(
+                        text = { Text(stringResource("discover.tokens.period.custom"), style = AppTextStyles.body) },
+                        onClick = {
+                            onSelectCustom()
+                            showMenu = false
+                        },
+                        modifier = Modifier.widthIn(min = 220.dp).pointerHoverIcon(PointerIcon.Hand),
+                    )
+                }
+            }
+
+            if (totalTokens > 0) {
                 Text(
-                    // abbreviateTokens uses LocalizationManager internally
                     text = stringResource("discover.tokens.total", abbreviateTokens(totalTokens)),
                     style = AppTextStyles.caption,
                 )
@@ -440,7 +671,9 @@ private fun tokenUsageSectionHeader(
 @Composable
 private fun tokenUsageChartCard(
     totalTokens: Long,
+    totalCalls: Int,
     topModels: List<LlmInstanceStats>,
+    selectedPeriod: TokenUsagePeriod,
 ) {
     Surface(
         shape = MaterialTheme.shapes.large,
@@ -453,7 +686,7 @@ private fun tokenUsageChartCard(
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = stringResource("discover.tokens.empty"),
+                    text = stringResource(selectedPeriod.emptyKey),
                     style = AppTextStyles.bodySecondary,
                 )
             }
@@ -462,6 +695,16 @@ private fun tokenUsageChartCard(
                 modifier = Modifier.fillMaxWidth().padding(Spacing.large),
                 verticalArrangement = Arrangement.spacedBy(Spacing.medium),
             ) {
+                // 3-column summary strip: Tokens used / Calls made / Top model
+                val topModelName = topModels.firstOrNull()?.let { stat ->
+                    stat.model.ifBlank {
+                        stat.instanceKey.split(":", limit = 2).getOrElse(0) { stat.instanceKey }
+                            .replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+                    }
+                }
+                tokenUsageSummaryStrip(totalTokens = totalTokens, totalCalls = totalCalls, topModel = topModelName)
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+
                 topModels.forEachIndexed { index, stat ->
                     val provider = stat.instanceKey
                         .split(":", limit = 2).getOrElse(0) { stat.instanceKey }
@@ -476,6 +719,7 @@ private fun tokenUsageChartCard(
                         tokens = stat.tokens,
                         fraction = fraction,
                         pctFormatted = pctFormatted,
+                        calls = stat.calls,
                     )
 
                     if (index < topModels.lastIndex) {
@@ -490,12 +734,49 @@ private fun tokenUsageChartCard(
 }
 
 @Composable
+private fun tokenUsageSummaryStrip(totalTokens: Long, totalCalls: Int, topModel: String?) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        summaryStatItem(
+            value = abbreviateTokens(totalTokens),
+            label = stringResource("discover.tokens.stat.tokens"),
+            modifier = Modifier.weight(1f),
+        )
+        summaryStatItem(
+            value = LocalizationManager.formatNumber(totalCalls),
+            label = stringResource("discover.tokens.stat.calls"),
+            modifier = Modifier.weight(1f),
+        )
+        summaryStatItem(
+            value = topModel ?: "—",
+            label = stringResource("discover.tokens.stat.top_model"),
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun summaryStatItem(value: String, label: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(text = value, style = AppTextStyles.itemTitle)
+        Text(text = label, style = AppTextStyles.hint, textAlign = TextAlign.Center)
+    }
+}
+
+@Composable
 private fun tokenBarRow(
     provider: String,
     model: String,
     tokens: Long,
     fraction: Float,
     pctFormatted: String,
+    calls: Int,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
@@ -551,6 +832,14 @@ private fun tokenBarRow(
             style = AppTextStyles.hint,
             textAlign = TextAlign.End,
             modifier = Modifier.width(40.dp),
+        )
+
+        // Call count
+        Text(
+            text = stringResource("discover.tokens.calls", LocalizationManager.formatNumber(calls)),
+            style = AppTextStyles.hint,
+            textAlign = TextAlign.End,
+            modifier = Modifier.width(52.dp),
         )
     }
 }

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -114,7 +114,6 @@ discover.customize.show_token_usage=Show token usage card
 discover.tokens.title=Top Models by Token Usage
 discover.tokens.total={0} total
 discover.tokens.view_details=View details
-discover.tokens.empty=No token usage recorded yet. Start chatting to see stats here.
 discover.explore.title=Explore Features
 discover.explore.mcp.title=MCP Servers
 discover.explore.mcp.desc=Extend Askimo with external tools and data sources via the Model Context Protocol.
@@ -126,11 +125,28 @@ discover.explore.skills.title=Skills
 discover.explore.skills.desc=Run AI-powered skills backed by Gemini CLI or Claude Code directly from your workspace.
 discover.recent.title=Recent Sessions
 discover.recent.empty=No recent sessions yet.
+discover.tokens.period.24h=Past 24 Hours
+discover.tokens.period.week=Past 1 Week
+discover.tokens.period.month=Past 1 Month
+discover.tokens.period.custom=Custom
+discover.tokens.stat.tokens=Tokens used
+discover.tokens.stat.calls=Calls made
+discover.tokens.stat.top_model=Top model
+discover.tokens.calls={0} calls
+discover.tokens.empty.24h=No token usage recorded in the past 24 hours
+discover.tokens.empty.week=No token usage recorded in the past week
+discover.tokens.empty.month=No token usage recorded in the past month
+discover.tokens.empty.custom=No token usage recorded in the selected period
+discover.tokens.custom.from=From
+discover.tokens.custom.to=To
+discover.tokens.custom.next=Next
+discover.tokens.custom.back=← Back
+discover.tokens.custom.apply=Apply
+discover.tokens.custom.cancel=Cancel
 
 # Sessions
 session.star=Star
 session.unstar=Unstar
-session.delete.confirm=Are you sure you want to delete this session?
 session.delete.confirm.title=Delete Chat?
 session.delete.confirm.message=Are you sure you want to delete "{0}"?\n\nThis action cannot be undone.
 session.delete.confirm.button=Delete Chat
@@ -464,7 +480,6 @@ welcome.required_note=* Required field
 user.menu.edit_profile=Edit Profile
 user.menu.settings=Settings
 user.menu.about=About Askimo
-user.menu.logout=Sign Out
 
 # User Interest Categories
 user.interest.technology=Technology
@@ -941,8 +956,6 @@ provider.type.picker.select.hint=← Select a provider from the list to see deta
 provider.connect.button=Connect
 provider.other.title=Other providers
 provider.other.description=Connect any provider that supports the OpenAI-compatible API (/v1).\n\nWorks with self-hosted models, proxies, and any cloud service that follows the OpenAI API specification. You can enter your own base URL and API key.
-provider.template.apikey.required=Required
-provider.template.apikey.optional=Not required
 provider.template.get.apikey=Get API key →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1056,17 +1069,7 @@ telemetry.export.error.message=Failed to export telemetry data: {0}
 telemetry.reset=Reset telemetry data
 telemetry.title=📊 Session Metrics
 telemetry.no.data=No metrics collected yet. Send a message to see telemetry data.
-telemetry.rag.efficiency=RAG Efficiency
-telemetry.rag.triggered={0}/{1} triggered
-telemetry.classification=Classification
-telemetry.classification.time=avg decision time
-telemetry.retrieval=Retrieval
-telemetry.retrieval.chunks={0} chunks avg
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=Total Queries
-telemetry.rag.triggered.label=Triggered
-telemetry.rag.skipped.label=Skipped
 telemetry.llm.col.instance=Instance
 telemetry.llm.col.model=Model
 telemetry.llm.col.calls=Calls
@@ -1132,7 +1135,6 @@ error.model.not_available.config_link=Configure Embedding Model
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=Something Went Wrong
 error.app.message=An unexpected error occurred: {0}
 
 # Send Message Errors

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -113,7 +113,6 @@ discover.customize.show_token_usage=Token-Nutzungskarte anzeigen
 discover.tokens.title=Top-Modelle nach Token-Nutzung
 discover.tokens.total={0} insgesamt
 discover.tokens.view_details=Details anzeigen
-discover.tokens.empty=Noch keine Token-Nutzung aufgezeichnet. Beginnen Sie zu chatten, um hier Statistiken zu sehen.
 discover.explore.title=Funktionen entdecken
 discover.explore.mcp.title=MCP-Server
 discover.explore.mcp.desc=Erweitern Sie Askimo mit externen Tools und Datenquellen über das Model Context Protocol.
@@ -125,11 +124,28 @@ discover.explore.skills.title=Fähigkeiten
 discover.explore.skills.desc=Führen Sie KI-gestützte Fähigkeiten aus, die von Gemini CLI oder Claude Code unterstützt werden, direkt aus Ihrem Arbeitsbereich.
 discover.recent.title=Letzte Sitzungen
 discover.recent.empty=Noch keine kürzlichen Sitzungen.
+discover.tokens.period.24h=Letzte 24 Stunden
+discover.tokens.period.week=Letzte 1 Woche
+discover.tokens.period.month=Letzter 1 Monat
+discover.tokens.period.custom=Benutzerdefiniert
+discover.tokens.stat.tokens=Tokens verwendet
+discover.tokens.stat.calls=Aufrufe gemacht
+discover.tokens.stat.top_model=Top-Modell
+discover.tokens.calls={0} Aufrufe
+discover.tokens.empty.24h=Keine Token-Nutzung in den letzten 24 Stunden aufgezeichnet
+discover.tokens.empty.week=Keine Token-Nutzung in der letzten Woche aufgezeichnet
+discover.tokens.empty.month=Keine Token-Nutzung im letzten Monat aufgezeichnet
+discover.tokens.empty.custom=Keine Token-Nutzung im ausgewählten Zeitraum aufgezeichnet
+discover.tokens.custom.from=Von
+discover.tokens.custom.to=Bis
+discover.tokens.custom.next=Weiter
+discover.tokens.custom.back=← Zurück
+discover.tokens.custom.apply=Anwenden
+discover.tokens.custom.cancel=Abbrechen
 
 # Sessions
 session.star=Favorisieren
 session.unstar=Favorisierung entfernen
-session.delete.confirm=Möchten Sie diese Sitzung wirklich löschen?
 session.delete.confirm.title=Chat löschen?
 session.delete.confirm.message=Sind Sie sicher, dass Sie "{0}" löschen möchten?\n\nDiese Aktion kann nicht rückgängig gemacht werden.
 session.delete.confirm.button=Chat löschen
@@ -463,7 +479,6 @@ welcome.required_note=* Pflichtfeld
 user.menu.edit_profile=Profil bearbeiten
 user.menu.settings=Einstellungen
 user.menu.about=Über Askimo
-user.menu.logout=Abmelden
 
 # User Interest Categories
 user.interest.technology=Technologie
@@ -940,8 +955,6 @@ provider.type.picker.select.hint=← Wählen Sie einen Anbieter aus der Liste, u
 provider.connect.button=Verbinden
 provider.other.title=Andere Anbieter
 provider.other.description=Verbinden Sie jeden Anbieter, der die OpenAI-kompatible API (/v1) unterstützt.\n\nFunktioniert mit selbst gehosteten Modellen, Proxys und jedem Cloud-Dienst, der der OpenAI API-Spezifikation folgt. Sie können Ihre eigene Basis-URL und Ihren API-Schlüssel eingeben.
-provider.template.apikey.required=Erforderlich
-provider.template.apikey.optional=Nicht erforderlich
 provider.template.get.apikey=API-Schlüssel abrufen →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1055,17 +1068,7 @@ telemetry.export.error.message=Telemetriedaten konnten nicht exportiert werden: 
 telemetry.reset=Telemetriedaten zurücksetzen
 telemetry.title=📊 Sitzungsmetriken
 telemetry.no.data=Noch keine Metriken erfasst. Senden Sie eine Nachricht, um Telemetriedaten zu sehen.
-telemetry.rag.efficiency=RAG-Effizienz
-telemetry.rag.triggered={0}/{1} ausgelöst
-telemetry.classification=Klassifizierung
-telemetry.classification.time=Ø Entscheidungszeit
-telemetry.retrieval=Abruf
-telemetry.retrieval.chunks=Ø {0} Chunks
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=Gesamte Anfragen
-telemetry.rag.triggered.label=Ausgelöst
-telemetry.rag.skipped.label=Übersprungen
 telemetry.llm.col.instance=Instanz
 telemetry.llm.col.model=Modell
 telemetry.llm.col.calls=Aufrufe
@@ -1131,7 +1134,6 @@ error.model.not_available.config_link=Einbettungsmodell konfigurieren
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=Etwas ist schiefgelaufen
 error.app.message=Ein unerwarteter Fehler ist aufgetreten: {0}
 
 # Send Message Errors
@@ -1450,7 +1452,7 @@ rag.status.not.indexed=Nicht indiziert
 
 # RAG Empty State
 rag.empty.title=Keine Wissensquellen
-rag.empty.description=Fügen Sie Dateien oder Ordner hinzu,\num RAG für dieses Projekt zu aktivieren
+rag.empty.description=Fügen Sie Dateien oder Ordner hinzu,\um RAG für dieses Projekt zu aktivieren
 rag.empty.button.add=Quellen hinzufügen
 
 # Plans

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -113,7 +113,6 @@ discover.customize.show_token_usage=Mostrar tarjeta de uso de tokens
 discover.tokens.title=Modelos principales por uso de tokens
 discover.tokens.total={0} en total
 discover.tokens.view_details=Ver detalles
-discover.tokens.empty=Aún no se ha registrado el uso de tokens. Empiece a chatear para ver las estadísticas aquí.
 discover.explore.title=Explorar funciones
 discover.explore.mcp.title=Servidores MCP
 discover.explore.mcp.desc=Amplía Askimo con herramientas externas y fuentes de datos mediante el Model Context Protocol.
@@ -125,11 +124,28 @@ discover.explore.skills.title=Habilidades
 discover.explore.skills.desc=Ejecuta habilidades impulsadas por IA respaldadas por Gemini CLI o Claude Code directamente desde tu espacio de trabajo.
 discover.recent.title=Sesiones recientes
 discover.recent.empty=Aún no hay sesiones recientes.
+discover.tokens.period.24h=Últimas 24 horas
+discover.tokens.period.week=Última semana
+discover.tokens.period.month=Último mes
+discover.tokens.period.custom=Personalizado
+discover.tokens.stat.tokens=Tokens usados
+discover.tokens.stat.calls=Llamadas realizadas
+discover.tokens.stat.top_model=Modelo principal
+discover.tokens.calls={0} llamadas
+discover.tokens.empty.24h=No se ha registrado uso de tokens en las últimas 24 horas
+discover.tokens.empty.week=No se ha registrado uso de tokens en la última semana
+discover.tokens.empty.month=No se ha registrado uso de tokens en el último mes
+discover.tokens.empty.custom=No se ha registrado uso de tokens en el período seleccionado
+discover.tokens.custom.from=Desde
+discover.tokens.custom.to=Hasta
+discover.tokens.custom.next=Siguiente
+discover.tokens.custom.back=← Atrás
+discover.tokens.custom.apply=Aplicar
+discover.tokens.custom.cancel=Cancelar
 
 # Sessions
 session.star=Favorito
 session.unstar=Quitar favorito
-session.delete.confirm=¿Seguro que deseas eliminar esta sesión?
 session.delete.confirm.title=¿Eliminar chat?
 session.delete.confirm.message=¿Seguro que quieres eliminar "{0}"?\n\nEsta acción no se puede deshacer.
 session.delete.confirm.button=Eliminar chat
@@ -463,7 +479,6 @@ welcome.required_note=* Campo obligatorio
 user.menu.edit_profile=Editar perfil
 user.menu.settings=Configuración
 user.menu.about=Acerca de Askimo
-user.menu.logout=Cerrar sesión
 
 # User Interest Categories
 user.interest.technology=Tecnología
@@ -940,8 +955,6 @@ provider.type.picker.select.hint=← Seleccione un proveedor de la lista para ve
 provider.connect.button=Conectar
 provider.other.title=Otros proveedores
 provider.other.description=Conecte cualquier proveedor que admita la API compatible con OpenAI (/v1).\n\nFunciona con modelos autohospedados, proxies y cualquier servicio en la nube que siga la especificación de la API de OpenAI. Puede ingresar su propia URL base y clave de API.
-provider.template.apikey.required=Requerido
-provider.template.apikey.optional=No requerido
 provider.template.get.apikey=Obtener clave de API →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1055,17 +1068,7 @@ telemetry.export.error.message=Error al exportar datos de telemetría: {0}
 telemetry.reset=Restablecer datos de telemetría
 telemetry.title=📊 Métricas de sesión
 telemetry.no.data=Aún no se han recopilado métricas. Envía un mensaje para ver los datos de telemetría.
-telemetry.rag.efficiency=Eficiencia de RAG
-telemetry.rag.triggered={0}/{1} activado
-telemetry.classification=Clasificación
-telemetry.classification.time=tiempo medio de decisión
-telemetry.retrieval=Recuperación
-telemetry.retrieval.chunks={0} fragmentos de promedio
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=Consultas Totales
-telemetry.rag.triggered.label=Activado
-telemetry.rag.skipped.label=Omitido
 telemetry.llm.col.instance=Instancia
 telemetry.llm.col.model=Modelo
 telemetry.llm.col.calls=Llamadas
@@ -1131,7 +1134,6 @@ error.model.not_available.config_link=Configurar modelo de incrustación
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=Algo salió mal
 error.app.message=Ocurrió un error inesperado: {0}
 
 # Send Message Errors

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -113,7 +113,6 @@ discover.customize.show_token_usage=Afficher la carte d'utilisation des jetons
 discover.tokens.title=Meilleurs modèles par utilisation de jetons
 discover.tokens.total={0} au total
 discover.tokens.view_details=Voir les détails
-discover.tokens.empty=Aucune utilisation de jetons enregistrée pour le moment. Commencez à discuter pour voir les statistiques ici.
 discover.explore.title=Explorer les fonctionnalités
 discover.explore.mcp.title=Serveurs MCP
 discover.explore.mcp.desc=Étendez Askimo avec des outils externes et des sources de données via le Model Context Protocol.
@@ -125,11 +124,28 @@ discover.explore.skills.title=Compétences
 discover.explore.skills.desc=Exécutez des compétences propulsées par l’IA et prises en charge par Gemini CLI ou Claude Code directement depuis votre espace de travail.
 discover.recent.title=Sessions récentes
 discover.recent.empty=Aucune session récente pour le moment.
+discover.tokens.period.24h=Dernières 24 heures
+discover.tokens.period.week=7 derniers jours
+discover.tokens.period.month=30 derniers jours
+discover.tokens.period.custom=Personnalisé
+discover.tokens.stat.tokens=Jetons utilisés
+discover.tokens.stat.calls=Appels effectués
+discover.tokens.stat.top_model=Modèle principal
+discover.tokens.calls={0} appels
+discover.tokens.empty.24h=Aucune utilisation de jetons enregistrée dans les dernières 24 heures
+discover.tokens.empty.week=Aucune utilisation de jetons enregistrée la semaine dernière
+discover.tokens.empty.month=Aucune utilisation de jetons enregistrée le mois dernier
+discover.tokens.empty.custom=Aucune utilisation de jetons enregistrée pour la période sélectionnée
+discover.tokens.custom.from=Du
+discover.tokens.custom.to=Au
+discover.tokens.custom.next=Suivant
+discover.tokens.custom.back=← Retour
+discover.tokens.custom.apply=Appliquer
+discover.tokens.custom.cancel=Annuler
 
 # Sessions
 session.star=Favori
 session.unstar=Retirer des favoris
-session.delete.confirm=Voulez-vous vraiment supprimer cette session ?
 session.delete.confirm.title=Supprimer le chat ?
 session.delete.confirm.message=Voulez-vous vraiment supprimer "{0}" ?\n\nCette action ne peut pas être annulée.
 session.delete.confirm.button=Supprimer le chat
@@ -463,7 +479,6 @@ welcome.required_note=* Champ obligatoire
 user.menu.edit_profile=Modifier le profil
 user.menu.settings=Paramètres
 user.menu.about=À propos d’Askimo
-user.menu.logout=Se déconnecter
 
 # User Interest Categories
 user.interest.technology=Technologie
@@ -940,8 +955,6 @@ provider.type.picker.select.hint=← Sélectionnez un fournisseur dans la liste 
 provider.connect.button=Connecter
 provider.other.title=Autres fournisseurs
 provider.other.description=Connectez n'importe quel fournisseur prenant en charge l'API compatible avec OpenAI (/v1).\n\nFonctionne avec des modèles auto-hébergés, des proxys et tout service cloud conforme aux spécifications de l'API OpenAI. Vous pouvez saisir votre propre URL de base et votre clé API.
-provider.template.apikey.required=Requis
-provider.template.apikey.optional=Non requis
 provider.template.get.apikey=Obtenir une clé API →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1055,17 +1068,7 @@ telemetry.export.error.message=Échec de l'exportation des données de télémé
 telemetry.reset=Réinitialiser les données de télémétrie
 telemetry.title=📊 Métriques de session
 telemetry.no.data=Aucune métrique collectée pour le moment. Envoyez un message pour voir les données de télémétrie.
-telemetry.rag.efficiency=Efficacité RAG
-telemetry.rag.triggered={0}/{1} déclenché
-telemetry.classification=Classification
-telemetry.classification.time=temps moyen de décision
-telemetry.retrieval=Récupération
-telemetry.retrieval.chunks={0} segments en moyenne
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=Requêtes Totales
-telemetry.rag.triggered.label=Déclenché
-telemetry.rag.skipped.label=Ignoré
 telemetry.llm.col.instance=Instance
 telemetry.llm.col.model=Modèle
 telemetry.llm.col.calls=Appels
@@ -1131,7 +1134,6 @@ error.model.not_available.config_link=Configurer le modèle d’embedding
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=Une erreur s’est produite
 error.app.message=Une erreur inattendue s’est produite : {0}
 
 # Send Message Errors

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -113,7 +113,6 @@ discover.customize.show_token_usage=トークン使用量カードを表示
 discover.tokens.title=トークン使用量別のトップモデル
 discover.tokens.total=合計 {0}
 discover.tokens.view_details=詳細を表示
-discover.tokens.empty=トークンの使用記録がまだありません。チャットを開始して統計を表示してください。
 discover.explore.title=機能を探索
 discover.explore.mcp.title=MCPサーバー
 discover.explore.mcp.desc=Model Context Protocolを介して、外部ツールやデータソースでAskimoを拡張します。
@@ -125,11 +124,28 @@ discover.explore.skills.title=スキル
 discover.explore.skills.desc=Gemini CLI または Claude Code によって支えられた AI 搭載のスキルを、ワークスペースから直接実行できます。
 discover.recent.title=最近のセッション
 discover.recent.empty=最近のセッションはまだありません。
+discover.tokens.period.24h=過去24時間
+discover.tokens.period.week=過去1週間
+discover.tokens.period.month=過去1ヶ月
+discover.tokens.period.custom=カスタム
+discover.tokens.stat.tokens=使用トークン
+discover.tokens.stat.calls=呼び出し回数
+discover.tokens.stat.top_model=トップモデル
+discover.tokens.calls={0} 回
+discover.tokens.empty.24h=過去24時間にトークン使用記録はありません
+discover.tokens.empty.week=過去1週間にトークン使用記録はありません
+discover.tokens.empty.month=過去1ヶ月にトークン使用記録はありません
+discover.tokens.empty.custom=選択した期間にトークン使用記録はありません
+discover.tokens.custom.from=開始日
+discover.tokens.custom.to=終了日
+discover.tokens.custom.next=次へ
+discover.tokens.custom.back=← 戻る
+discover.tokens.custom.apply=適用
+discover.tokens.custom.cancel=キャンセル
 
 # Sessions
 session.star=スターを付ける
 session.unstar=スターを外す
-session.delete.confirm=このセッションを削除しますか？
 session.delete.confirm.title=チャットを削除しますか？
 session.delete.confirm.message="{0}"を削除してもよろしいですか？\n\nこの操作は元に戻せません。
 session.delete.confirm.button=チャットを削除
@@ -463,7 +479,6 @@ welcome.required_note=* 必須項目
 user.menu.edit_profile=プロフィールを編集
 user.menu.settings=設定
 user.menu.about=Askimo について
-user.menu.logout=サインアウト
 
 # User Interest Categories
 user.interest.technology=テクノロジー
@@ -940,8 +955,6 @@ provider.type.picker.select.hint=← リストからプロバイダーを選択�
 provider.connect.button=接続
 provider.other.title=その他のプロバイダー
 provider.other.description=OpenAI互換API (/v1) をサポートする任意のプロバイダーを接続します。\n\nセルフホストモデル、プロキシ、およびOpenAI API仕様に従うあらゆるクラウドサービスで動作します。独自のベースURLとAPIキーを入力できます。
-provider.template.apikey.required=必須
-provider.template.apikey.optional=不要
 provider.template.get.apikey=APIキーを取得 →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1055,17 +1068,7 @@ telemetry.export.error.message=テレメトリデータのエクスポートに�
 telemetry.reset=テレメトリデータをリセット
 telemetry.title=📊 セッション指標
 telemetry.no.data=まだ指標が収集されていません。メッセージを送信するとテレメトリデータが表示されます。
-telemetry.rag.efficiency=RAG 効率
-telemetry.rag.triggered={0}/{1} 実行
-telemetry.classification=分類
-telemetry.classification.time=平均判定時間
-telemetry.retrieval=検索
-telemetry.retrieval.chunks=平均 {0} チャンク
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=総クエリ数
-telemetry.rag.triggered.label=トリガー済み
-telemetry.rag.skipped.label=スキップ済み
 telemetry.llm.col.instance=インスタンス
 telemetry.llm.col.model=モデル
 telemetry.llm.col.calls=呼び出し
@@ -1131,7 +1134,6 @@ error.model.not_available.config_link=埋め込みモデルを設定
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=問題が発生しました
 error.app.message=予期しないエラーが発生しました: {0}
 
 # Send Message Errors

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -113,7 +113,6 @@ discover.customize.show_token_usage=토큰 사용량 카드 표시
 discover.tokens.title=토큰 사용량 기준 상위 모델
 discover.tokens.total=총 {0}
 discover.tokens.view_details=세부 정보 보기
-discover.tokens.empty=아직 기록된 토큰 사용량이 없습니다. 채팅을 시작하여 여기에서 통계를 확인하세요.
 discover.explore.title=기능 살펴보기
 discover.explore.mcp.title=MCP 서버
 discover.explore.mcp.desc=Model Context Protocol을 통해 외부 도구와 데이터 소스로 Askimo를 확장하세요.
@@ -125,11 +124,28 @@ discover.explore.skills.title=스킬
 discover.explore.skills.desc=Gemini CLI 또는 Claude Code로 지원되는 AI 기반 스킬을 워크스페이스에서 직접 실행하세요.
 discover.recent.title=최근 세션
 discover.recent.empty=아직 최근 세션이 없습니다.
+discover.tokens.period.24h=지난 24시간
+discover.tokens.period.week=지난 1주일
+discover.tokens.period.month=지난 1개월
+discover.tokens.period.custom=사용자 지정
+discover.tokens.stat.tokens=사용된 토큰
+discover.tokens.stat.calls=호출 횟수
+discover.tokens.stat.top_model=상위 모델
+discover.tokens.calls={0}회 호출
+discover.tokens.empty.24h=지난 24시간 동안 기록된 토큰 사용량이 없습니다
+discover.tokens.empty.week=지난 1주일 동안 기록된 토큰 사용량이 없습니다
+discover.tokens.empty.month=지난 1개월 동안 기록된 토큰 사용량이 없습니다
+discover.tokens.empty.custom=선택한 기간에 기록된 토큰 사용량이 없습니다
+discover.tokens.custom.from=시작일
+discover.tokens.custom.to=종료일
+discover.tokens.custom.next=다음
+discover.tokens.custom.back=← 뒤로
+discover.tokens.custom.apply=적용
+discover.tokens.custom.cancel=취소
 
 # Sessions
 session.star=즐겨찾기
 session.unstar=즐겨찾기 해제
-session.delete.confirm=이 세션을 삭제하시겠습니까?
 session.delete.confirm.title=채팅을 삭제하시겠습니까?
 session.delete.confirm.message="{0}"을(를) 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.
 session.delete.confirm.button=채팅 삭제
@@ -463,7 +479,6 @@ welcome.required_note=* 필수 항목
 user.menu.edit_profile=프로필 편집
 user.menu.settings=설정
 user.menu.about=Askimo 정보
-user.menu.logout=로그아웃
 
 # User Interest Categories
 user.interest.technology=기술
@@ -940,8 +955,6 @@ provider.type.picker.select.hint=← 목록에서 공급자를 선택하여 세�
 provider.connect.button=연결
 provider.other.title=기타 공급자
 provider.other.description=OpenAI 호환 API(/v1)를 지원하는 모든 공급자를 연결하세요.\n\n자체 호스팅 모델, 프록시 및 OpenAI API 사양을 따르는 모든 클라우드 서비스에서 작동합니다. 고유한 기본 URL과 API 키를 입력할 수 있습니다.
-provider.template.apikey.required=필수
-provider.template.apikey.optional=필수 아님
 provider.template.get.apikey=API 키 가져오기 →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1055,17 +1068,7 @@ telemetry.export.error.message=텔레메트리 데이터 내보내기 실패: {0
 telemetry.reset=텔레메트리 데이터 재설정
 telemetry.title=📊 세션 지표
 telemetry.no.data=아직 수집된 지표가 없습니다. 메시지를 보내면 텔레메트리 데이터를 확인할 수 있습니다.
-telemetry.rag.efficiency=RAG 효율
-telemetry.rag.triggered={0}/{1} 실행됨
-telemetry.classification=분류
-telemetry.classification.time=평균 결정 시간
-telemetry.retrieval=검색
-telemetry.retrieval.chunks=평균 {0}개 청크
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=총 쿼리
-telemetry.rag.triggered.label=트리거됨
-telemetry.rag.skipped.label=건너뜀
 telemetry.llm.col.instance=인스턴스
 telemetry.llm.col.model=모델
 telemetry.llm.col.calls=호출
@@ -1131,7 +1134,6 @@ error.model.not_available.config_link=임베딩 모델 설정
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=문제가 발생했습니다
 error.app.message=예기치 않은 오류가 발생했습니다: {0}
 
 # Send Message Errors

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -113,7 +113,6 @@ discover.customize.show_token_usage=Mostrar cartão de uso de tokens
 discover.tokens.title=Principais modelos por uso de tokens
 discover.tokens.total={0} no total
 discover.tokens.view_details=Ver detalhes
-discover.tokens.empty=Nenhum uso de token registrado ainda. Comece a conversar para ver as estatísticas aqui.
 discover.explore.title=Explorar funcionalidades
 discover.explore.mcp.title=Servidores MCP
 discover.explore.mcp.desc=Expanda o Askimo com ferramentas externas e fontes de dados através do Model Context Protocol.
@@ -125,11 +124,28 @@ discover.explore.skills.title=Habilidades
 discover.explore.skills.desc=Execute habilidades com tecnologia de IA apoiadas pelo Gemini CLI ou Claude Code diretamente do seu espaço de trabalho.
 discover.recent.title=Sessões recentes
 discover.recent.empty=Ainda não há sessões recentes.
+discover.tokens.period.24h=Últimas 24 horas
+discover.tokens.period.week=Última semana
+discover.tokens.period.month=Último mês
+discover.tokens.period.custom=Personalizado
+discover.tokens.stat.tokens=Tokens usados
+discover.tokens.stat.calls=Chamadas realizadas
+discover.tokens.stat.top_model=Modelo principal
+discover.tokens.calls={0} chamadas
+discover.tokens.empty.24h=Nenhum uso de token registrado nas últimas 24 horas
+discover.tokens.empty.week=Nenhum uso de token registrado na última semana
+discover.tokens.empty.month=Nenhum uso de token registrado no último mês
+discover.tokens.empty.custom=Nenhum uso de token registrado no período selecionado
+discover.tokens.custom.from=De
+discover.tokens.custom.to=Até
+discover.tokens.custom.next=Próximo
+discover.tokens.custom.back=← Voltar
+discover.tokens.custom.apply=Aplicar
+discover.tokens.custom.cancel=Cancelar
 
 # Sessions
 session.star=Favoritar
 session.unstar=Remover favorito
-session.delete.confirm=Tem certeza de que deseja excluir esta sessão?
 session.delete.confirm.title=Excluir chat?
 session.delete.confirm.message=Tem certeza de que deseja excluir "{0}"?\n\nEsta ação não pode ser desfeita.
 session.delete.confirm.button=Excluir chat
@@ -463,7 +479,6 @@ welcome.required_note=* Campo obrigatório
 user.menu.edit_profile=Editar perfil
 user.menu.settings=Configurações
 user.menu.about=Sobre o Askimo
-user.menu.logout=Sair
 
 # User Interest Categories
 user.interest.technology=Tecnologia
@@ -940,8 +955,6 @@ provider.type.picker.select.hint=← Selecione um provedor da lista para ver det
 provider.connect.button=Conectar
 provider.other.title=Outros provedores
 provider.other.description=Conecte qualquer provedor que suporte a API compatível com OpenAI (/v1).\n\nFunciona com modelos auto-hospedados, proxies e qualquer serviço em nuvem que siga a especificação da API da OpenAI. Você pode inserir sua própria URL base e chave de API.
-provider.template.apikey.required=Obrigatório
-provider.template.apikey.optional=Não obrigatório
 provider.template.get.apikey=Obter chave de API →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1055,17 +1068,7 @@ telemetry.export.error.message=Falha ao exportar dados de telemetria: {0}
 telemetry.reset=Redefinir dados de telemetria
 telemetry.title=📊 Métricas da sessão
 telemetry.no.data=Nenhuma métrica coletada ainda. Envie uma mensagem para ver os dados de telemetria.
-telemetry.rag.efficiency=Eficiência do RAG
-telemetry.rag.triggered={0}/{1} acionado
-telemetry.classification=Classificação
-telemetry.classification.time=tempo médio de decisão
-telemetry.retrieval=Recuperação
-telemetry.retrieval.chunks={0} chunks em média
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=Consultas Totais
-telemetry.rag.triggered.label=Acionado
-telemetry.rag.skipped.label=Ignorado
 telemetry.llm.col.instance=Instância
 telemetry.llm.col.model=Modelo
 telemetry.llm.col.calls=Chamadas
@@ -1131,7 +1134,6 @@ error.model.not_available.config_link=Configurar modelo de embedding
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=Algo deu errado
 error.app.message=Ocorreu um erro inesperado: {0}
 
 # Send Message Errors

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -113,7 +113,6 @@ discover.customize.show_token_usage=Hiển thị thẻ sử dụng token
 discover.tokens.title=Các model hàng đầu theo mức sử dụng token
 discover.tokens.total=Tổng {0}
 discover.tokens.view_details=Xem chi tiết
-discover.tokens.empty=Chưa có dữ liệu sử dụng token. Hãy bắt đầu trò chuyện để xem thống kê tại đây.
 discover.explore.title=Khám phá tính năng
 discover.explore.mcp.title=Máy chủ MCP
 discover.explore.mcp.desc=Mở rộng Askimo bằng các công cụ bên ngoài và nguồn dữ liệu thông qua Model Context Protocol.
@@ -125,11 +124,28 @@ discover.explore.skills.title=Kỹ năng
 discover.explore.skills.desc=Chạy các kỹ năng được hỗ trợ bởi AI dựa trên Gemini CLI hoặc Claude Code trực tiếp từ không gian làm việc của bạn.
 discover.recent.title=Phiên gần đây
 discover.recent.empty=Chưa có phiên gần đây.
+discover.tokens.period.24h=24 giờ qua
+discover.tokens.period.week=1 tuần qua
+discover.tokens.period.month=1 tháng qua
+discover.tokens.period.custom=Tùy chỉnh
+discover.tokens.stat.tokens=Token đã dùng
+discover.tokens.stat.calls=Số lần gọi
+discover.tokens.stat.top_model=Mô hình hàng đầu
+discover.tokens.calls={0} lần gọi
+discover.tokens.empty.24h=Không có lượt sử dụng token nào trong 24 giờ qua
+discover.tokens.empty.week=Không có lượt sử dụng token nào trong tuần qua
+discover.tokens.empty.month=Không có lượt sử dụng token nào trong tháng qua
+discover.tokens.empty.custom=Không có lượt sử dụng token nào trong khoảng thời gian đã chọn
+discover.tokens.custom.from=Từ ngày
+discover.tokens.custom.to=Đến ngày
+discover.tokens.custom.next=Tiếp theo
+discover.tokens.custom.back=← Quay lại
+discover.tokens.custom.apply=Áp dụng
+discover.tokens.custom.cancel=Hủy
 
 # Sessions
 session.star=Gắn sao
 session.unstar=Bỏ gắn sao
-session.delete.confirm=Bạn có chắc chắn muốn xóa phiên này?
 session.delete.confirm.title=Xóa cuộc trò chuyện?
 session.delete.confirm.message=Bạn có chắc chắn muốn xóa "{0}" không?\n\nKhông thể hoàn tác hành động này.
 session.delete.confirm.button=Xóa cuộc trò chuyện
@@ -463,7 +479,6 @@ welcome.required_note=* Trường bắt buộc
 user.menu.edit_profile=Chỉnh sửa hồ sơ
 user.menu.settings=Cài đặt
 user.menu.about=Giới thiệu Askimo
-user.menu.logout=Đăng xuất
 
 # User Interest Categories
 user.interest.technology=Công nghệ
@@ -940,8 +955,6 @@ provider.type.picker.select.hint=← Chọn một nhà cung cấp từ danh sác
 provider.connect.button=Kết nối
 provider.other.title=Các nhà cung cấp khác
 provider.other.description=Kết nối bất kỳ nhà cung cấp nào hỗ trợ API tương thích với OpenAI (/v1).\n\nHoạt động với các mô hình tự lưu trữ, proxy và bất kỳ dịch vụ đám mây nào tuân thủ đặc tả API của OpenAI. Bạn có thể nhập URL cơ sở và khóa API của riêng mình.
-provider.template.apikey.required=Bắt buộc
-provider.template.apikey.optional=Không bắt buộc
 provider.template.get.apikey=Lấy khóa API →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1055,17 +1068,7 @@ telemetry.export.error.message=Không thể xuất dữ liệu đo lường: {0}
 telemetry.reset=Đặt lại dữ liệu telemetry
 telemetry.title=📊 Chỉ số phiên làm việc
 telemetry.no.data=Chưa thu thập chỉ số nào. Gửi tin nhắn để xem dữ liệu telemetry.
-telemetry.rag.efficiency=Hiệu quả RAG
-telemetry.rag.triggered={0}/{1} được kích hoạt
-telemetry.classification=Phân loại
-telemetry.classification.time=thời gian quyết định trung bình
-telemetry.retrieval=Truy xuất
-telemetry.retrieval.chunks=trung bình {0} đoạn
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=Tổng số truy vấn
-telemetry.rag.triggered.label=Đã kích hoạt
-telemetry.rag.skipped.label=Đã bỏ qua
 telemetry.llm.col.instance=Instance
 telemetry.llm.col.model=Mô hình
 telemetry.llm.col.calls=Cuộc gọi
@@ -1131,7 +1134,6 @@ error.model.not_available.config_link=Cấu hình mô hình embedding
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=Đã xảy ra lỗi
 error.app.message=Đã xảy ra lỗi không mong muốn: {0}
 
 # Send Message Errors

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -113,7 +113,6 @@ discover.customize.show_token_usage=显示 Token 使用情况卡片
 discover.tokens.title=按 Token 使用量排名的模型
 discover.tokens.total=共 {0}
 discover.tokens.view_details=查看详情
-discover.tokens.empty=暂无 Token 使用记录。开始聊天以在此处查看统计信息。
 discover.explore.title=探索功能
 discover.explore.mcp.title=MCP 服务器
 discover.explore.mcp.desc=通过 Model Context Protocol，使用外部工具和数据源扩展 Askimo。
@@ -125,11 +124,28 @@ discover.explore.skills.title=技能
 discover.explore.skills.desc=直接从您的工作区运行由 Gemini CLI 或 Claude Code 支持的 AI 驱动技能。
 discover.recent.title=最近会话
 discover.recent.empty=还没有最近会话。
+discover.tokens.period.24h=过去 24 小时
+discover.tokens.period.week=过去 1 周
+discover.tokens.period.month=过去 1 个月
+discover.tokens.period.custom=自定义
+discover.tokens.stat.tokens=已用 Token
+discover.tokens.stat.calls=调用次数
+discover.tokens.stat.top_model=最多用量模型
+discover.tokens.calls={0} 次调用
+discover.tokens.empty.24h=过去 24 小时内无 Token 使用记录
+discover.tokens.empty.week=过去 1 周内无 Token 使用记录
+discover.tokens.empty.month=过去 1 个月内无 Token 使用记录
+discover.tokens.empty.custom=所选时间段内无 Token 使用记录
+discover.tokens.custom.from=开始日期
+discover.tokens.custom.to=结束日期
+discover.tokens.custom.next=下一步
+discover.tokens.custom.back=← 返回
+discover.tokens.custom.apply=应用
+discover.tokens.custom.cancel=取消
 
 # Sessions
 session.star=收藏
 session.unstar=取消收藏
-session.delete.confirm=确定要删除此会话吗？
 session.delete.confirm.title=删除聊天？
 session.delete.confirm.message=确定要删除 "{0}" 吗？\n\n此操作无法撤销。
 session.delete.confirm.button=删除聊天
@@ -463,7 +479,6 @@ welcome.required_note=* 必填项
 user.menu.edit_profile=编辑资料
 user.menu.settings=设置
 user.menu.about=关于 Askimo
-user.menu.logout=退出登录
 
 # User Interest Categories
 user.interest.technology=技术
@@ -940,8 +955,6 @@ provider.type.picker.select.hint=← 从列表中选择一个提供商以查看�
 provider.connect.button=连接
 provider.other.title=其他提供商
 provider.other.description=连接任何支持 OpenAI 兼容 API (/v1) 的提供商。\n\n适用于自托管模型、代理以及任何遵循 OpenAI API 规范的云服务。您可以输入自己的基础 URL 和 API 密钥。
-provider.template.apikey.required=必填
-provider.template.apikey.optional=无需
 provider.template.get.apikey=获取 API 密钥 →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1055,17 +1068,7 @@ telemetry.export.error.message=导出遥测数据失败：{0}
 telemetry.reset=重置遥测数据
 telemetry.title=📊 会话指标
 telemetry.no.data=尚未收集任何指标。发送一条消息即可查看遥测数据。
-telemetry.rag.efficiency=RAG 效率
-telemetry.rag.triggered={0}/{1} 已触发
-telemetry.classification=分类
-telemetry.classification.time=平均决策时间
-telemetry.retrieval=检索
-telemetry.retrieval.chunks=平均 {0} 个分块
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=总查询数
-telemetry.rag.triggered.label=已触发
-telemetry.rag.skipped.label=已跳过
 telemetry.llm.col.instance=实例
 telemetry.llm.col.model=模型
 telemetry.llm.col.calls=调用
@@ -1131,7 +1134,6 @@ error.model.not_available.config_link=配置嵌入模型
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=出现错误
 error.app.message=发生了一个意外错误：{0}
 
 # Send Message Errors

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -113,7 +113,6 @@ discover.customize.show_token_usage=顯示 Token 使用量卡片
 discover.tokens.title=按 Token 使用量排名的模型
 discover.tokens.total=共 {0}
 discover.tokens.view_details=查看詳情
-discover.tokens.empty=暫無 Token 使用記錄。開始聊天以在此處查看統計資訊。
 discover.explore.title=探索功能
 discover.explore.mcp.title=MCP 伺服器
 discover.explore.mcp.desc=透過 Model Context Protocol，使用外部工具和資料來源擴充 Askimo。
@@ -125,11 +124,28 @@ discover.explore.skills.title=技能
 discover.explore.skills.desc=直接從您的工作區執行由 Gemini CLI 或 Claude Code 支援的 AI 驅動技能。
 discover.recent.title=最近工作階段
 discover.recent.empty=尚無最近工作階段。
+discover.tokens.period.24h=過去 24 小時
+discover.tokens.period.week=過去 1 週
+discover.tokens.period.month=過去 1 個月
+discover.tokens.period.custom=自訂
+discover.tokens.stat.tokens=已用 Token
+discover.tokens.stat.calls=呼叫次數
+discover.tokens.stat.top_model=最多用量模型
+discover.tokens.calls={0} 次呼叫
+discover.tokens.empty.24h=過去 24 小時內無 Token 使用記錄
+discover.tokens.empty.week=過去 1 週內無 Token 使用記錄
+discover.tokens.empty.month=過去 1 個月內無 Token 使用記錄
+discover.tokens.empty.custom=所選時間段內無 Token 使用記錄
+discover.tokens.custom.from=開始日期
+discover.tokens.custom.to=結束日期
+discover.tokens.custom.next=下一步
+discover.tokens.custom.back=← 返回
+discover.tokens.custom.apply=套用
+discover.tokens.custom.cancel=取消
 
 # Sessions
 session.star=加上星號
 session.unstar=移除星號
-session.delete.confirm=確定要刪除此對話嗎？
 session.delete.confirm.title=刪除聊天？
 session.delete.confirm.message=您確定要刪除「{0}」嗎？\n\n此操作無法復原。
 session.delete.confirm.button=刪除聊天
@@ -463,7 +479,6 @@ welcome.required_note=* 必填欄位
 user.menu.edit_profile=編輯個人資料
 user.menu.settings=設定
 user.menu.about=關於 Askimo
-user.menu.logout=登出
 
 # User Interest Categories
 user.interest.technology=科技
@@ -940,8 +955,6 @@ provider.type.picker.select.hint=← 從列表中選擇一個提供商以查看�
 provider.connect.button=連接
 provider.other.title=其他提供商
 provider.other.description=連接任何支援 OpenAI 相容 API (/v1) 的提供商。\n\n適用於自託管模型、代理以及任何遵循 OpenAI API 規範的雲端服務。您可以輸入自己的基礎 URL 和 API 金鑰。
-provider.template.apikey.required=必填
-provider.template.apikey.optional=無需
 provider.template.get.apikey=獲取 API 金鑰 →
 
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
@@ -1055,17 +1068,7 @@ telemetry.export.error.message=無法匯出遙測資料：{0}
 telemetry.reset=重設遙測資料
 telemetry.title=📊 工作階段指標
 telemetry.no.data=尚未收集任何指標。傳送訊息即可查看遙測資料。
-telemetry.rag.efficiency=RAG 效率
-telemetry.rag.triggered={0}/{1} 已觸發
-telemetry.classification=分類
-telemetry.classification.time=平均決策時間
-telemetry.retrieval=檢索
-telemetry.retrieval.chunks=平均 {0} 個區塊
-telemetry.tab.rag=RAG
 telemetry.tab.llm=LLM
-telemetry.rag.total.queries=總查詢數
-telemetry.rag.triggered.label=已觸發
-telemetry.rag.skipped.label=已跳過
 telemetry.llm.col.instance=Instance
 telemetry.llm.col.model=模型
 telemetry.llm.col.calls=呼叫
@@ -1131,7 +1134,6 @@ error.model.not_available.config_link=設定嵌入模型
 error.model.not_available.config_url=https://askimo.chat/docs/desktop/rag/#embedding-model-configuration
 
 # Generic Application Errors
-error.app.title=發生錯誤
 error.app.message=發生未預期的錯誤：{0}
 
 # Send Message Errors


### PR DESCRIPTION
- Allows users to see detailed token consumption statistics for their chats.
- Updates localization strings across multiple languages for token usage and telemetry features.

Ref: https://github.com/askimo-ai/askimo/issues/604

Screenshots:

<img width="1218" height="410" alt="Screenshot 2026-08-10 at 9 56 49 PM" src="https://github.com/user-attachments/assets/d56839ea-7c10-4a4a-b4cf-738cc6e0c5fd" />
