### PR TITLE
feat(tool-approval): add user approval flow for unsafe tool execution

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatState.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatState.kt
@@ -6,6 +6,7 @@ package io.askimo.ui.chat
 
 import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.dto.ChatMessageDTO
+import io.askimo.core.chat.dto.ToolApprovalRequest
 import io.askimo.core.chat.dto.ToolCallInfo
 
 /**
@@ -44,6 +45,10 @@ data class ChatState(
 
     // Tool call state — ephemeral, populated only during active streaming
     val activeToolCalls: List<ToolCallInfo> = emptyList(),
+
+    // Pending tool approval — non-null when the AI wants to run a tool that requires user consent.
+    // Cleared automatically once the user approves or denies.
+    val pendingToolApproval: ToolApprovalRequest? = null,
 
     // Thinking/reasoning content — ephemeral, streamed from models that expose reasoning.
     // Populated during active streaming; cleared when a new message starts.

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -97,6 +97,8 @@ import io.askimo.core.logging.currentFileLogger
 import io.askimo.core.rag.ProjectIndexer
 import io.askimo.core.util.TimeUtil.formatDisplay
 import io.askimo.core.util.formatFileSize
+import io.askimo.ui.common.components.primaryButton
+import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.KeyMapManager.AppShortcut
@@ -177,6 +179,7 @@ fun chatView(
     val activeThinkingContent = state.activeThinkingContent
     val bookmarkedMessageIds = state.bookmarkedMessageIds
     val pendingScrollToMessageId = state.pendingScrollToMessageId
+    val pendingToolApproval = state.pendingToolApproval
 
     // Internal state management for ChatView
     val scope = rememberCoroutineScope()
@@ -1148,6 +1151,45 @@ fun chatView(
                         adapter = rememberScrollbarAdapter(messagesScrollState),
                         style = AppComponents.scrollbarStyle(),
                     )
+                }
+
+                // Tool approval banner — inline between messages and input field
+                if (pendingToolApproval != null) {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Card(
+                            modifier = Modifier
+                                .widthIn(max = ThemePreferences.CONTENT_MAX_WIDTH)
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 4.dp),
+                            colors = AppComponents.bannerCardColors(),
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(Spacing.medium),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = stringResource("chat.tool.approval.prompt", pendingToolApproval.toolName),
+                                    style = AppTextStyles.caption,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.small)) {
+                                    secondaryButton(onClick = pendingToolApproval.deny) {
+                                        Text(stringResource("chat.tool.approval.deny"))
+                                    }
+                                    primaryButton(onClick = pendingToolApproval.approve) {
+                                        Text(stringResource("chat.tool.approval.approve"))
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 // Input area

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
@@ -12,6 +12,7 @@ import io.askimo.core.analytics.AnalyticsEvent
 import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
+import io.askimo.core.chat.dto.ToolApprovalRequest
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDTO
 import io.askimo.core.chat.repository.PaginationDirection
@@ -115,6 +116,9 @@ class ChatViewModel(
     var activeToolCalls by mutableStateOf<List<ToolCallInfo>>(emptyList())
         private set
 
+    var pendingToolApproval by mutableStateOf<ToolApprovalRequest?>(null)
+        private set
+
     var activeThinkingContent by mutableStateOf("")
         private set
 
@@ -144,6 +148,7 @@ class ChatViewModel(
             sessionTitle = sessionTitle ?: "",
             project = project,
             activeToolCalls = activeToolCalls,
+            pendingToolApproval = pendingToolApproval,
             activeThinkingContent = activeThinkingContent,
             bookmarkedMessageIds = bookmarkedMessageIds,
             pendingScrollToMessageId = pendingScrollToMessageId,
@@ -278,6 +283,51 @@ class ChatViewModel(
     fun getSpinnerFrame(): Char = spinnerFrames[thinkingFrameIndex % spinnerFrames.size]
 
     /**
+     * Inserts [message] at [retryInsertPosition] (retry mode) or replaces a trailing
+     * AI message / appends (normal mode). Use for first-time placement of a new bubble.
+     */
+    private fun insertAiMessage(message: ChatMessageDTO) {
+        messages = if (retryInsertPosition != null) {
+            messages.toMutableList().apply { add(retryInsertPosition!!, message) }
+        } else {
+            val last = messages.lastOrNull()
+            if (last != null && !last.isUser) messages.dropLast(1) + message else messages + message
+        }
+    }
+
+    /**
+     * Updates an already-present streaming bubble (id=null) in-place, or falls back to
+     * [insertAiMessage] if the bubble does not exist yet. Use inside `chunks.collect`.
+     */
+    private fun upsertStreamingAiMessage(message: ChatMessageDTO) {
+        messages = if (retryInsertPosition != null) {
+            val list = messages.toMutableList()
+            val pos = retryInsertPosition!!
+            if (pos < list.size && !list[pos].isUser && list[pos].id == null) {
+                list[pos] = message
+                list
+            } else {
+                list.apply { add(pos, message) }
+            }
+        } else {
+            val last = messages.lastOrNull()
+            if (last != null && !last.isUser) messages.dropLast(1) + message else messages + message
+        }
+    }
+
+    /**
+     * Ensures a placeholder AI message (id=null) exists in [messages].
+     * If one already exists this is a no-op. Otherwise inserts an empty bubble via
+     * [insertAiMessage] and stops the thinking indicator.
+     */
+    private fun ensurePlaceholderAiMessage() {
+        if (messages.any { !it.isUser && it.id == null }) return
+        isThinking = false
+        stopThinkingTimer()
+        insertAiMessage(ChatMessageDTO(content = "", isUser = false, id = null, timestamp = null))
+    }
+
+    /**
      * Subscribe to a SPECIFIC thread by sessionId.
      * This ensures we only get chunks from THIS specific question, not old ones.
      */
@@ -304,18 +354,7 @@ class ChatViewModel(
                 )
 
                 // Insert at retry position or append to end
-                messages = if (retryInsertPosition != null) {
-                    messages.toMutableList().apply {
-                        add(retryInsertPosition!!, newAiMessage)
-                    }
-                } else {
-                    val lastMessage = messages.lastOrNull()
-                    if (lastMessage != null && !lastMessage.isUser) {
-                        messages.dropLast(1) + newAiMessage
-                    } else {
-                        messages + newAiMessage
-                    }
-                }
+                insertAiMessage(newAiMessage)
             }
 
             // Create a single job for this SPECIFIC threadId's subscription
@@ -341,28 +380,7 @@ class ChatViewModel(
                         )
 
                         // Insert at retry position or update/append at end
-                        messages = if (retryInsertPosition != null) {
-                            // Check if message already exists at retry position
-                            val messagesList = messages.toMutableList()
-                            if (retryInsertPosition!! < messagesList.size &&
-                                !messagesList[retryInsertPosition!!].isUser &&
-                                messagesList[retryInsertPosition!!].id == null
-                            ) {
-                                // Replace existing streaming message
-                                messagesList[retryInsertPosition!!] = newAiMessage
-                                messagesList
-                            } else {
-                                // Insert new message
-                                messagesList.apply { add(retryInsertPosition!!, newAiMessage) }
-                            }
-                        } else {
-                            val lastMessage = messages.lastOrNull()
-                            if (lastMessage != null && !lastMessage.isUser) {
-                                messages.dropLast(1) + newAiMessage
-                            } else {
-                                messages + newAiMessage
-                            }
-                        }
+                        upsertStreamingAiMessage(newAiMessage)
                     }
                 }
             }
