### PR TITLE
feat(providers): add DeepSeek template

### DIFF
--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -977,6 +977,8 @@ provider.template.get.apikey=Get API key →
 # OpenAI-Compatible template taglines and setup help (see OpenAiCompatibleTemplate.kt)
 provider.template.cloudflare_ai.tagline=Run AI models on Cloudflare's global edge network with Workers AI.
 provider.template.cloudflare_ai.help=💡 To use Cloudflare AI:\n\n1. Find your Account ID in your Cloudflare dashboard\n2. Replace {ACCOUNT_ID} in the Base URL with it\n3. Create an API token with 'Workers AI' permission at:\n   dash.cloudflare.com/profile/api-tokens
+provider.template.deepseek.tagline=Reasoning and general-purpose models with a straightforward OpenAI-compatible API.
+provider.template.deepseek.help=💡 To use DeepSeek:\n\n1. Create an API key at: platform.deepseek.com/api_keys\n2. Add credit to your DeepSeek account if needed\n3. Click Next to browse the available models
 provider.template.groq.tagline=Ultra-fast inference for open-source models — Llama, Mixtral, Gemma and more.
 provider.template.groq.help=💡 To use Groq:\n\n1. Get your free API key at: console.groq.com/keys\n2. Enter a model name, e.g. llama-3.1-8b-instant\n3. Click Next to browse all available models
 provider.template.nvidia_nim.tagline=Run optimized AI models on NVIDIA's cloud GPU infrastructure.

--- a/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/openaicompatible/OpenAiCompatibleTemplate.kt
@@ -78,6 +78,16 @@ enum class OpenAiCompatibleTemplate(
         },
     ),
 
+    DEEPSEEK(
+        displayName = "DeepSeek",
+        initials = "DS",
+        taglineKey = "provider.template.deepseek.tagline",
+        baseUrl = "https://api.deepseek.com/v1",
+        apiKeyRequired = true,
+        apiKeyUrl = "https://platform.deepseek.com/api_keys",
+        helpTextKey = "provider.template.deepseek.help",
+    ),
+
     GROQ(
         displayName = "Groq",
         initials = "GR",


### PR DESCRIPTION
## Summary
- add a DeepSeek preset to the OpenAI-compatible provider templates
- add the DeepSeek onboarding tagline and setup help

## Verification
- `./gradlew spotlessCheck` passes
- manually tested on Windows 11 with a real DeepSeek account: the model list loaded successfully and a chat message returned `DeepSeek connection verified.`

## Notes
- `./gradlew detekt test` completed detekt with 0 errors (1280 existing warnings), but the full test run has one unrelated existing failure in `UrlContentExtractorProxyTest.should store proxy credentials` because the test reads an existing stored proxy password.

Signed-off-by: Saturday-boyi <2174084306@qq.com>