### PR TITLE
feat(ui): Implement real-time bookmark count synchronization

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
@@ -19,6 +19,7 @@ import io.askimo.core.chat.service.ChatSessionService
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.error.SendMessageErrorEvent
+import io.askimo.core.event.internal.BookmarkToggledEvent
 import io.askimo.core.event.internal.ChatCompletedEvent
 import io.askimo.core.event.internal.ChatInProgressEvent
 import io.askimo.core.event.internal.DiagramFixedEvent
@@ -1356,22 +1357,36 @@ class ChatViewModel(
      * Toggle the bookmark state of a message.
      * Updates the DB on a background thread and reflects the change immediately in UI state
      * for instant feedback (optimistic update).
+     *
+     * On success, emits a [BookmarkToggledEvent] so that [SessionsViewModel] can update
+     * the sidebar bookmark-count badge without a full reload.
      */
     override fun toggleBookmark(messageId: String) {
-        bookmarkedMessageIds = if (messageId in bookmarkedMessageIds) {
-            bookmarkedMessageIds - messageId
-        } else {
+        val isAdding = messageId !in bookmarkedMessageIds
+        bookmarkedMessageIds = if (isAdding) {
             bookmarkedMessageIds + messageId
+        } else {
+            bookmarkedMessageIds - messageId
         }
 
         scope.launch {
             try {
-                withContext(Dispatchers.IO) {
+                val nowBookmarked = withContext(Dispatchers.IO) {
                     chatSessionService.toggleBookmark(messageId)
+                }
+                // Notify the sidebar so the bookmark-count badge updates immediately
+                val sessionId = currentSessionId.value
+                if (sessionId != null) {
+                    EventBus.post(
+                        BookmarkToggledEvent(
+                            sessionId = sessionId,
+                            delta = if (nowBookmarked) +1 else -1,
+                        ),
+                    )
                 }
             } catch (e: Exception) {
                 // Roll back the optimistic update on failure
-                bookmarkedMessageIds = if (messageId in bookmarkedMessageIds) {
+                bookmarkedMessageIds = if (isAdding) {
                     bookmarkedMessageIds - messageId
                 } else {
                     bookmarkedMessageIds + messageId

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsViewModel.kt
@@ -12,6 +12,7 @@ import io.askimo.core.chat.service.ChatSessionExporterService
 import io.askimo.core.chat.service.ChatSessionService
 import io.askimo.core.db.Pageable
 import io.askimo.core.event.EventBus
+import io.askimo.core.event.internal.BookmarkToggledEvent
 import io.askimo.core.event.internal.SessionCreatedEvent
 import io.askimo.core.event.internal.SessionTitleUpdatedEvent
 import io.askimo.core.event.internal.SessionsRefreshEvent
@@ -180,6 +181,28 @@ class SessionsViewModel(
                     log.debug("Sessions refresh requested: ${event.reason ?: "no reason specified"}")
                     loadRecentSessions()
                     loadStarredSessions()
+                }
+        }
+
+        // Listen for bookmark toggles — update the sidebar badge count in-place,
+        // no DB round-trip needed.
+        scope.launch {
+            EventBus.internalEvents
+                .filterIsInstance<BookmarkToggledEvent>()
+                .collect { event ->
+                    val current = bookmarkCountsBySession[event.sessionId] ?: 0
+                    val updated = (current + event.delta).coerceAtLeast(0)
+                    bookmarkCountsBySession = if (updated == 0) {
+                        bookmarkCountsBySession - event.sessionId
+                    } else {
+                        bookmarkCountsBySession + (event.sessionId to updated)
+                    }
+                    log.debug(
+                        "Bookmark badge updated for session {}: {} → {}",
+                        event.sessionId,
+                        current,
+                        updated,
+                    )
                 }
         }
     }

--- a/shared/src/main/kotlin/io/askimo/core/event/internal/BookmarkToggledEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/event/internal/BookmarkToggledEvent.kt
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.event.internal
+
+import io.askimo.core.event.Event
+import io.askimo.core.event.EventSource
+import io.askimo.core.event.EventType
+import java.time.Instant
+
+/**
+ * Emitted after a message bookmark is successfully toggled.
+ *
+ * Consumed by [SessionsViewModel] to keep the sidebar bookmark-count badge
+ * in sync without a full reload.
+ *
+ * @param sessionId The session that owns the bookmarked message.
+ * @param delta     +1 when a bookmark was added, -1 when it was removed.
+ */
+data class BookmarkToggledEvent(
+    val sessionId: String,
+    val delta: Int,
+    override val timestamp: Instant = Instant.now(),
+    override val source: EventSource = EventSource.SYSTEM,
+) : Event {
+    override val type = EventType.INTERNAL
+    override fun getDetails() = "Bookmark toggled in session $sessionId (delta=$delta)"
+}


### PR DESCRIPTION
- Enables immediate updating of sidebar bookmark badges when bookmarks are toggled within a chat session.
- Uses `BookmarkToggledEvent` to communicate state changes between the chat and session view models.

Ref: https://github.com/askimo-ai/askimo/issues/613

@haiphucnguyen I use the eventbus solution existing in the askimo codebase instead of instruction in the ticket. Please let me know if it is okay.