### PR TITLE
feat(providers): support template-specific model retrieval

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/io.askimo/cli/reachability-metadata.json
+++ b/cli/src/main/resources/META-INF/native-image/io.askimo/cli/reachability-metadata.json
@@ -1890,6 +1890,8 @@
   }, {
     "type": "dev.langchain4j.model.chat.ChatModel"
   }, {
+    "type": "dev.langchain4j.model.chat.request.ChatRequest"
+  }, {
     "type": "dev.langchain4j.model.embedding.EmbeddingModel"
   }, {
     "type": "dev.langchain4j.model.googleai.GeminiContent",
@@ -3557,6 +3559,9 @@
       "name": "<init>",
       "parameterTypes": [ ]
     }, {
+      "name": "DEFAULT_YAML snake_case fields are correctly deserialized",
+      "parameterTypes": [ ]
+    }, {
       "name": "DEFAULT_YAML snake_case fields are correctly deserialized for all providers",
       "parameterTypes": [ ]
     }, {
@@ -3576,6 +3581,9 @@
       "parameterTypes": [ ]
     }, {
       "name": "YAML round-trip preserves snake_case field values after updateField",
+      "parameterTypes": [ ]
+    }, {
+      "name": "YAML round-trip preserves timeout values after updateField",
       "parameterTypes": [ ]
     }, {
       "name": "saveContext overwrites a previously saved context",
@@ -3829,6 +3837,9 @@
     "type": "io.askimo.core.config.ModelsConfig",
     "allDeclaredFields": true,
     "methods": [ {
+      "name": "<init>",
+      "parameterTypes": [ "int", "io.askimo.core.config.ModelTimeoutsConfig" ]
+    }, {
       "name": "<init>",
       "parameterTypes": [ "int", "io.askimo.core.config.ModelTimeoutsConfig", "io.askimo.core.config.ProviderModelConfig", "io.askimo.core.config.ProviderModelConfig", "io.askimo.core.config.ProviderModelConfig", "io.askimo.core.config.ProviderModelConfig", "io.askimo.core.config.ProviderModelConfig", "io.askimo.core.config.ProviderModelConfig", "io.askimo.core.config.ProviderModelConfig", "io.askimo.core.config.ProviderModelConfig", "io.askimo.core.config.ProviderModelConfig", "io.askimo.core.config.ProviderModelConfig" ]
     }, {
@@ -5270,6 +5281,8 @@
   }, {
     "type": "io.askimo.core.providers.HasBaseUrl"
   }, {
+    "type": "io.askimo.core.providers.HttpVersion"
+  }, {
     "type": "io.askimo.core.providers.ModelFilterUtilsTest",
     "methods": [ {
       "name": "<init>",
@@ -5616,6 +5629,9 @@
     "type": "io.askimo.core.providers.ProviderSettings",
     "methods": [ {
       "name": "getDefaultModel",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getHttpVersion",
       "parameterTypes": [ ]
     } ]
   }, {
@@ -6569,6 +6585,84 @@
       "parameterTypes": [ ]
     }, {
       "name": "save persists file and findByPath retrieves the skill",
+      "parameterTypes": [ ]
+    } ]
+  }, {
+    "type": "io.askimo.core.telemetry.LlmUsageRepositoryTest",
+    "methods": [ {
+      "name": "<init>",
+      "parameterTypes": [ ]
+    }, {
+      "name": "setup",
+      "parameterTypes": [ ]
+    }, {
+      "name": "tearDown",
+      "parameterTypes": [ ]
+    } ]
+  }, {
+    "type": "io.askimo.core.telemetry.LlmUsageRepositoryTest$Insert",
+    "methods": [ {
+      "name": "<init>",
+      "parameterTypes": [ "io.askimo.core.telemetry.LlmUsageRepositoryTest" ]
+    }, {
+      "name": "insert does not throw for a successful call",
+      "parameterTypes": [ ]
+    }, {
+      "name": "insert does not throw for an error call",
+      "parameterTypes": [ ]
+    }, {
+      "name": "inserted record appears in queryGroupedByInstance",
+      "parameterTypes": [ ]
+    } ]
+  }, {
+    "type": "io.askimo.core.telemetry.LlmUsageRepositoryTest$QueryGroupedByInstance",
+    "methods": [ {
+      "name": "<init>",
+      "parameterTypes": [ "io.askimo.core.telemetry.LlmUsageRepositoryTest" ]
+    }, {
+      "name": "avgDurationMs is the arithmetic mean of all calls in a group",
+      "parameterTypes": [ ]
+    }, {
+      "name": "calls for the same provider and model are merged into one group",
+      "parameterTypes": [ ]
+    }, {
+      "name": "different models under the same provider form separate groups",
+      "parameterTypes": [ ]
+    }, {
+      "name": "errors counts only the rows with isError true",
+      "parameterTypes": [ ]
+    }, {
+      "name": "from is inclusive and to is exclusive",
+      "parameterTypes": [ ]
+    }, {
+      "name": "instanceId takes precedence over provider for grouping key",
+      "parameterTypes": [ ]
+    }, {
+      "name": "instanceKey is the instanceId when present",
+      "parameterTypes": [ ]
+    }, {
+      "name": "instanceKey is the provider when instanceId is null",
+      "parameterTypes": [ ]
+    }, {
+      "name": "provider and model fields are preserved on each stats row",
+      "parameterTypes": [ ]
+    }, {
+      "name": "records before the from boundary are excluded",
+      "parameterTypes": [ ]
+    }, {
+      "name": "records inside the time window are included",
+      "parameterTypes": [ ]
+    }, {
+      "name": "results are ordered by total tokens descending",
+      "parameterTypes": [ ]
+    }, {
+      "name": "returns empty list when no records exist",
+      "parameterTypes": [ ]
+    }, {
+      "name": "tokens are summed across all calls in a group",
+      "parameterTypes": [ ]
+    }, {
+      "name": "zero errors when all calls succeed",
       "parameterTypes": [ ]
     } ]
   }, {
@@ -8667,6 +8761,16 @@
     "type": "org.mockito.internal.creation.bytebuddy.codegen.ChatClient$MockitoMock$a577cr1op99200N$auxiliary$4cscpe1S"
   }, {
     "type": "org.mockito.internal.creation.bytebuddy.codegen.ChatClient$MockitoMock$a577cr1op99200N$auxiliary$7m9oaq0S"
+  }, {
+    "type": "org.mockito.internal.creation.bytebuddy.codegen.ChatModel$MockitoMock$u6jvu43op99200N",
+    "methods": [ {
+      "name": "<init>",
+      "parameterTypes": [ ]
+    } ]
+  }, {
+    "type": "org.mockito.internal.creation.bytebuddy.codegen.ChatModel$MockitoMock$u6jvu43op99200N$auxiliary$4cscpe1S"
+  }, {
+    "type": "org.mockito.internal.creation.bytebuddy.codegen.ChatModel$MockitoMock$u6jvu43op99200N$auxiliary$7m9oaq0S"
   }, {
     "type": "org.mockito.internal.creation.bytebuddy.codegen.ParsedLine$MockitoMock$mharrt1op99200N",
     "methods": [ {

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderWizardViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderWizardViewModel.kt
@@ -349,6 +349,7 @@ class ProviderWizardViewModel(
             apiMode = template.apiMode,
             httpVersion = template.httpVersion,
             isTemplate = true,
+            templateName = template.name,
         )
         templateBaseSettings = prefilled
         providerConfigFields = prefilled.getConfigFields(LocalizationManager.messageResolver)
@@ -581,7 +582,7 @@ class ProviderWizardViewModel(
 
                     @Suppress("UNCHECKED_CAST")
                     val models = (factory as ChatModelFactory<ProviderSettings>)
-                        .availableModels((editingInstance?.settings ?: factory.defaultSettings()).applyConfigFields(providerFieldValues))
+                        .availableModels((editingInstance?.settings ?: templateBaseSettings ?: factory.defaultSettings()).applyConfigFields(providerFieldValues))
 
                     isLoadingModels = false
                     if (models.isNotEmpty()) {
@@ -641,7 +642,7 @@ class ProviderWizardViewModel(
 
                 @Suppress("UNCHECKED_CAST")
                 val models = (factory as ChatModelFactory<ProviderSettings>)
-                    .availableModels((editingInstance?.settings ?: factory.defaultSettings()).applyConfigFields(providerFieldValues))
+                    .availableModels((editingInstance?.settings ?: templateBaseSettings ?: factory.defaultSettings()).applyConfigFields(providerFieldValues))
 
                 isLoadingModels = false
                 if (models.isEmpty()) {

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/ProviderModelPanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/ProviderModelPanel.kt
@@ -243,7 +243,7 @@ internal fun providerModelPanel(
                         Icons.Default.Add,
                         contentDescription = stringResource("provider.add.new"),
                         modifier = Modifier.size(16.dp),
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Text(
                         text = stringResource("provider.add.new"),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.4.15
+projectVersion=1.4.16
 jvmVersion=25
 
 # About information

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleModelFactory.kt
@@ -8,9 +8,12 @@ import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.model.chat.StreamingChatModel
 import dev.langchain4j.model.embedding.EmbeddingModel
 import dev.langchain4j.model.openai.OpenAiEmbeddingModel.OpenAiEmbeddingModelBuilder
+import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
+import io.askimo.core.providers.ProviderModelUtils
 import io.askimo.core.util.ApiKeyUtils.safeApiKey
 import io.askimo.core.util.createJdkHttpClientBuilder
+import io.askimo.core.util.toJdkVersion
 
 /**
  * The registered factory for [ModelProvider.OPENAI_COMPATIBLE].
@@ -35,6 +38,29 @@ class OpenAiCompatibleModelFactory : OpenAiCompatibleChatModelFactory<OpenAiComp
     override fun getProvider(): ModelProvider = ModelProvider.OPENAI_COMPATIBLE
     override fun defaultSettings(): OpenAiCompatibleSettings = OpenAiCompatibleSettings()
     override fun resolveApiKey(settings: OpenAiCompatibleSettings): String = safeApiKey(settings.apiKey.ifBlank { "not-needed" })
+
+    override fun availableModels(settings: OpenAiCompatibleSettings): List<ModelDTO> {
+        if (!canFetchModels(settings)) return emptyList()
+        val template = settings.templateName
+            ?.let { name -> OpenAiCompatibleTemplate.entries.find { it.name == name } }
+        val modelIds = if (template?.modelFetcher != null) {
+            template.modelFetcher(
+                resolveApiKey(settings),
+                settings.baseUrl,
+                settings.httpVersion.toJdkVersion(),
+            )
+        } else {
+            ProviderModelUtils.fetchModels(
+                apiKey = resolveApiKey(settings),
+                url = "${settings.baseUrl.trimEnd('/')}/models",
+                providerName = getProvider(),
+                httpVersion = settings.httpVersion.toJdkVersion(),
+            )
+        }
+        return modelIds.map { ModelDTO.of(getProvider(), it) }
+    }
+
+    override fun canFetchModels(settings: OpenAiCompatibleSettings): Boolean = settings.baseUrl.isNotBlank() && settings.apiKey.isNotBlank()
 
     override fun probeThinkingSupport(settings: OpenAiCompatibleSettings): Boolean = delegate(settings).probeThinkingSupport(
         baseUrl = settings.baseUrl,

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleSettings.kt
@@ -44,6 +44,13 @@ data class OpenAiCompatibleSettings(
      * Existing serialised configs without this field deserialise to `false` safely.
      */
     val isTemplate: Boolean = false,
+    /**
+     * The [OpenAiCompatibleTemplate.name] of the template this instance was created from,
+     * or `null` for manually configured instances.
+     * Used to look up template-specific behaviour such as a custom model-fetching strategy.
+     * Existing serialised configs without this field deserialise to `null` safely.
+     */
+    val templateName: String? = null,
 ) : ProviderSettings,
     HasApiKey,
     HasBaseUrl {
@@ -190,7 +197,7 @@ data class OpenAiCompatibleSettings(
                 ?.let { runCatching { HttpVersion.valueOf(it) }.getOrNull() }
                 ?: httpVersion
         }
-        return copy(baseUrl = newBaseUrl, apiKey = newApiKey, apiMode = newApiMode, httpVersion = newHttpVersion)
+        return copy(baseUrl = newBaseUrl, apiKey = newApiKey, apiMode = newApiMode, httpVersion = newHttpVersion, isTemplate = isTemplate, templateName = templateName)
     }
 
     override fun deepCopy(): ProviderSettings = copy()

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleTemplate.kt
@@ -5,6 +5,13 @@
 package io.askimo.core.providers.openaicompatible
 
 import io.askimo.core.providers.HttpVersion
+import io.askimo.core.util.appJson
+import io.askimo.core.util.httpGet
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.http.HttpClient
 
 /**
  * Predefined OpenAI-compatible cloud provider templates.
@@ -38,6 +45,14 @@ enum class OpenAiCompatibleTemplate(
      * providers known to have HTTP/2 issues.
      */
     val httpVersion: HttpVersion = HttpVersion.HTTP_2,
+    /**
+     * Custom model-fetching strategy for providers whose model-list endpoint differs from the
+     * standard OpenAI `GET /models`. If `null`, the default `{baseUrl}/models` fetch is used.
+     *
+     * Receives the resolved API key, the configured base URL, and the HTTP version;
+     * returns a sorted, deduplicated list of model ID strings.
+     */
+    val modelFetcher: ((apiKey: String, baseUrl: String, httpVersion: HttpClient.Version) -> List<String>)? = null,
 ) {
     CLOUDFLARE_AI(
         displayName = "Cloudflare AI",
@@ -47,6 +62,20 @@ enum class OpenAiCompatibleTemplate(
         apiKeyRequired = true,
         apiKeyUrl = "https://dash.cloudflare.com/profile/api-tokens",
         helpTextKey = "provider.template.cloudflare_ai.help",
+        modelFetcher = { apiKey, baseUrl, httpVersion ->
+            // Cloudflare AI does not implement the standard GET /models endpoint.
+            // Derive the models/search URL from the configured base URL so the user's
+            // actual account ID is honoured.
+            // e.g. https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1
+            //   →  https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/models/search
+            val searchUrl = baseUrl.trimEnd('/').removeSuffix("/v1") + "/models/search"
+            val (_, body) = httpGet(searchUrl, headers = mapOf("Authorization" to "Bearer $apiKey"), httpVersion = httpVersion)
+            val json = appJson.parseToJsonElement(body)
+            json.jsonObject["result"]?.jsonArray.orEmpty()
+                .mapNotNull { it.jsonObject["name"]?.jsonPrimitive?.contentOrNull }
+                .distinct()
+                .sorted()
+        },
     ),
 
     GROQ(


### PR DESCRIPTION
- Add templateName to OpenAiCompatibleSettings to identify the source template
- Enable OpenAiCompatibleTemplate to implement custom model discovery (e.g., Cloudflare)
- Update OpenAiCompatibleModelFactory to support template-driven fetching
- Integrate template tracking into the desktop provider wizard
- Update CLI reachability metadata for native image compatibility