### PR TITLE
docs(i18n): Add missing approval.default translations across locales

### DIFF
--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=Date and time operations
 mcp.tool.category.OTHER.desc=Unclassified tools
 mcp.tool.approval.label=Approval
 mcp.tool.approval.require_approval=Require approval
+mcp.tool.approval.default=Auto
 mcp.tool.approval.default.hint=Runs automatically. Write-like categories (file write, execute, git, messaging) require approval by default.
 mcp.tool.approval.require_approval.hint=Always pauses and asks for your confirmation before the AI executes this tool.
 

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=Datum- und Zeitoperationen
 mcp.tool.category.OTHER.desc=Nicht klassifizierte Tools
 mcp.tool.approval.label=Freigabe
 mcp.tool.approval.require_approval=Freigabe erforderlich
+mcp.tool.approval.default=Automatisch
 mcp.tool.approval.default.hint=Läuft automatisch. Schreibähnliche Kategorien (Datei schreiben, Ausführen, Git, Messaging) erfordern standardmäßig eine Freigabe.
 mcp.tool.approval.require_approval.hint=Hält immer an und bittet um Ihre Bestätigung, bevor die KI dieses Tool ausführt.
 

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=Operaciones de fecha y hora
 mcp.tool.category.OTHER.desc=Herramientas no clasificadas
 mcp.tool.approval.label=Aprobación
 mcp.tool.approval.require_approval=Requerir aprobación
+mcp.tool.approval.default=Automatique
 mcp.tool.approval.default.hint=Se ejecuta automáticamente. Las categorías de escritura (escritura de archivos, ejecución, git, mensajería) requieren aprobación por defecto.
 mcp.tool.approval.require_approval.hint=Siempre se detiene y pide confirmación antes de que la IA ejecute esta herramienta.
 

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=Opérations de date et heure
 mcp.tool.category.OTHER.desc=Outils non classifiés
 mcp.tool.approval.label=Approbation
 mcp.tool.approval.require_approval=Exiger une approbation
+mcp.tool.approval.default=Automatique
 mcp.tool.approval.default.hint=S'exécute automatiquement. Les catégories d'écriture (écriture de fichiers, exécution, git, messagerie) nécessitent une approbation par défaut.
 mcp.tool.approval.require_approval.hint=Se met toujours en pause et demande votre confirmation avant que l'IA n'exécute cet outil.
 

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=日付および時刻操作
 mcp.tool.category.OTHER.desc=未分類ツール
 mcp.tool.approval.label=承認
 mcp.tool.approval.require_approval=承認を必要とする
+mcp.tool.approval.default=自動
 mcp.tool.approval.default.hint=自動的に実行されます。書き込み系のカテゴリ（ファイルの書き込み、実行、git、メッセージング）はデフォルトで承認が必要です。
 mcp.tool.approval.require_approval.hint=AIがこのツールを実行する前に、常に一時停止して確認を求めます。
 

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=날짜 및 시간 작업
 mcp.tool.category.OTHER.desc=분류되지 않은 도구
 mcp.tool.approval.label=승인
 mcp.tool.approval.require_approval=승인 필요
+mcp.tool.approval.default=자동
 mcp.tool.approval.default.hint=자동으로 실행됩니다. 쓰기 관련 범주(파일 쓰기, 실행, git, 메시징)는 기본적으로 승인이 필요합니다.
 mcp.tool.approval.require_approval.hint=AI가 이 도구를 실행하기 전에 항상 일시 중지하고 확인을 요청합니다.
 

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=Operações de data e hora
 mcp.tool.category.OTHER.desc=Ferramentas não classificadas
 mcp.tool.approval.label=Aprovação
 mcp.tool.approval.require_approval=Exigir aprovação
+mcp.tool.approval.default=Automático
 mcp.tool.approval.default.hint=É executado automaticamente. Categorias de gravação (gravação de arquivos, execução, git, mensagens) exigem aprovação por padrão.
 mcp.tool.approval.require_approval.hint=Sempre pausa e pede sua confirmação antes que a IA execute esta ferramenta.
 

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=Các thao tác ngày và giờ
 mcp.tool.category.OTHER.desc=Các công cụ không phân loại
 mcp.tool.approval.label=Phê duyệt
 mcp.tool.approval.require_approval=Yêu cầu phê duyệt
+mcp.tool.approval.default=Tự động
 mcp.tool.approval.default.hint=Chạy tự động. Các danh mục có tính chất ghi (ghi tệp, thực thi, git, nhắn tin) yêu cầu phê duyệt theo mặc định.
 mcp.tool.approval.require_approval.hint=Luôn tạm dừng và yêu cầu bạn xác nhận trước khi AI thực thi công cụ này.
 

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=日期和时间操作
 mcp.tool.category.OTHER.desc=未分类工具
 mcp.tool.approval.label=批准
 mcp.tool.approval.require_approval=需要批准
+mcp.tool.approval.default=自动
 mcp.tool.approval.default.hint=自动运行。类似写入的操作类别（文件写入、执行、git、消息传递）默认需要批准。
 mcp.tool.approval.require_approval.hint=在 AI 执行此工具之前，总是会暂停并征求您的确认。
 

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1388,6 +1388,7 @@ mcp.tool.category.DATETIME.desc=日期和時間操作
 mcp.tool.category.OTHER.desc=未分類工具
 mcp.tool.approval.label=批准
 mcp.tool.approval.require_approval=需要批准
+mcp.tool.approval.default=自動
 mcp.tool.approval.default.hint=自動執行。類似寫入的操作類別（檔案寫入、執行、git、訊息傳遞）預設需要批准。
 mcp.tool.approval.require_approval.hint=在 AI 執行此工具之前，總是會暫停並徵求您的確認。
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 projectGroup=io.askimo
-projectVersion=1.4.17
+projectVersion=1.4.18
 jvmVersion=25
 
 # About information


### PR DESCRIPTION
- Add the mcp.tool.approval.default key to all i18n message files.
- Provide default approval translations for each supported locale.
- Update project version to 1.4.18 in gradle.properties.