@@ -376,28 +394,8 @@ class ChatViewModel(
             scope.launch {
                 activeThread.toolCalls.collect { calls ->
                     if (currentSessionId.value == sessionId) {
-                        activeToolCalls = calls
-                        // No streaming bubble yet — create placeholder so tool chips are visible
-                        if (calls.isNotEmpty() && messages.none { !it.isUser && it.id == null }) {
-                            isThinking = false
-                            stopThinkingTimer()
-                            val placeholder = ChatMessageDTO(
-                                content = "",
-                                isUser = false,
-                                id = null,
-                                timestamp = null,
-                            )
-                            messages = if (retryInsertPosition != null) {
-                                messages.toMutableList().apply { add(retryInsertPosition!!, placeholder) }
-                            } else {
-                                val lastMsg = messages.lastOrNull()
-                                if (lastMsg != null && !lastMsg.isUser) {
-                                    messages.dropLast(1) + placeholder
-                                } else {
-                                    messages + placeholder
-                                }
-                            }
-                        }
+                        activeToolCalls = calls // No streaming bubble yet — create placeholder so tool chips are visible
+                        if (calls.isNotEmpty()) ensurePlaceholderAiMessage()
                     }
                 }
             }
@@ -405,31 +403,20 @@ class ChatViewModel(
             // Subscribe to thinking/reasoning tokens streamed by models that expose reasoning.
             // Accumulate chunks into a single string; UI renders them in a collapsible section.
             scope.launch {
+                activeThread.pendingApproval.collect { request ->
+                    if (currentSessionId.value == sessionId) {
+                        pendingToolApproval = request
+                    }
+                }
+            }
+
+            scope.launch {
                 activeThread.thinkingChunks.collect { chunks ->
                     if (currentSessionId.value == sessionId) {
                         activeThinkingContent = chunks.joinToString("")
                         // Ensure a placeholder bubble exists so the thinking section is visible
                         // even before the first response token arrives.
-                        if (chunks.isNotEmpty() && messages.none { !it.isUser && it.id == null }) {
-                            isThinking = false
-                            stopThinkingTimer()
-                            val placeholder = ChatMessageDTO(
-                                content = "",
-                                isUser = false,
-                                id = null,
-                                timestamp = null,
-                            )
-                            messages = if (retryInsertPosition != null) {
-                                messages.toMutableList().apply { add(retryInsertPosition!!, placeholder) }
-                            } else {
-                                val lastMsg = messages.lastOrNull()
-                                if (lastMsg != null && !lastMsg.isUser) {
-                                    messages.dropLast(1) + placeholder
-                                } else {
-                                    messages + placeholder
-                                }
-                            }
-                        }
+                        if (chunks.isNotEmpty()) ensurePlaceholderAiMessage()
                     }
                 }
             }
@@ -608,6 +595,7 @@ class ChatViewModel(
 
                 // Clear tool chips and thinking content from the previous response before retrying
                 activeToolCalls = emptyList()
+                pendingToolApproval = null
                 activeThinkingContent = ""
 
                 startThinkingTimer()
@@ -689,6 +677,7 @@ class ChatViewModel(
 
         // Clear tool chips and thinking content from the previous response now that a new message is starting
         activeToolCalls = emptyList()
+        pendingToolApproval = null
         activeThinkingContent = ""
 
         // Session ID must be set by this point (from resumeSession)

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpToolsDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpToolsDialog.kt
@@ -5,6 +5,9 @@
 package io.askimo.ui.mcp
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
@@ -39,13 +43,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import io.askimo.core.intent.ToolApprovalPolicy
 import io.askimo.core.intent.ToolCategory
 import io.askimo.core.intent.ToolConfig
 import io.askimo.core.intent.ToolStrategy
-import io.askimo.core.mcp.McpClientFactory
 import io.askimo.core.mcp.McpInstance
+import io.askimo.core.mcp.McpInstanceService
 import io.askimo.core.mcp.SecretDetector
 import io.askimo.core.mcp.config.McpServersConfig
 import io.askimo.ui.common.components.inlineErrorMessage
@@ -70,7 +82,7 @@ fun mcpToolsDialog(
     onDismiss: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
-    val mcpClientFactory = get<McpClientFactory>(McpClientFactory::class.java)
+    val mcpInstanceService = remember { get<McpInstanceService>(McpInstanceService::class.java) }
     val serverDefinition = remember(instance.serverId) { McpServersConfig.get(instance.serverId) }
     var tools by remember { mutableStateOf<List<ToolConfig>?>(null) }
     var isLoading by remember { mutableStateOf(true) }
@@ -94,7 +106,7 @@ fun mcpToolsDialog(
         isLoading = true
         dialogState.clearError()
         try {
-            val result = withContext(Dispatchers.IO) { mcpClientFactory.listTools(instance) }
+            val result = withContext(Dispatchers.IO) { mcpInstanceService.listTools(instance.id) }
             result.fold(
                 onSuccess = { tools = it },
                 onFailure = { e ->
@@ -360,6 +372,18 @@ fun mcpToolsDialog(
                                     toolCategoryChip(tool.category)
                                     toolStrategyChip(tool.strategy)
                                 }
+                                toolApprovalPolicyControl(
+                                    current = tool.approvalPolicy,
+                                    onPolicyChanged = { newPolicy ->
+                                        scope.launch(Dispatchers.IO) {
+                                            mcpInstanceService.setToolApproval(instance.id, tool.specification.name(), newPolicy)
+                                            // Reflect change locally so the UI updates instantly
+                                            tools = tools?.map { t ->
+                                                if (t.specification.name() == tool.specification.name()) t.copy(approvalPolicy = newPolicy) else t
+                                            }
+                                        }
+                                    },
+                                )
                             }
                         }
                     }
@@ -428,6 +452,79 @@ private fun String?.toJsonString(): String {
         .replace("\r", "\\r")
         .replace("\t", "\\t")
     return "\"$escaped\""
+}
+
+@Composable
+private fun toolApprovalPolicyControl(
+    current: ToolApprovalPolicy,
+    onPolicyChanged: (ToolApprovalPolicy) -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource("mcp.tool.approval.label"),
+            style = AppTextStyles.caption,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        ToolApprovalPolicy.entries.forEach { policy ->
+            approvalPolicyButton(
+                label = stringResource("mcp.tool.approval.${policy.name.lowercase()}"),
+                tooltip = stringResource("mcp.tool.approval.${policy.name.lowercase()}.hint"),
+                isSelected = policy == current,
+                onClick = { if (policy != current) onPolicyChanged(policy) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun approvalPolicyButton(
+    label: String,
+    tooltip: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val density = LocalDensity.current
+
+    Box(modifier = Modifier.hoverable(interactionSource)) {
+        if (isSelected) {
+            primaryButton(onClick = onClick) { Text(label, style = MaterialTheme.typography.labelSmall) }
+        } else {
+            secondaryButton(onClick = onClick) { Text(label, style = MaterialTheme.typography.labelSmall) }
+        }
+        if (isHovered) {
+            AppComponents.anchoredPopup(
+                positionProvider = remember(density) {
+                    object : PopupPositionProvider {
+                        override fun calculatePosition(
+                            anchorBounds: IntRect,
+                            windowSize: IntSize,
+                            layoutDirection: LayoutDirection,
+                            popupContentSize: IntSize,
+                        ): IntOffset = IntOffset(
+                            x = anchorBounds.left,
+                            y = anchorBounds.bottom + with(density) { 4.dp.roundToPx() },
+                        )
+                    }
+                },
+                onDismissRequest = {},
+                shape = MaterialTheme.shapes.small,
+                properties = PopupProperties(focusable = false),
+            ) {
+                Text(
+                    text = tooltip,
+                    style = AppTextStyles.hint,
+                    modifier = Modifier
+                        .widthIn(max = 220.dp)
+                        .padding(Spacing.small),
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
@@ -11,6 +11,7 @@ import io.askimo.core.chat.domain.ChatMessage
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
+import io.askimo.core.chat.dto.ToolApprovalRequest
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.dto.ToolCallStatus
 import io.askimo.core.chat.service.ChatSessionService
@@ -19,7 +20,10 @@ import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.SessionCreatedEvent
 import io.askimo.core.exception.ContextLengthException
 import io.askimo.core.exception.ExceptionHandler
+import io.askimo.core.i18n.LocalizationManager
+import io.askimo.core.intent.ToolConfig
 import io.askimo.core.logging.logger
+import io.askimo.core.mcp.McpInstanceService
 import io.askimo.core.providers.ConfigurationErrorException
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ProxyChatContext
@@ -32,7 +36,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -65,6 +68,7 @@ import java.util.concurrent.ConcurrentHashMap
 class SessionManager(
     private val chatSessionService: ChatSessionService,
     private val scope: CoroutineScope,
+    private val mcpInstanceService: McpInstanceService? = null,
 ) {
     private val log = logger<SessionManager>()
 
@@ -139,12 +143,24 @@ class SessionManager(
         private val _savedMessage: MutableStateFlow<ChatMessage?> = MutableStateFlow(null),
         private val _toolCalls: MutableStateFlow<List<ToolCallInfo>> = MutableStateFlow(emptyList()),
         private val _thinkingChunks: MutableStateFlow<List<String>> = MutableStateFlow(emptyList()),
+        private val _pendingApproval: MutableStateFlow<ToolApprovalRequest?> = MutableStateFlow(null),
     ) {
         val chunks: StateFlow<List<String>> = _chunks.asStateFlow()
         val isComplete: StateFlow<Boolean> = _isComplete.asStateFlow()
         val savedMessage: StateFlow<ChatMessage?> = _savedMessage.asStateFlow()
         val toolCalls: StateFlow<List<ToolCallInfo>> = _toolCalls.asStateFlow()
         val thinkingChunks: StateFlow<List<String>> = _thinkingChunks.asStateFlow()
+        val pendingApproval: StateFlow<ToolApprovalRequest?> = _pendingApproval.asStateFlow()
+
+        /** Sets the pending approval request, surfacing Approve/Deny buttons in the UI. */
+        fun requestApproval(request: ToolApprovalRequest) {
+            _pendingApproval.value = request
+        }
+
+        /** Clears the pending approval request after the user has responded. */
+        fun clearApproval() {
+            _pendingApproval.value = null
+        }
 
         private val mutex = Mutex()
 
@@ -298,6 +314,14 @@ class SessionManager(
                     var capturedTotalTokens: Int? = null
                     var capturedDurationMs: Long? = null
 
+                    // Fetch resolved tools for the approval guardrail.
+                    // Only fetched when MCP servers are enabled and the service is available.
+                    val resolvedTools: List<ToolConfig> = if (enabledServerIds.isNotEmpty() && mcpInstanceService != null) {
+                        mcpInstanceService.getGlobalTools().getOrDefault(emptyList())
+                    } else {
+                        emptyList()
+                    }
+
                     // Pre-generate the assistant message ID and set the ProxyChatContext
                     // ThreadLocal on this thread so the correlating HTTP client can inject
                     // the tracking headers into the outgoing proxy request.
@@ -350,6 +374,33 @@ class SessionManager(
                                 onThinkingToken = { token ->
                                     streamingScope.launch {
                                         thread.appendThinkingChunk(token)
+                                    }
+                                },
+                                resolvedTools = resolvedTools,
+                                onToolApprovalRequired = { toolName, arguments, approve, deny ->
+                                    streamingScope.launch {
+                                        val argBlock = if (!arguments.isNullOrBlank()) {
+                                            ":\n```json\n$arguments\n```"
+                                        } else {
+                                            "."
+                                        }
+                                        thread.appendChunk(
+                                            LocalizationManager.getString("chat.tool.approval.required", toolName, argBlock),
+                                        )
+                                        thread.requestApproval(
+                                            ToolApprovalRequest(
+                                                toolName = toolName,
+                                                arguments = arguments,
+                                                approve = {
+                                                    streamingScope.launch { thread.clearApproval() }
+                                                    approve()
+                                                },
+                                                deny = {
+                                                    streamingScope.launch { thread.clearApproval() }
+                                                    deny()
+                                                },
+                                            ),
+                                        )
                                     }
                                 },
                             )
@@ -437,7 +488,7 @@ class SessionManager(
                 val savedMessage = chatSessionService.saveAiResponse(sessionId, failedResponse, isFailed = true)
                 thread.setSavedMessage(savedMessage)
 
-                if (failedResponse != partialResponse) {
+                if (failedResponse != partialResponse && failedResponse.length > partialResponse.length) {
                     val remainingContent = failedResponse.substring(partialResponse.length)
                     if (remainingContent.isNotEmpty()) {
                         thread.appendChunk(remainingContent)
@@ -607,9 +658,6 @@ class SessionManager(
 
                 // Navigate to chat view
                 onComplete()
-
-                // Small delay to ensure UI and ViewModel are ready
-                delay(100)
 
                 // Now send the message - ViewModel is ready
                 val viewModel = getOrCreateChatViewModel(newSession.id)

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=Image model not configured
 chat.image.model.missing.message=No image model is set for {0}. Open Settings > AI Provider > Image Generation Models and set a model name first.
 chat.tools.button=Available Tools
 chat.tools.button.disabled=Available Tools ({0} disabled)
+chat.tool.approval.required=\n\n⏸️ **Approval required** — The AI wants to run `{0}`{1}\n\n
+chat.tool.approval.timed_out=Tool approval timed out: {0}
+chat.tool.approval.denied=Tool execution denied by user: {0}
+chat.tool.approval.prompt=The AI wants to run: {0}
+chat.tool.approval.approve=Approve
+chat.tool.approval.deny=Deny
 chat.tools.button.model.no.support=Tools are not supported by this model
 chat.tools.popup.title=Available Tools
 chat.tools.popup.loading=Loading servers...
@@ -1380,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=Weather data and forecasts
 mcp.tool.category.WEB_SEARCH.desc=Web search and page reading
 mcp.tool.category.DATETIME.desc=Date and time operations
 mcp.tool.category.OTHER.desc=Unclassified tools
+mcp.tool.approval.label=Approval
+mcp.tool.approval.require_approval=Require approval
+mcp.tool.approval.default.hint=Runs automatically. Write-like categories (file write, execute, git, messaging) require approval by default.
+mcp.tool.approval.require_approval.hint=Always pauses and asks for your confirmation before the AI executes this tool.
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Available Tools - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=Bildmodell nicht konfiguriert
 chat.image.model.missing.message=Für {0} ist kein Bildmodell festgelegt. Öffnen Sie Einstellungen > KI-Anbieter > Modelle zur Bilderzeugung und legen Sie zuerst einen Modellnamen fest.
 chat.tools.button=Verfügbare Tools
 chat.tools.button.disabled=Verfügbare Tools ({0} deaktiviert)
+chat.tool.approval.required=\n\n⏸️ **Genehmigung erforderlich** — Die KI möchte ausführen `{0}`{1}\n\n
+chat.tool.approval.timed_out=Tool-Genehmigung abgelaufen: {0}
+chat.tool.approval.denied=Tool-Ausführung durch Benutzer verweigert: {0}
+chat.tool.approval.prompt=Die KI möchte ausführen: {0}
+chat.tool.approval.approve=Genehmigen
+chat.tool.approval.deny=Ablehnen
 chat.tools.button.model.no.support=Tools werden von diesem Modell nicht unterstützt
 chat.tools.popup.title=Verfügbare Tools
 chat.tools.popup.loading=Server werden geladen...
@@ -983,6 +989,7 @@ provider.template.lite_llm.tagline=A unified proxy that lets you call 100+ LLMs 
 provider.search.placeholder=Search providers...
 provider.search.no_results=No providers found
 provider.template.lite_llm.help=💡 To use LiteLLM:\n\n1. Start the LiteLLM proxy: litellm --model ollama/llama3\n2. The default URL is http://localhost:4000/v1\n3. No API key is needed for local setups (set any value if prompted)
+
 
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
@@ -1379,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=Wetterdaten und Vorhersagen
 mcp.tool.category.WEB_SEARCH.desc=Websuche und Seitenlesen
 mcp.tool.category.DATETIME.desc=Datum- und Zeitoperationen
 mcp.tool.category.OTHER.desc=Nicht klassifizierte Tools
+mcp.tool.approval.label=Freigabe
+mcp.tool.approval.require_approval=Freigabe erforderlich
+mcp.tool.approval.default.hint=Läuft automatisch. Schreibähnliche Kategorien (Datei schreiben, Ausführen, Git, Messaging) erfordern standardmäßig eine Freigabe.
+mcp.tool.approval.require_approval.hint=Hält immer an und bittet um Ihre Bestätigung, bevor die KI dieses Tool ausführt.
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Verfügbare Tools - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=Modelo de imagen no configurado
 chat.image.model.missing.message=No hay ningún modelo de imagen configurado para {0}. Abre Configuración > Proveedor de IA > Modelos de generación de imágenes y establece primero un nombre de modelo.
 chat.tools.button=Herramientas disponibles
 chat.tools.button.disabled=Herramientas disponibles ({0} deshabilitadas)
+chat.tool.approval.required=\n\n⏸️ **Aprobación requerida** — La IA quiere ejecutar `{0}`{1}\n\n
+chat.tool.approval.timed_out=Tiempo de espera agotado para la aprobación de la herramienta: {0}
+chat.tool.approval.denied=Ejecución de la herramienta denegada por el usuario: {0}
+chat.tool.approval.prompt=La IA quiere ejecutar: {0}
+chat.tool.approval.approve=Aprobar
+chat.tool.approval.deny=Denegar
 chat.tools.button.model.no.support=Las herramientas no son compatibles con este modelo
 chat.tools.popup.title=Herramientas disponibles
 chat.tools.popup.loading=Cargando servidores...
@@ -983,6 +989,7 @@ provider.template.lite_llm.tagline=A unified proxy that lets you call 100+ LLMs 
 provider.search.placeholder=Search providers...
 provider.search.no_results=No providers found
 provider.template.lite_llm.help=💡 To use LiteLLM:\n\n1. Start the LiteLLM proxy: litellm --model ollama/llama3\n2. The default URL is http://localhost:4000/v1\n3. No API key is needed for local setups (set any value if prompted)
+
 
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
@@ -1379,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=Datos meteorológicos y pronósticos
 mcp.tool.category.WEB_SEARCH.desc=Búsqueda web y lectura de páginas
 mcp.tool.category.DATETIME.desc=Operaciones de fecha y hora
 mcp.tool.category.OTHER.desc=Herramientas no clasificadas
+mcp.tool.approval.label=Aprobación
+mcp.tool.approval.require_approval=Requerir aprobación
+mcp.tool.approval.default.hint=Se ejecuta automáticamente. Las categorías de escritura (escritura de archivos, ejecución, git, mensajería) requieren aprobación por defecto.
+mcp.tool.approval.require_approval.hint=Siempre se detiene y pide confirmación antes de que la IA ejecute esta herramienta.
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Herramientas disponibles - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=Modèle d'image non configuré
 chat.image.model.missing.message=Aucun modèle d'image n'est défini pour {0}. Ouvrez Paramètres > Fournisseur d'IA > Modèles de génération d'images et définissez d'abord un nom de modèle.
 chat.tools.button=Outils disponibles
 chat.tools.button.disabled=Outils disponibles ({0} désactivés)
+chat.tool.approval.required=\n\n⏸️ **Approbation requise** — L'IA souhaite exécuter `{0}`{1}\n\n
+chat.tool.approval.timed_out=Délai d'approbation de l'outil expiré: {0}
+chat.tool.approval.denied=Exécution de l'outil refusée par l'utilisateur: {0}
+chat.tool.approval.prompt=L'IA souhaite exécuter : {0}
+chat.tool.approval.approve=Approuver
+chat.tool.approval.deny=Refuser
 chat.tools.button.model.no.support=Les outils ne sont pas pris en charge par ce modèle
 chat.tools.popup.title=Outils disponibles
 chat.tools.popup.loading=Chargement des serveurs...
@@ -983,6 +989,7 @@ provider.template.lite_llm.tagline=A unified proxy that lets you call 100+ LLMs 
 provider.search.placeholder=Search providers...
 provider.search.no_results=No providers found
 provider.template.lite_llm.help=💡 To use LiteLLM:\n\n1. Start the LiteLLM proxy: litellm --model ollama/llama3\n2. The default URL is http://localhost:4000/v1\n3. No API key is needed for local setups (set any value if prompted)
+
 
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
@@ -1379,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=Données météorologiques et prévisions
 mcp.tool.category.WEB_SEARCH.desc=Recherche web et lecture de pages
 mcp.tool.category.DATETIME.desc=Opérations de date et heure
 mcp.tool.category.OTHER.desc=Outils non classifiés
+mcp.tool.approval.label=Approbation
+mcp.tool.approval.require_approval=Exiger une approbation
+mcp.tool.approval.default.hint=S'exécute automatiquement. Les catégories d'écriture (écriture de fichiers, exécution, git, messagerie) nécessitent une approbation par défaut.
+mcp.tool.approval.require_approval.hint=Se met toujours en pause et demande votre confirmation avant que l'IA n'exécute cet outil.
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Outils disponibles - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=画像モデルが設定されていません
 chat.image.model.missing.message={0} に画像モデルが設定されていません。設定 > AI プロバイダー > 画像生成モデルを開き、まずモデル名を設定してください。
 chat.tools.button=利用可能なツール
 chat.tools.button.disabled=利用可能なツール（{0} 無効）
+chat.tool.approval.required=\n\n⏸️ **承認が必要です** — AIが `{0}`{1} を実行しようとしています\n\n
+chat.tool.approval.timed_out=ツールの承認がタイムアウトしました: {0}
+chat.tool.approval.denied=ユーザーによってツールの実行が拒否されました: {0}
+chat.tool.approval.prompt=AIが実行しようとしています: {0}
+chat.tool.approval.approve=承認
+chat.tool.approval.deny=拒否
 chat.tools.button.model.no.support=ツールはこのモデルではサポートされていません
 chat.tools.popup.title=利用可能なツール
 chat.tools.popup.loading=サーバーを読み込み中...
@@ -983,6 +989,7 @@ provider.template.lite_llm.tagline=A unified proxy that lets you call 100+ LLMs 
 provider.search.placeholder=Search providers...
 provider.search.no_results=No providers found
 provider.template.lite_llm.help=💡 To use LiteLLM:\n\n1. Start the LiteLLM proxy: litellm --model ollama/llama3\n2. The default URL is http://localhost:4000/v1\n3. No API key is needed for local setups (set any value if prompted)
+
 
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
@@ -1379,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=天気データと予報
 mcp.tool.category.WEB_SEARCH.desc=ウェブ検索およびページ読み取り
 mcp.tool.category.DATETIME.desc=日付および時刻操作
 mcp.tool.category.OTHER.desc=未分類ツール
+mcp.tool.approval.label=承認
+mcp.tool.approval.require_approval=承認を必要とする
+mcp.tool.approval.default.hint=自動的に実行されます。書き込み系のカテゴリ（ファイルの書き込み、実行、git、メッセージング）はデフォルトで承認が必要です。
+mcp.tool.approval.require_approval.hint=AIがこのツールを実行する前に、常に一時停止して確認を求めます。
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=利用可能なツール - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=이미지 모델이 구성되지 않았습니다
 chat.image.model.missing.message={0}에 설정된 이미지 모델이 없습니다. 설정 > AI 제공업체 > 이미지 생성 모델을 열고 먼저 모델 이름을 설정하세요.
 chat.tools.button=사용 가능한 도구
 chat.tools.button.disabled=사용 가능한 도구 ({0} 비활성화됨)
+chat.tool.approval.required=\n\n⏸️ **승인 필요** — AI가 `{0}`{1}을(를) 실행하려고 합니다\n\n
+chat.tool.approval.timed_out=도구 승인 시간 초과: {0}
+chat.tool.approval.denied=사용자가 도구 실행을 거부했습니다: {0}
+chat.tool.approval.prompt=AI가 다음을 실행하려고 합니다: {0}
+chat.tool.approval.approve=승인
+chat.tool.approval.deny=거부
 chat.tools.button.model.no.support=이 모델은 도구를 지원하지 않습니다
 chat.tools.popup.title=사용 가능한 도구
 chat.tools.popup.loading=서버 로딩 중...
@@ -983,6 +989,7 @@ provider.template.lite_llm.tagline=A unified proxy that lets you call 100+ LLMs 
 provider.search.placeholder=Search providers...
 provider.search.no_results=No providers found
 provider.template.lite_llm.help=💡 To use LiteLLM:\n\n1. Start the LiteLLM proxy: litellm --model ollama/llama3\n2. The default URL is http://localhost:4000/v1\n3. No API key is needed for local setups (set any value if prompted)
+
 
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
@@ -1379,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=날씨 데이터 및 예보
 mcp.tool.category.WEB_SEARCH.desc=웹 검색 및 페이지 읽기
 mcp.tool.category.DATETIME.desc=날짜 및 시간 작업
 mcp.tool.category.OTHER.desc=분류되지 않은 도구
+mcp.tool.approval.label=승인
+mcp.tool.approval.require_approval=승인 필요
+mcp.tool.approval.default.hint=자동으로 실행됩니다. 쓰기 관련 범주(파일 쓰기, 실행, git, 메시징)는 기본적으로 승인이 필요합니다.
+mcp.tool.approval.require_approval.hint=AI가 이 도구를 실행하기 전에 항상 일시 중지하고 확인을 요청합니다.
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=사용 가능한 도구 - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=Modelo de imagem não configurado
 chat.image.model.missing.message=Nenhum modelo de imagem está definido para {0}. Abra Configurações > Provedor de IA > Modelos de geração de imagens e defina primeiro um nome de modelo.
 chat.tools.button=Ferramentas disponíveis
 chat.tools.button.disabled=Ferramentas disponíveis ({0} desativadas)
+chat.tool.approval.required=\n\n⏸️ **Aprovação necessária** — A IA deseja executar `{0}`{1}\n\n
+chat.tool.approval.timed_out=Tempo limite de aprovação da ferramenta excedido: {0}
+chat.tool.approval.denied=Execução da ferramenta negada pelo usuário: {0}
+chat.tool.approval.prompt=A IA deseja executar: {0}
+chat.tool.approval.approve=Aprovar
+chat.tool.approval.deny=Negar
 chat.tools.button.model.no.support=As ferramentas não são suportadas por este modelo
 chat.tools.popup.title=Ferramentas disponíveis
 chat.tools.popup.loading=Carregando servidores...
@@ -983,6 +989,7 @@ provider.template.lite_llm.tagline=A unified proxy that lets you call 100+ LLMs 
 provider.search.placeholder=Search providers...
 provider.search.no_results=No providers found
 provider.template.lite_llm.help=💡 To use LiteLLM:\n\n1. Start the LiteLLM proxy: litellm --model ollama/llama3\n2. The default URL is http://localhost:4000/v1\n3. No API key is needed for local setups (set any value if prompted)
+
 
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
@@ -1379,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=Dados e previsões do tempo
 mcp.tool.category.WEB_SEARCH.desc=Busca web e leitura de páginas
 mcp.tool.category.DATETIME.desc=Operações de data e hora
 mcp.tool.category.OTHER.desc=Ferramentas não classificadas
+mcp.tool.approval.label=Aprovação
+mcp.tool.approval.require_approval=Exigir aprovação
+mcp.tool.approval.default.hint=É executado automaticamente. Categorias de gravação (gravação de arquivos, execução, git, mensagens) exigem aprovação por padrão.
+mcp.tool.approval.require_approval.hint=Sempre pausa e pede sua confirmação antes que a IA execute esta ferramenta.
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Ferramentas Disponíveis - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=Chưa cấu hình mô hình hình ảnh
 chat.image.model.missing.message=Chưa đặt mô hình hình ảnh cho {0}. Mở Cài đặt > Nhà cung cấp AI > Mô hình tạo hình ảnh và đặt tên mô hình trước.
 chat.tools.button=Công cụ khả dụng
 chat.tools.button.disabled=Công cụ khả dụng ({0} bị vô hiệu hóa)
+chat.tool.approval.required=\n\n⏸️ **Yêu cầu phê duyệt** — AI muốn chạy `{0}`{1}\n\n
+chat.tool.approval.timed_out=Hết thời gian chờ phê duyệt công cụ: {0}
+chat.tool.approval.denied=Người dùng từ chối thực thi công cụ: {0}
+chat.tool.approval.prompt=AI muốn chạy: {0}
+chat.tool.approval.approve=Phê duyệt
+chat.tool.approval.deny=Từ chối
 chat.tools.button.model.no.support=Các công cụ không được hỗ trợ bởi mô hình này
 chat.tools.popup.title=Công cụ khả dụng
 chat.tools.popup.loading=Đang tải máy chủ...
@@ -983,6 +989,7 @@ provider.template.lite_llm.tagline=A unified proxy that lets you call 100+ LLMs 
 provider.search.placeholder=Search providers...
 provider.search.no_results=No providers found
 provider.template.lite_llm.help=💡 To use LiteLLM:\n\n1. Start the LiteLLM proxy: litellm --model ollama/llama3\n2. The default URL is http://localhost:4000/v1\n3. No API key is needed for local setups (set any value if prompted)
+
 
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
@@ -1379,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=Dữ liệu và dự báo thời tiết
 mcp.tool.category.WEB_SEARCH.desc=Tìm kiếm web và đọc trang
 mcp.tool.category.DATETIME.desc=Các thao tác ngày và giờ
 mcp.tool.category.OTHER.desc=Các công cụ không phân loại
+mcp.tool.approval.label=Phê duyệt
+mcp.tool.approval.require_approval=Yêu cầu phê duyệt
+mcp.tool.approval.default.hint=Chạy tự động. Các danh mục có tính chất ghi (ghi tệp, thực thi, git, nhắn tin) yêu cầu phê duyệt theo mặc định.
+mcp.tool.approval.require_approval.hint=Luôn tạm dừng và yêu cầu bạn xác nhận trước khi AI thực thi công cụ này.
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Các công cụ có sẵn - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=未配置图像模型
 chat.image.model.missing.message=未为 {0} 设置图像模型。打开 设置 > AI 提供商 > 图像生成模型，并先设置模型名称。
 chat.tools.button=可用工具
 chat.tools.button.disabled=可用工具（{0} 已禁用）
+chat.tool.approval.required=\n\n⏸️ **需要批准** — AI 想要运行 `{0}`{1}\n\n
+chat.tool.approval.timed_out=工具审批超时: {0}
+chat.tool.approval.denied=用户拒绝执行工具: {0}
+chat.tool.approval.prompt=AI 想要运行：{0}
+chat.tool.approval.approve=批准
+chat.tool.approval.deny=拒绝
 chat.tools.button.model.no.support=此模型不支持工具
 chat.tools.popup.title=可用工具
 chat.tools.popup.loading=正在加载服务器...
@@ -983,6 +989,7 @@ provider.template.lite_llm.tagline=A unified proxy that lets you call 100+ LLMs 
 provider.search.placeholder=Search providers...
 provider.search.no_results=No providers found
 provider.template.lite_llm.help=💡 To use LiteLLM:\n\n1. Start the LiteLLM proxy: litellm --model ollama/llama3\n2. The default URL is http://localhost:4000/v1\n3. No API key is needed for local setups (set any value if prompted)
+
 
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
@@ -1379,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=天气数据和预报
 mcp.tool.category.WEB_SEARCH.desc=网络搜索和页面读取
 mcp.tool.category.DATETIME.desc=日期和时间操作
 mcp.tool.category.OTHER.desc=未分类工具
+mcp.tool.approval.label=批准
+mcp.tool.approval.require_approval=需要批准
+mcp.tool.approval.default.hint=自动运行。类似写入的操作类别（文件写入、执行、git、消息传递）默认需要批准。
+mcp.tool.approval.require_approval.hint=在 AI 执行此工具之前，总是会暂停并征求您的确认。
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=可用工具 - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -710,6 +710,12 @@ chat.image.model.missing.title=尚未設定圖片模型
 chat.image.model.missing.message=尚未為 {0} 設定圖片模型。開啟 設定 > AI 提供者 > 圖片生成模型，並先設定模型名稱。
 chat.tools.button=可用工具
 chat.tools.button.disabled=可用工具（{0} 已停用）
+chat.tool.approval.required=\n\n⏸️ **需要核准** — AI 想要執行 `{0}`{1}\n\n
+chat.tool.approval.timed_out=工具核准逾時: {0}
+chat.tool.approval.denied=使用者已拒絕執行工具: {0}
+chat.tool.approval.prompt=AI 想要執行：{0}
+chat.tool.approval.approve=批准
+chat.tool.approval.deny=拒絕
 chat.tools.button.model.no.support=此模型不支援工具
 chat.tools.popup.title=可用工具
 chat.tools.popup.loading=正在載入伺服器...
@@ -983,6 +989,7 @@ provider.template.lite_llm.tagline=A unified proxy that lets you call 100+ LLMs 
 provider.search.placeholder=Search providers...
 provider.search.no_results=No providers found
 provider.template.lite_llm.help=💡 To use LiteLLM:\n\n1. Start the LiteLLM proxy: litellm --model ollama/llama3\n2. The default URL is http://localhost:4000/v1\n3. No API key is needed for local setups (set any value if prompted)
+
 
 provider.configure.new.title=Configure {0}
 provider.edit.title=Edit "{0}"
@@ -1379,6 +1386,10 @@ mcp.tool.category.WEATHER.desc=天氣資料和預報
 mcp.tool.category.WEB_SEARCH.desc=網路搜尋和頁面閱讀
 mcp.tool.category.DATETIME.desc=日期和時間操作
 mcp.tool.category.OTHER.desc=未分類工具
+mcp.tool.approval.label=批准
+mcp.tool.approval.require_approval=需要批准
+mcp.tool.approval.default.hint=自動執行。類似寫入的操作類別（檔案寫入、執行、git、訊息傳遞）預設需要批准。
+mcp.tool.approval.require_approval.hint=在 AI 執行此工具之前，總是會暫停並徵求您的確認。
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=可用工具 - {0}

--- a/desktop/src/main/kotlin/io/askimo/desktop/di/DesktopModule.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/di/DesktopModule.kt
@@ -94,6 +94,7 @@ val desktopModule = module {
         SessionManager(
             chatSessionService = get(),
             scope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+            mcpInstanceService = get(),
         )
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 graalvm-plugin = "1.1.3"
 jline = "3.30.6"
-langchain4j = "1.18.0"
-langchain4j-extra = "1.18.0-beta28"
+langchain4j = "1.19.0"
+langchain4j-extra = "1.19.0-beta29"
 langchain4j-jvector = "1.18.0-beta28"
 commonmark = "0.29.0"
 kotlinxSerializationJson = "1.11.0"

--- a/shared/src/main/kotlin/io/askimo/core/chat/dto/ToolApprovalRequest.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/dto/ToolApprovalRequest.kt
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.chat.dto
+
+/**
+ * Represents a pending tool-execution approval request surfaced to the user
+ * during an active AI streaming session.
+ *
+ * The streaming thread is blocked until one of the two callbacks is invoked.
+ * Call [approve] to let the tool proceed, or [deny] to cancel it.
+ * One of the two **must** be called — failing to do so stalls the streaming thread
+ * until the 120-second timeout fires.
+ */
+data class ToolApprovalRequest(
+    /** Name of the tool the AI wants to invoke. */
+    val toolName: String,
+    /** Raw JSON arguments string, or null if the tool takes no arguments. */
+    val arguments: String?,
+    /** Unblocks the streaming thread and lets the tool execute. */
+    val approve: () -> Unit,
+    /** Unblocks the streaming thread and cancels the tool call. */
+    val deny: () -> Unit,
+)

--- a/shared/src/main/kotlin/io/askimo/core/intent/ToolConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/intent/ToolConfig.kt
@@ -16,7 +16,39 @@ data class ToolConfig(
     val source: ToolSource,
     /** The MCP instance ID this tool belongs to. Null for built-in Askimo tools. */
     val serverId: String? = null,
+    /**
+     * Resolved approval policy for this tool.
+     * [ToolApprovalPolicy.DEFAULT] means the runtime falls back to [ToolCategory.defaultApprovalPolicy].
+     */
+    val approvalPolicy: ToolApprovalPolicy = ToolApprovalPolicy.DEFAULT,
 )
+
+/**
+ * Per-tool execution approval policy configured by the user.
+ */
+enum class ToolApprovalPolicy {
+    /**
+     * Derive behaviour from the tool's [ToolCategory]:
+     * mutating categories require approval automatically; read-only categories run freely.
+     */
+    DEFAULT,
+
+    /** Always pause and ask the user before the AI executes this tool. */
+    REQUIRE_APPROVAL,
+}
+
+/**
+ * Returns the approval policy implied by this category when the user has not set an explicit override.
+ * Mutating / side-effectful categories default to [ToolApprovalPolicy.REQUIRE_APPROVAL];
+ * safe read-only categories default to [ToolApprovalPolicy.DEFAULT] (auto-run).
+ */
+fun ToolCategory.defaultApprovalPolicy(): ToolApprovalPolicy = when (this) {
+    ToolCategory.FILE_WRITE,
+    ToolCategory.EXECUTE,
+    -> ToolApprovalPolicy.REQUIRE_APPROVAL
+
+    else -> ToolApprovalPolicy.DEFAULT
+}
 
 /**
  * Tool execution strategy using bitwise flags.

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpClientFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpClientFactory.kt
@@ -7,8 +7,6 @@ package io.askimo.core.mcp
 import dev.langchain4j.agent.tool.ToolSpecification
 import dev.langchain4j.mcp.client.DefaultMcpClient
 import io.askimo.core.intent.ToolCategory
-import io.askimo.core.intent.ToolConfig
-import io.askimo.core.intent.ToolSource
 import io.askimo.core.intent.ToolStrategy
 import io.askimo.core.logging.logger
 import io.askimo.core.mcp.config.McpServersConfig
@@ -84,77 +82,6 @@ class McpClientFactory(
             Result.failure(
                 IllegalStateException(
                     "Failed to create MCP client for '${instance.name}': ${e.message}",
-                    e,
-                ),
-            )
-        }
-    }
-
-    /**
-     * Connects using a fully-resolved [definition] (no local config lookup).
-     * Intended for org-managed / remote servers whose definition is not stored in [McpServersConfig].
-     *
-     * Returns [Result.failure] with the root cause so callers can surface a meaningful message.
-     */
-    suspend fun listTools(name: String, definition: McpServerDefinition): Result<List<ToolConfig>> {
-        val clientKey = "list_${definition.id}_${System.currentTimeMillis()}"
-        return try {
-            val connector = McpInstance(
-                id = definition.id,
-                serverId = definition.id,
-                name = name,
-                parameterValues = emptyMap(),
-                enabled = true,
-                createdAt = java.time.LocalDateTime.now(),
-                updatedAt = java.time.LocalDateTime.now(),
-            ).toConnector(definition)
-
-            val transport = connector.createTransport()
-            val client = DefaultMcpClient.builder()
-                .key(clientKey)
-                .transport(transport)
-                .build()
-
-            val tools = client.listTools().map { toolSpec ->
-                ToolConfig(
-                    specification = toolSpec,
-                    category = inferToolCategory(toolSpec),
-                    strategy = inferToolStrategy(toolSpec),
-                    source = ToolSource.MCP_EXTERNAL,
-                )
-            }
-            Result.success(tools)
-        } catch (e: Exception) {
-            Result.failure(
-                IllegalStateException("Failed to list tools from '$name': ${e.message}", e),
-            )
-        }
-    }
-
-    /**
-     * Connects to [instance], fetches its tool list, and returns classified [ToolConfig]s.
-     *
-     * Returns [Result.failure] with the root cause so callers can surface a meaningful message.
-     */
-    suspend fun listTools(instance: McpInstance): Result<List<ToolConfig>> {
-        val clientKey = "list_${instance.id}_${System.currentTimeMillis()}"
-        val mcpClient = createMcpClient(instance, clientKey)
-            .getOrElse { return Result.failure(it) }
-
-        return try {
-            val tools = mcpClient.listTools().map { toolSpec ->
-                ToolConfig(
-                    specification = toolSpec,
-                    category = inferToolCategory(toolSpec),
-                    strategy = inferToolStrategy(toolSpec),
-                    source = ToolSource.MCP_EXTERNAL,
-                )
-            }
-            Result.success(tools)
-        } catch (e: Exception) {
-            Result.failure(
-                IllegalStateException(
-                    "Failed to list tools from '${instance.name}': ${e.message}",
                     e,
                 ),
             )

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpInstanceService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpInstanceService.kt
@@ -14,10 +14,12 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import dev.langchain4j.agent.tool.ToolSpecification
 import dev.langchain4j.mcp.client.DefaultMcpClient
+import io.askimo.core.intent.ToolApprovalPolicy
 import io.askimo.core.intent.ToolCategory
 import io.askimo.core.intent.ToolConfig
 import io.askimo.core.intent.ToolSource
 import io.askimo.core.intent.ToolVectorIndex
+import io.askimo.core.intent.defaultApprovalPolicy
 import io.askimo.core.logging.logger
 import io.askimo.core.mcp.config.McpInstancesConfig
 import io.askimo.core.mcp.config.McpServersConfig
@@ -41,6 +43,11 @@ private data class ToolConfigData(
     val strategy: Int,
     val autoInferred: Boolean = true,
     val updatedAt: LocalDateTime = LocalDateTime.now(),
+    /**
+     * Explicit user-set approval policy. Null means "use the category default"
+     * ([ToolCategory.defaultApprovalPolicy]).
+     */
+    val approvalPolicy: ToolApprovalPolicy? = null,
 )
 
 private data class GlobalToolsConfigWrapper(val tools: List<ToolConfigData>)
@@ -265,12 +272,14 @@ class McpInstanceService(
 
                 if (userConfig != null && !userConfig.autoInferred) {
                     log.trace("Using user-customized config for tool '{}': {}, {}", toolName, userConfig.category, userConfig.strategy)
+                    val category = ToolCategory.valueOf(userConfig.category)
                     ToolConfig(
                         specification = toolSpec,
-                        category = ToolCategory.valueOf(userConfig.category),
+                        category = category,
                         strategy = userConfig.strategy,
                         source = ToolSource.MCP_EXTERNAL,
                         serverId = instance.id,
+                        approvalPolicy = userConfig.approvalPolicy ?: category.defaultApprovalPolicy(),
                     )
                 } else {
                     val inferredCategory = inferToolCategory(toolSpec)
@@ -295,6 +304,7 @@ class McpInstanceService(
                         strategy = inferredStrategy,
                         source = ToolSource.MCP_EXTERNAL,
                         serverId = instance.id,
+                        approvalPolicy = userConfig?.approvalPolicy ?: inferredCategory.defaultApprovalPolicy(),
                     )
                 }
             },
@@ -347,7 +357,34 @@ class McpInstanceService(
     suspend fun listTools(instanceId: String): Result<List<ToolConfig>> {
         val instance = getInstance(instanceId)
             ?: return Result.failure(IllegalArgumentException("Instance not found: $instanceId"))
-        return fetchToolsFromInstance(instance)
+        val userConfigs = loadToolConfigs()
+        return fetchToolsFromInstance(instance, userConfigs)
+    }
+
+    /**
+     * Persists a user-defined [ToolApprovalPolicy] for a specific tool on an instance.
+     * Invalidates the global tools cache so the change takes effect immediately.
+     */
+    fun setToolApproval(instanceId: String, toolName: String, policy: ToolApprovalPolicy) {
+        val configs = loadToolConfigs().toMutableMap()
+        val key = "$instanceId:$toolName"
+        val existing = configs[key]
+        configs[key] = (
+            existing ?: ToolConfigData(
+                toolName = toolName,
+                instanceId = instanceId,
+                category = ToolCategory.OTHER.name,
+                strategy = io.askimo.core.intent.ToolStrategy.INTENT_BASED,
+                autoInferred = true,
+            )
+            ).copy(
+            approvalPolicy = policy,
+            autoInferred = false,
+            updatedAt = LocalDateTime.now(),
+        )
+        saveGlobalToolConfigs(configs)
+        invalidateCache()
+        log.debug("Set approval policy for tool '{}' on instance '{}': {}", toolName, instanceId, policy)
     }
 
     fun getMcpClientForTool(toolName: String): DefaultMcpClient? = mcpClientsByToolCache.getIfPresent(toolName)

--- a/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
+++ b/shared/src/main/kotlin/io/askimo/core/plan/PlanExecutor.kt
@@ -112,13 +112,22 @@ class PlanExecutor(private val chatModel: ChatModel) {
         } catch (e: IllegalArgumentException) {
             Analytics.track(
                 AnalyticsEvent.PLAN_FAILED,
-                mapOf("step_count" to stepCount.toString(), "error_type" to "missing_input"),
+                mapOf(
+                    "step_count" to stepCount.toString(),
+                    "error_type" to "missing_input",
+                    "error_message" to (e.message ?: "unknown"),
+                ),
             )
             throw e
         } catch (e: Exception) {
             Analytics.track(
                 AnalyticsEvent.PLAN_FAILED,
-                mapOf("step_count" to stepCount.toString(), "error_type" to "step_failed"),
+                mapOf(
+                    "step_count" to stepCount.toString(),
+                    "error_type" to "step_failed",
+                    "error_class" to e::class.simpleName.orEmpty(),
+                    "error_message" to (e.message ?: "unknown"),
+                ),
             )
             throw e
         }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -27,7 +27,10 @@ import io.askimo.core.exception.ToolExecutionException
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.core.intent.DetectAiResponseIntentCommand
 import io.askimo.core.intent.FollowUpSuggestion
+import io.askimo.core.intent.ToolApprovalPolicy
+import io.askimo.core.intent.ToolConfig
 import io.askimo.core.intent.ToolRegistry
+import io.askimo.core.intent.defaultApprovalPolicy
 import io.askimo.core.logging.logger
 import io.askimo.core.memory.SessionConversationSummary
 import io.askimo.core.memory.UserMemorySummary
@@ -36,11 +39,13 @@ import io.askimo.core.util.RetryPresets
 import io.askimo.core.util.RetryUtils
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import java.nio.channels.UnresolvedAddressException
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Extension function to detect if an exception is due to unsupported sampling parameters.
@@ -204,6 +209,24 @@ fun ChatClient.sendStreamingMessageWithCallback(
     onToolStarted: ((toolName: String, arguments: String?) -> Unit)? = null,
     onToolFinished: ((toolName: String, arguments: String?, result: String?, hasFailed: Boolean) -> Unit)? = null,
     onThinkingToken: ((String) -> Unit)? = null,
+    /**
+     * Resolved [ToolConfig] list for the current session.
+     * Used to look up each tool's [io.askimo.core.intent.ToolApprovalPolicy] before execution.
+     * When empty, no approval checks are performed and all tools run automatically.
+     */
+    resolvedTools: List<ToolConfig> = emptyList(),
+    /**
+     * Called in [beforeToolExecution] when the resolved approval policy for a tool is
+     * [ToolApprovalPolicy.REQUIRE_APPROVAL] (either explicitly set or implied by the tool's
+     * [io.askimo.core.intent.ToolCategory.defaultApprovalPolicy]).
+     *
+     * The callback **must** eventually invoke either [approve] or [deny] — failing to do so
+     * will stall the streaming thread until the 120-second timeout fires.
+     *
+     * - Invoke [approve] to let the tool proceed.
+     * - Invoke [deny] to cancel the tool call (surfaces as a [ToolExecutionException]).
+     */
+    onToolApprovalRequired: ((toolName: String, arguments: String?, approve: () -> Unit, deny: () -> Unit) -> Unit)? = null,
 ): String {
     val log = logger<ChatClient>()
 
@@ -281,6 +304,37 @@ fun ChatClient.sendStreamingMessageWithCallback(
                             val arguments = before.request().arguments()
                             log.debug("Tool starting: {}", toolName)
                             onToolStarted?.invoke(toolName, arguments)
+
+                            // ── Approval guardrail ─────────────────────────────────────────────
+                            if (onToolApprovalRequired != null) {
+                                val toolConfig = resolvedTools.find { it.specification.name() == toolName }
+                                val effectivePolicy = when (toolConfig?.approvalPolicy ?: ToolApprovalPolicy.DEFAULT) {
+                                    ToolApprovalPolicy.DEFAULT -> toolConfig?.category?.defaultApprovalPolicy()
+                                        ?: ToolApprovalPolicy.DEFAULT
+
+                                    ToolApprovalPolicy.REQUIRE_APPROVAL -> ToolApprovalPolicy.REQUIRE_APPROVAL
+                                }
+
+                                if (effectivePolicy == ToolApprovalPolicy.REQUIRE_APPROVAL) {
+                                    val latch = CountDownLatch(1)
+                                    var approved = false
+                                    onToolApprovalRequired.invoke(
+                                        toolName,
+                                        arguments,
+                                        {
+                                            approved = true
+                                            latch.countDown()
+                                        },
+                                        { latch.countDown() },
+                                    )
+                                    if (!latch.await(120, TimeUnit.SECONDS)) {
+                                        throw ToolExecutionException(toolName = toolName, errorDetails = LocalizationManager.getString("chat.tool.approval.timed_out", toolName))
+                                    }
+                                    if (!approved) {
+                                        throw ToolExecutionException(toolName = toolName, errorDetails = LocalizationManager.getString("chat.tool.approval.denied", toolName))
+                                    }
+                                }
+                            }
                         }.onToolExecuted { tool ->
                             val toolName = tool.request().name()
                             val arguments = tool.request().arguments()
@@ -638,7 +692,7 @@ internal fun normalizeJsonFieldTypes(
         val root = jsonParser.parseToJsonElement(jsonText)
         if (root !is JsonObject) return jsonText
 
-        fun normalizeValue(key: String, value: kotlinx.serialization.json.JsonElement): kotlinx.serialization.json.JsonElement = when {
+        fun normalizeValue(key: String, value: JsonElement): JsonElement = when {
             key in arrayKeys -> when (value) {
                 is JsonArray -> value
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
@@ -109,7 +109,7 @@ object ChatRequestTransformers {
         val deduplicatedNonSystem = nonSystemMessages.fold(mutableListOf<ChatMessage>()) { acc, msg ->
             val lastSameType = acc.lastOrNull { it.type() == msg.type() }
             if (lastSameType != null && getMessageText(lastSameType) == getMessageText(msg)) {
-                log.debug("Dropping consecutive duplicate {} message", msg.type())
+                log.debug("Dropping consecutive duplicate {} message: {}", msg.type(), getMessageText(msg).take(100))
                 acc
             } else {
                 acc.also { it.add(msg) }


### PR DESCRIPTION
- Add ToolApprovalRequest DTO and pendingToolApproval state in ViewModel
- Update ChatView to display approval dialog with approve/deny buttons
- Extend McpInstanceService to honor ToolApprovalPolicy
- Add i18n messages for approval prompts and results
- Bump langchain4j dependency to 1.19.0
- Adjust SessionManager to handle approval policy changes and timeout handling
- Update ChatRequestTransformers to throw ToolExecutionException on denial or timeout