### PR TITLE
feat(menu-bar): replace native menu bar with Compose and add exit full screen menu

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -481,6 +481,7 @@ object AppComponents {
         showDivider: Boolean = false,
         enabled: Boolean = true,
         trailingIcon: (@Composable () -> Unit)? = null,
+        contentPadding: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
     ) {
         DropdownMenuItem(
             text = text,
@@ -497,7 +498,7 @@ object AppComponents {
             },
             trailingIcon = trailingIcon,
             colors = menuItemColors(),
-            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+            contentPadding = contentPadding,
         )
         if (showDivider) {
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NativeMenuBar.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NativeMenuBar.kt
@@ -25,23 +25,13 @@ import java.net.URI
 
 /**
  * Native menu bar handler that provides OS-specific menu implementations.
- * - macOS: Uses system menu bar at the top of screen
- * - Windows/Linux: Uses AWT MenuBar with native look and feel
+ * - macOS: Uses system/native menu bar at the top of screen
+ * - Windows/Linux: Native AWT menu bar is disabled (Compose UI handles actions)
  */
 object NativeMenuBar {
     private var updateSidebarMenuItem: ((Boolean) -> Unit)? = null
 
-    private fun menuLabel(key: String, vararg args: Any): String = sanitizeMenuLabelForPlatform(LocalizationManager.getString(key, *args))
-
-    private fun sanitizeMenuLabelForPlatform(text: String): String {
-        if (!Platform.isWindows) return text
-
-        // AWT menu rendering on Windows often lacks proper emoji fallback.
-        // Strip leading symbol emoji and variation selectors for menu labels.
-        return text
-            .replace("\uFE0F", "")
-            .replace(Regex("^[\\p{So}\\p{Cn}]+\\s*"), "")
-    }
+    private fun menuLabel(key: String, vararg args: Any): String = LocalizationManager.getString(key, *args)
 
     fun updateSidebarMenuLabel(isSidebarExpanded: Boolean) {
         updateSidebarMenuItem?.invoke(isSidebarExpanded)
@@ -72,7 +62,7 @@ object NativeMenuBar {
         onShowSettings: () -> Unit,
         onShowEventLog: () -> Unit,
         onCheckForUpdates: () -> Unit,
-        onEnterFullScreen: () -> Unit,
+        onToggleFullScreen: () -> Unit,
         onNavigateToSessions: () -> Unit,
         onNavigateToProjects: () -> Unit,
         onNavigateToDiscover: () -> Unit,
@@ -90,6 +80,7 @@ object NativeMenuBar {
         isPlansVisible: Boolean = true,
         isSkillsVisible: Boolean = true,
         isProjectsVisible: Boolean = true,
+        isFullScreen: Boolean = false,
         onShowSystemDiagnostics: () -> Unit = {},
         onNavigateToBookmarks: () -> Unit,
         onSupportAskimo: () -> Unit = {},
@@ -97,11 +88,11 @@ object NativeMenuBar {
     ) {
         val window = frameWindowScope.window
 
-        // Setup AWT menu bar for all platforms (includes Documentation)
-        setupAWTMenuBar(window, onShowAbout, onNewChat, onNewProject, onSearchInSessions, onShowSettings, onShowEventLog, onCheckForUpdates, onEnterFullScreen, onNavigateToSessions, onNavigateToProjects, onNavigateToDiscover, onToggleSidebar, onInvalidateCaches, onExportBackup, onImportBackup, onShowGettingStarted, onOpenTerminal, onClearPreferences, onClearAccountPreferences, onTogglePlans, onToggleSkills, onToggleProjects, isPlansVisible, isSkillsVisible, isProjectsVisible, onShowSystemDiagnostics, onNavigateToBookmarks, onSupportAskimo, onShareFeedback)
-
-        // On macOS, also register the About handler for the app menu
+        // Use native AWT menu bar only on macOS to avoid CJK glyph issues on some platforms.
         if (Platform.isMac) {
+            setupAWTMenuBar(window, onShowAbout, onNewChat, onNewProject, onSearchInSessions, onShowSettings, onShowEventLog, onCheckForUpdates, onToggleFullScreen, onNavigateToSessions, onNavigateToProjects, onNavigateToDiscover, onToggleSidebar, onInvalidateCaches, onExportBackup, onImportBackup, onShowGettingStarted, onOpenTerminal, onClearPreferences, onClearAccountPreferences, onTogglePlans, onToggleSkills, onToggleProjects, isPlansVisible, isSkillsVisible, isProjectsVisible, isFullScreen, onShowSystemDiagnostics, onNavigateToBookmarks, onSupportAskimo, onShareFeedback)
+
+            // Register About handler in the macOS application menu.
             setupMacAboutHandler(onShowAbout)
         }
     }
@@ -129,7 +120,7 @@ object NativeMenuBar {
         onShowSettings: () -> Unit,
         onShowEventLog: () -> Unit,
         onCheckForUpdates: () -> Unit,
-        onEnterFullScreen: () -> Unit,
+        onToggleFullScreen: () -> Unit,
         onNavigateToSessions: () -> Unit,
         onNavigateToProjects: () -> Unit,
         onNavigateToDiscover: () -> Unit,
@@ -147,6 +138,7 @@ object NativeMenuBar {
         isPlansVisible: Boolean,
         isSkillsVisible: Boolean,
         isProjectsVisible: Boolean,
+        isFullScreen: Boolean,
         onShowSystemDiagnostics: () -> Unit,
         onNavigateToBookmarks: () -> Unit,
         onSupportAskimo: () -> Unit,
@@ -155,10 +147,10 @@ object NativeMenuBar {
         if (window is Frame) {
             val menuBar = MenuBar()
 
-            val fileMenu = Menu(LocalizationManager.getString("menu.file"))
+            val fileMenu = Menu(menuLabel("menu.file"))
 
             val newChatItem = MenuItem(
-                LocalizationManager.getString("chat.new"),
+                menuLabel("chat.new"),
                 MenuShortcut(KeyEvent.VK_N),
             )
             newChatItem.addActionListener {
@@ -167,7 +159,7 @@ object NativeMenuBar {
             fileMenu.add(newChatItem)
 
             val newProjectItem = MenuItem(
-                LocalizationManager.getString("menu.new.project"),
+                menuLabel("menu.new.project"),
                 MenuShortcut(KeyEvent.VK_N, true), // Shift+Ctrl+N (or Shift+Cmd+N on Mac)
             )
             newProjectItem.addActionListener {
@@ -178,7 +170,7 @@ object NativeMenuBar {
             fileMenu.addSeparator()
 
             val searchSessionsItem = MenuItem(
-                LocalizationManager.getString("menu.search.sessions"),
+                menuLabel("menu.search.sessions"),
                 MenuShortcut(KeyEvent.VK_F, true), // Shift+Ctrl+F (or Shift+Cmd+F on Mac)
             )
             searchSessionsItem.addActionListener {
@@ -189,7 +181,7 @@ object NativeMenuBar {
             fileMenu.addSeparator()
 
             val exportBackupItem = MenuItem(
-                LocalizationManager.getString("menu.export.backup"),
+                menuLabel("menu.export.backup"),
                 MenuShortcut(KeyEvent.VK_E, true), // Shift+Ctrl+E (or Shift+Cmd+E on Mac)
             )
             exportBackupItem.addActionListener {
@@ -198,7 +190,7 @@ object NativeMenuBar {
             fileMenu.add(exportBackupItem)
 
             val importBackupItem = MenuItem(
-                LocalizationManager.getString("menu.import.backup"),
+                menuLabel("menu.import.backup"),
                 MenuShortcut(KeyEvent.VK_I, true), // Shift+Ctrl+I (or Shift+Cmd+I on Mac)
             )
             importBackupItem.addActionListener {
@@ -209,7 +201,7 @@ object NativeMenuBar {
             fileMenu.addSeparator()
 
             val invalidateCachesItem = MenuItem(
-                LocalizationManager.getString("menu.invalidate.caches"),
+                menuLabel("menu.invalidate.caches"),
             )
             invalidateCachesItem.addActionListener {
                 onInvalidateCaches()
@@ -217,7 +209,7 @@ object NativeMenuBar {
             fileMenu.add(invalidateCachesItem)
 
             val clearPreferencesItem = MenuItem(
-                LocalizationManager.getString("menu.clear.preferences"),
+                menuLabel("menu.clear.preferences"),
             )
             clearPreferencesItem.addActionListener {
                 onClearPreferences()
@@ -227,7 +219,7 @@ object NativeMenuBar {
             fileMenu.addSeparator()
 
             val settingsItem = MenuItem(
-                LocalizationManager.getString("settings.title"),
+                menuLabel("settings.title"),
                 MenuShortcut(KeyEvent.VK_COMMA),
             )
             settingsItem.addActionListener {
@@ -237,9 +229,9 @@ object NativeMenuBar {
 
             menuBar.add(fileMenu)
 
-            val viewMenu = Menu(LocalizationManager.getString("menu.view"))
+            val viewMenu = Menu(menuLabel("menu.view"))
 
-            val appearanceMenu = Menu(LocalizationManager.getString("menu.view.appearance"))
+            val appearanceMenu = Menu(menuLabel("menu.view.appearance"))
 
             val systemThemeItem = MenuItem("")
             val lightThemeItem = MenuItem("")
@@ -249,11 +241,11 @@ object NativeMenuBar {
             fun updateThemeMenuItems() {
                 val currentTheme = ThemePreferences.themeMode.value
                 systemThemeItem.label = (if (currentTheme == ThemeMode.SYSTEM) "✓ " else "  ") +
-                    LocalizationManager.getString("menu.view.appearance.system")
+                    menuLabel("menu.view.appearance.system")
                 lightThemeItem.label = (if (currentTheme == ThemeMode.LIGHT) "✓ " else "  ") +
-                    LocalizationManager.getString("menu.view.appearance.light")
+                    menuLabel("menu.view.appearance.light")
                 darkThemeItem.label = (if (currentTheme == ThemeMode.DARK) "✓ " else "  ") +
-                    LocalizationManager.getString("menu.view.appearance.dark")
+                    menuLabel("menu.view.appearance.dark")
             }
 
             // Initialize labels
@@ -284,7 +276,7 @@ object NativeMenuBar {
 
             // Discover — standalone menu item
             val discoverItemGo = MenuItem(
-                LocalizationManager.getString("menu.view.discover"),
+                menuLabel("menu.view.discover"),
                 MenuShortcut(KeyEvent.VK_D),
             )
             discoverItemGo.addActionListener { onNavigateToDiscover() }
@@ -294,7 +286,7 @@ object NativeMenuBar {
                 val plansToggleItem = MenuItem("")
                 val updatePlansMenuItemFunc: (Boolean) -> Unit = { visible ->
                     plansToggleItem.label = (if (visible) "✓ " else "  ") +
-                        LocalizationManager.getString("menu.view.plans")
+                        menuLabel("menu.view.plans")
                 }
                 updatePlansMenuItem = updatePlansMenuItemFunc
                 updatePlansMenuItemFunc(isPlansVisible)
@@ -306,7 +298,7 @@ object NativeMenuBar {
                 val skillsToggleItem = MenuItem("")
                 val updateSkillsMenuItemFunc: (Boolean) -> Unit = { visible ->
                     skillsToggleItem.label = (if (visible) "✓ " else "  ") +
-                        LocalizationManager.getString("menu.view.skills")
+                        menuLabel("menu.view.skills")
                 }
                 updateSkillsMenuItem = updateSkillsMenuItemFunc
                 updateSkillsMenuItemFunc(isSkillsVisible)
@@ -318,7 +310,7 @@ object NativeMenuBar {
                 val projectsToggleItem = MenuItem("")
                 val updateProjectsMenuItemFunc: (Boolean) -> Unit = { visible ->
                     projectsToggleItem.label = (if (visible) "✓ " else "  ") +
-                        LocalizationManager.getString("menu.view.projects")
+                        menuLabel("menu.view.projects")
                 }
                 updateProjectsMenuItem = updateProjectsMenuItemFunc
                 updateProjectsMenuItemFunc(isProjectsVisible)
@@ -332,9 +324,9 @@ object NativeMenuBar {
 
             val updateSidebarMenuItemFunc: (Boolean) -> Unit = { isSidebarExpanded ->
                 toggleSidebarItem.label = if (isSidebarExpanded) {
-                    LocalizationManager.getString("menu.view.hide.sidebar")
+                    menuLabel("menu.view.hide.sidebar")
                 } else {
-                    LocalizationManager.getString("menu.view.show.sidebar")
+                    menuLabel("menu.view.show.sidebar")
                 }
             }
 
@@ -348,18 +340,22 @@ object NativeMenuBar {
             viewMenu.add(toggleSidebarItem)
 
             val fullScreenItem = MenuItem(
-                LocalizationManager.getString("menu.view.fullscreen"),
+                if (isFullScreen) {
+                    menuLabel("menu.view.exit.fullscreen")
+                } else {
+                    menuLabel("menu.view.fullscreen")
+                },
                 MenuShortcut(KeyEvent.VK_F, true), // Ctrl+Cmd+F on Mac, Ctrl+F on others
             )
             fullScreenItem.addActionListener {
-                onEnterFullScreen()
+                onToggleFullScreen()
             }
             viewMenu.add(fullScreenItem)
 
             // Bookmarks — navigate to the global Bookmarks view
             viewMenu.addSeparator()
             val bookmarksItem = MenuItem(
-                LocalizationManager.getString("menu.view.bookmarks"),
+                menuLabel("menu.view.bookmarks"),
                 MenuShortcut(KeyEvent.VK_B, true), // Shift+Cmd+B on Mac, Shift+Ctrl+B on others
             )
             bookmarksItem.addActionListener { onNavigateToBookmarks() }
@@ -368,10 +364,10 @@ object NativeMenuBar {
             menuBar.add(viewMenu)
 
             // Terminal Menu
-            val terminalMenu = Menu(LocalizationManager.getString("menu.terminal"))
+            val terminalMenu = Menu(menuLabel("menu.terminal"))
 
             val newTerminalItem = MenuItem(
-                LocalizationManager.getString("menu.terminal.new"),
+                menuLabel("menu.terminal.new"),
                 MenuShortcut(KeyEvent.VK_T, true), // Shift+Ctrl+T (or Shift+Cmd+T on Mac)
             )
             newTerminalItem.addActionListener {

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=System
 menu.view.appearance.light=Light
 menu.view.appearance.dark=Dark
 menu.view.fullscreen=Enter Full Screen
+menu.view.exit.fullscreen=Exit Full Screen
 menu.view.bookmarks=View Bookmarks
 menu.terminal=Terminal
 menu.terminal.new=New Terminal

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=System
 menu.view.appearance.light=Hell
 menu.view.appearance.dark=Dunkel
 menu.view.fullscreen=Vollbildmodus aktivieren
+menu.view.exit.fullscreen=Vollbildmodus beenden
 menu.view.bookmarks=Lesezeichen anzeigen
 menu.terminal=Terminal
 menu.terminal.new=Neues Terminal

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=Sistema
 menu.view.appearance.light=Claro
 menu.view.appearance.dark=Oscuro
 menu.view.fullscreen=Entrar en pantalla completa
+menu.view.exit.fullscreen=Salir de pantalla completa
 menu.view.bookmarks=Ver marcadores
 menu.terminal=Terminal
 menu.terminal.new=Nuevo terminal

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=Système
 menu.view.appearance.light=Clair
 menu.view.appearance.dark=Sombre
 menu.view.fullscreen=Entrer en plein écran
+menu.view.exit.fullscreen=Quitter le plein écran
 menu.view.bookmarks=Voir les signets
 menu.terminal=Terminal
 menu.terminal.new=Nouveau terminal

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=システム
 menu.view.appearance.light=ライト
 menu.view.appearance.dark=ダーク
 menu.view.fullscreen=フルスクリーンにする
+menu.view.exit.fullscreen=フルスクリーンを終了
 menu.view.bookmarks=ブックマークを表示
 menu.terminal=ターミナル
 menu.terminal.new=新しいターミナル

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=시스템
 menu.view.appearance.light=라이트
 menu.view.appearance.dark=다크
 menu.view.fullscreen=전체 화면으로 전환
+menu.view.exit.fullscreen=전체 화면 종료
 menu.view.bookmarks=북마크 보기
 menu.terminal=터미널
 menu.terminal.new=새 터미널

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=Sistema
 menu.view.appearance.light=Claro
 menu.view.appearance.dark=Escuro
 menu.view.fullscreen=Entrar em tela cheia
+menu.view.exit.fullscreen=Sair da tela cheia
 menu.view.bookmarks=Ver favoritos
 menu.terminal=Terminal
 menu.terminal.new=Novo terminal

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=Hệ thống
 menu.view.appearance.light=Sáng
 menu.view.appearance.dark=Tối
 menu.view.fullscreen=Chuyển sang toàn màn hình
+menu.view.exit.fullscreen=Thoát toàn màn hình
 menu.view.bookmarks=Xem dấu trang
 menu.terminal=Terminal
 menu.terminal.new=Terminal mới

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=系统
 menu.view.appearance.light=浅色
 menu.view.appearance.dark=深色
 menu.view.fullscreen=进入全屏
+menu.view.exit.fullscreen=退出全屏
 menu.view.bookmarks=查看书签
 menu.terminal=终端
 menu.terminal.new=新建终端

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -32,6 +32,7 @@ menu.view.appearance.system=系統
 menu.view.appearance.light=淺色
 menu.view.appearance.dark=深色
 menu.view.fullscreen=進入全螢幕
+menu.view.exit.fullscreen=退出全螢幕
 menu.view.bookmarks=查看書籤
 menu.terminal=終端機
 menu.terminal.new=新增終端機

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -94,6 +94,7 @@ import io.askimo.desktop.settings.aboutDialog
 import io.askimo.desktop.settings.fileViewerDialog
 import io.askimo.desktop.settings.providerWizardDialog
 import io.askimo.desktop.settings.settingsViewWithSidebar
+import io.askimo.desktop.shell.composeTopMenuBar
 import io.askimo.desktop.shell.footerBar
 import io.askimo.desktop.shell.navigationSidebar
 import io.askimo.desktop.shell.telemetryPanel
@@ -325,6 +326,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
     var showTokenUsageCard by remember { mutableStateOf(ApplicationPreferences.getShowTokenUsageCard()) }
     var selectedProjectId by remember { mutableStateOf<String?>(null) }
     var sidebarWidthFraction by remember { mutableStateOf(ThemePreferences.getMainSidebarWidthFraction()) }
+    var isFullScreen by remember { mutableStateOf(windowState?.placement == WindowPlacement.Fullscreen) }
     var showQuitDialog by remember { mutableStateOf(false) }
     var showInvalidateCacheDialog by remember { mutableStateOf(false) }
     var showCacheDeletedDialog by remember { mutableStateOf(false) }
@@ -630,6 +632,16 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
             }
     }
 
+    // Watch for window placement changes to update full screen state
+    LaunchedEffect(windowState) {
+        windowState?.let { state ->
+            snapshotFlow { state.placement }
+                .collect { placement ->
+                    isFullScreen = (placement == WindowPlacement.Fullscreen)
+                }
+        }
+    }
+
     LaunchedEffect(preferredResponseAILocale, locale) {
         val localeString = preferredResponseAILocale
         val aiLocale = if (localeString.isNullOrBlank()) {
@@ -645,6 +657,109 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
         appContext.setLanguageDirective(aiLocale)
     }
 
+    val onShowAboutMenuAction = {
+        showAboutDialog = true
+    }
+    val onShowEventLogMenuAction = {
+        // Toggle between attached panel and detached window.
+        if (!showEventLogPanel && !showEventLogWindow) {
+            showEventLogPanel = true
+        } else if (showEventLogPanel) {
+            showEventLogPanel = false
+        }
+    }
+    val onNewChatMenuAction = {
+        sessionManager.clearActiveSession()
+        chatViewModel?.clearChat()
+        currentView = View.CHAT
+    }
+    val onNewProjectMenuAction = {
+        showNewProjectDialog = true
+    }
+    val onSearchInSessionsMenuAction = {
+        showGlobalSearchDialog = true
+    }
+    val onShowSettingsMenuAction = {
+        currentView = View.SETTINGS
+    }
+    val onCheckForUpdatesMenuAction = {
+        updateViewModel.checkForUpdates(silent = false)
+    }
+    val onToggleFullScreenMenuAction: () -> Unit = {
+        val state = windowState
+        if (state != null) {
+            state.placement = if (state.placement == WindowPlacement.Fullscreen) {
+                WindowPlacement.Floating
+            } else {
+                WindowPlacement.Fullscreen
+            }
+        }
+    }
+    val onNavigateToSessionsMenuAction = {
+        currentView = View.SESSIONS
+    }
+    val onNavigateToProjectsMenuAction = {
+        currentView = View.PROJECTS
+        Analytics.track(AnalyticsEvent.RAG_PANEL_OPENED)
+    }
+    val onNavigateToDiscoverMenuAction = {
+        currentView = View.DISCOVER
+    }
+    val onToggleSidebarMenuAction = {
+        isSidebarExpanded = !isSidebarExpanded
+        NativeMenuBar.updateSidebarMenuLabel(isSidebarExpanded)
+    }
+    val onInvalidateCachesMenuAction = {
+        showInvalidateCacheDialog = true
+    }
+    val onExportBackupMenuAction = {
+        exportBackup()
+    }
+    val onImportBackupMenuAction = {
+        importBackup()
+    }
+    val onShowGettingStartedMenuAction = {
+        showOnboardingWizard = true
+    }
+    val onOpenTerminalMenuAction = {
+        val opening = !showTerminalPanel
+        showTerminalPanel = opening
+        if (opening) Analytics.track(AnalyticsEvent.TERMINAL_OPENED, mapOf("source" to "toolbar"))
+    }
+    val onClearPreferencesMenuAction = {
+        showClearPreferencesDialog = true
+    }
+    val onTogglePlansMenuAction = {
+        showPlansInSidebar = !showPlansInSidebar
+        ApplicationPreferences.setShowPlansInSidebar(showPlansInSidebar)
+        NativeMenuBar.updatePlansMenuLabel(showPlansInSidebar)
+    }
+    val onToggleSkillsMenuAction = {
+        showSkillsInSidebar = !showSkillsInSidebar
+        ApplicationPreferences.setShowSkillsInSidebar(showSkillsInSidebar)
+        NativeMenuBar.updateSkillsMenuLabel(showSkillsInSidebar)
+    }
+    val onToggleProjectsMenuAction = {
+        showProjectsInSidebar = !showProjectsInSidebar
+        ApplicationPreferences.setShowProjectsInSidebar(showProjectsInSidebar)
+        NativeMenuBar.updateProjectsMenuLabel(showProjectsInSidebar)
+    }
+    val onShowSystemDiagnosticsMenuAction = {
+        showSystemDiagnosticsDialog = true
+    }
+    val onNavigateToBookmarksMenuAction = {
+        currentView = View.BOOKMARKS
+    }
+    val onSupportAskimoMenuAction = {
+        starPromptOpenedFromMenu = true
+        showStarPromptDialog = true
+    }
+    val onShareFeedbackMenuAction = {
+        feedbackSentiment = "direct"
+        feedbackOpenedFromMenu = true
+        showFeedbackPromptDialog = true
+    }
+
     // React to locale changes - update menu bar and language settings
     LaunchedEffect(locale, frameWindowScope) {
         LocalizationManager.setLocale(locale)
@@ -652,106 +767,35 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
         frameWindowScope?.let { scope ->
             NativeMenuBar.setup(
                 frameWindowScope = scope,
-                onShowAbout = { showAboutDialog = true },
-                onShowEventLog = {
-                    // Toggle between attached panel and detached window
-                    if (!showEventLogPanel && !showEventLogWindow) {
-                        showEventLogPanel = true // Default to attached
-                    } else if (showEventLogPanel) {
-                        showEventLogPanel = false // Close if already open
-                    } else {
-                        // If detached window is open, bring it to focus (handled by window manager)
-                    }
-                },
-                onNewChat = {
-                    sessionManager.clearActiveSession()
-                    chatViewModel?.clearChat()
-                    currentView = View.CHAT
-                },
-                onNewProject = {
-                    showNewProjectDialog = true
-                },
-                onSearchInSessions = {
-                    showGlobalSearchDialog = true
-                },
-                onShowSettings = {
-                    currentView = View.SETTINGS
-                },
-                onCheckForUpdates = {
-                    updateViewModel.checkForUpdates(silent = false)
-                },
-                onEnterFullScreen = {
-                    windowState?.let { state ->
-                        state.placement = if (state.placement == WindowPlacement.Fullscreen) {
-                            WindowPlacement.Floating
-                        } else {
-                            WindowPlacement.Fullscreen
-                        }
-                    }
-                },
-                onNavigateToSessions = {
-                    currentView = View.SESSIONS
-                },
-                onNavigateToProjects = {
-                    currentView = View.PROJECTS
-                    Analytics.track(AnalyticsEvent.RAG_PANEL_OPENED)
-                },
-                onNavigateToDiscover = {
-                    currentView = View.DISCOVER
-                },
-                onToggleSidebar = {
-                    isSidebarExpanded = !isSidebarExpanded
-                    NativeMenuBar.updateSidebarMenuLabel(isSidebarExpanded)
-                },
-                onInvalidateCaches = {
-                    showInvalidateCacheDialog = true
-                },
-                onExportBackup = {
-                    exportBackup()
-                },
-                onImportBackup = {
-                    importBackup()
-                },
-                onShowGettingStarted = {
-                    showOnboardingWizard = true
-                },
-                onOpenTerminal = {
-                    val opening = !showTerminalPanel
-                    showTerminalPanel = opening
-                    if (opening) Analytics.track(AnalyticsEvent.TERMINAL_OPENED, mapOf("source" to "toolbar"))
-                },
-                onClearPreferences = {
-                    showClearPreferencesDialog = true
-                },
-                onTogglePlans = {
-                    showPlansInSidebar = !showPlansInSidebar
-                    ApplicationPreferences.setShowPlansInSidebar(showPlansInSidebar)
-                    NativeMenuBar.updatePlansMenuLabel(showPlansInSidebar)
-                },
-                onToggleSkills = {
-                    showSkillsInSidebar = !showSkillsInSidebar
-                    ApplicationPreferences.setShowSkillsInSidebar(showSkillsInSidebar)
-                    NativeMenuBar.updateSkillsMenuLabel(showSkillsInSidebar)
-                },
-                onToggleProjects = {
-                    showProjectsInSidebar = !showProjectsInSidebar
-                    ApplicationPreferences.setShowProjectsInSidebar(showProjectsInSidebar)
-                    NativeMenuBar.updateProjectsMenuLabel(showProjectsInSidebar)
-                },
+                onShowAbout = onShowAboutMenuAction,
+                onShowEventLog = onShowEventLogMenuAction,
+                onNewChat = onNewChatMenuAction,
+                onNewProject = onNewProjectMenuAction,
+                onSearchInSessions = onSearchInSessionsMenuAction,
+                onShowSettings = onShowSettingsMenuAction,
+                onCheckForUpdates = onCheckForUpdatesMenuAction,
+                onToggleFullScreen = onToggleFullScreenMenuAction,
+                onNavigateToSessions = onNavigateToSessionsMenuAction,
+                onNavigateToProjects = onNavigateToProjectsMenuAction,
+                onNavigateToDiscover = onNavigateToDiscoverMenuAction,
+                onToggleSidebar = onToggleSidebarMenuAction,
+                onInvalidateCaches = onInvalidateCachesMenuAction,
+                onExportBackup = onExportBackupMenuAction,
+                onImportBackup = onImportBackupMenuAction,
+                onShowGettingStarted = onShowGettingStartedMenuAction,
+                onOpenTerminal = onOpenTerminalMenuAction,
+                onClearPreferences = onClearPreferencesMenuAction,
+                onTogglePlans = onTogglePlansMenuAction,
+                onToggleSkills = onToggleSkillsMenuAction,
+                onToggleProjects = onToggleProjectsMenuAction,
                 isPlansVisible = showPlansInSidebar,
                 isSkillsVisible = showSkillsInSidebar,
                 isProjectsVisible = showProjectsInSidebar,
-                onShowSystemDiagnostics = { showSystemDiagnosticsDialog = true },
-                onNavigateToBookmarks = { currentView = View.BOOKMARKS },
-                onSupportAskimo = {
-                    starPromptOpenedFromMenu = true
-                    showStarPromptDialog = true
-                },
-                onShareFeedback = {
-                    feedbackSentiment = "direct"
-                    feedbackOpenedFromMenu = true
-                    showFeedbackPromptDialog = true
-                },
+                isFullScreen = isFullScreen,
+                onShowSystemDiagnostics = onShowSystemDiagnosticsMenuAction,
+                onNavigateToBookmarks = onNavigateToBookmarksMenuAction,
+                onSupportAskimo = onSupportAskimoMenuAction,
+                onShareFeedback = onShareFeedbackMenuAction,
             )
         }
     }
@@ -825,6 +869,39 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                     },
                                 ),
                         ) {
+                            if (Platform.isWindows || Platform.isLinux) {
+                                composeTopMenuBar(
+                                    onShowAbout = onShowAboutMenuAction,
+                                    onNewChat = onNewChatMenuAction,
+                                    onNewProject = onNewProjectMenuAction,
+                                    onSearchInSessions = onSearchInSessionsMenuAction,
+                                    onShowSettings = onShowSettingsMenuAction,
+                                    onShowEventLog = onShowEventLogMenuAction,
+                                    onCheckForUpdates = onCheckForUpdatesMenuAction,
+                                    onToggleFullScreen = onToggleFullScreenMenuAction,
+                                    onNavigateToDiscover = onNavigateToDiscoverMenuAction,
+                                    onToggleSidebar = onToggleSidebarMenuAction,
+                                    onInvalidateCaches = onInvalidateCachesMenuAction,
+                                    onExportBackup = onExportBackupMenuAction,
+                                    onImportBackup = onImportBackupMenuAction,
+                                    onShowGettingStarted = onShowGettingStartedMenuAction,
+                                    onOpenTerminal = onOpenTerminalMenuAction,
+                                    onClearPreferences = onClearPreferencesMenuAction,
+                                    onTogglePlans = onTogglePlansMenuAction,
+                                    onToggleSkills = onToggleSkillsMenuAction,
+                                    onToggleProjects = onToggleProjectsMenuAction,
+                                    isPlansVisible = showPlansInSidebar,
+                                    isSkillsVisible = showSkillsInSidebar,
+                                    isProjectsVisible = showProjectsInSidebar,
+                                    isFullScreen = isFullScreen,
+                                    onShowSystemDiagnostics = onShowSystemDiagnosticsMenuAction,
+                                    onNavigateToBookmarks = onNavigateToBookmarksMenuAction,
+                                    onSupportAskimo = onSupportAskimoMenuAction,
+                                    onShareFeedback = onShareFeedbackMenuAction,
+                                    isSidebarExpanded = isSidebarExpanded,
+                                )
+                            }
+
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/ComposeTopMenuBar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/ComposeTopMenuBar.kt
@@ -1,0 +1,363 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.desktop.shell
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import io.askimo.core.AppConstants.DOMAIN
+import io.askimo.core.config.AppConfig
+import io.askimo.core.config.FeatureFlags
+import io.askimo.core.util.AskimoHome
+import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppTextStyles
+import io.askimo.ui.common.theme.Spacing
+import io.askimo.ui.common.theme.ThemeMode
+import io.askimo.ui.common.theme.ThemePreferences
+import io.askimo.ui.common.ui.clickableCard
+import java.awt.Desktop
+import java.net.URI
+
+private enum class TopMenu {
+    FILE,
+    VIEW,
+    TERMINAL,
+    HELP,
+}
+
+@Composable
+fun composeTopMenuBar(
+    onShowAbout: () -> Unit,
+    onNewChat: () -> Unit,
+    onNewProject: () -> Unit,
+    onSearchInSessions: () -> Unit,
+    onShowSettings: () -> Unit,
+    onShowEventLog: () -> Unit,
+    onCheckForUpdates: () -> Unit,
+    onToggleFullScreen: () -> Unit,
+    onNavigateToDiscover: () -> Unit,
+    onToggleSidebar: () -> Unit,
+    onInvalidateCaches: () -> Unit,
+    onExportBackup: () -> Unit,
+    onImportBackup: () -> Unit,
+    onShowGettingStarted: () -> Unit,
+    onOpenTerminal: () -> Unit,
+    onClearPreferences: () -> Unit,
+    onClearAccountPreferences: (() -> Unit)? = null,
+    onTogglePlans: (() -> Unit)?,
+    onToggleSkills: (() -> Unit)?,
+    onToggleProjects: (() -> Unit)?,
+    isPlansVisible: Boolean,
+    isSkillsVisible: Boolean,
+    isProjectsVisible: Boolean,
+    isFullScreen: Boolean,
+    onShowSystemDiagnostics: () -> Unit,
+    onNavigateToBookmarks: () -> Unit,
+    onSupportAskimo: () -> Unit,
+    onShareFeedback: () -> Unit,
+    isSidebarExpanded: Boolean,
+) {
+    var expandedMenu by remember { mutableStateOf<TopMenu?>(null) }
+
+    Column(modifier = Modifier.fillMaxWidth().background(AppComponents.sidebarSurfaceColor())) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            menuAnchor(
+                label = stringResource("menu.file"),
+                expanded = expandedMenu == TopMenu.FILE,
+                onExpandToggle = { expandedMenu = if (expandedMenu == TopMenu.FILE) null else TopMenu.FILE },
+                onDismiss = { expandedMenu = null },
+            ) {
+                menuAction("chat.new") {
+                    expandedMenu = null
+                    onNewChat()
+                }
+                menuAction("menu.new.project") {
+                    expandedMenu = null
+                    onNewProject()
+                }
+                menuDivider()
+                menuAction("menu.search.sessions") {
+                    expandedMenu = null
+                    onSearchInSessions()
+                }
+                menuDivider()
+                menuAction("menu.export.backup") {
+                    expandedMenu = null
+                    onExportBackup()
+                }
+                menuAction("menu.import.backup") {
+                    expandedMenu = null
+                    onImportBackup()
+                }
+                menuDivider()
+                menuAction("menu.invalidate.caches") {
+                    expandedMenu = null
+                    onInvalidateCaches()
+                }
+                menuAction("menu.clear.preferences") {
+                    expandedMenu = null
+                    onClearPreferences()
+                }
+                menuDivider()
+                menuAction("settings.title") {
+                    expandedMenu = null
+                    onShowSettings()
+                }
+            }
+
+            menuAnchor(
+                label = stringResource("menu.view"),
+                expanded = expandedMenu == TopMenu.VIEW,
+                onExpandToggle = { expandedMenu = if (expandedMenu == TopMenu.VIEW) null else TopMenu.VIEW },
+                onDismiss = { expandedMenu = null },
+            ) {
+                val currentTheme = ThemePreferences.themeMode.value
+                menuToggleAction("menu.view.appearance.system", currentTheme == ThemeMode.SYSTEM) {
+                    expandedMenu = null
+                    ThemePreferences.setThemeMode(ThemeMode.SYSTEM)
+                }
+                menuToggleAction("menu.view.appearance.light", currentTheme == ThemeMode.LIGHT) {
+                    expandedMenu = null
+                    ThemePreferences.setThemeMode(ThemeMode.LIGHT)
+                }
+                menuToggleAction("menu.view.appearance.dark", currentTheme == ThemeMode.DARK) {
+                    expandedMenu = null
+                    ThemePreferences.setThemeMode(ThemeMode.DARK)
+                }
+                menuDivider()
+                menuAction("menu.view.discover") {
+                    expandedMenu = null
+                    onNavigateToDiscover()
+                }
+                if (FeatureFlags.plansEnabled) {
+                    menuToggleAction("menu.view.plans", isPlansVisible) {
+                        expandedMenu = null
+                        onTogglePlans?.invoke()
+                    }
+                }
+                if (FeatureFlags.skillsEnabled) {
+                    menuToggleAction("menu.view.skills", isSkillsVisible) {
+                        expandedMenu = null
+                        onToggleSkills?.invoke()
+                    }
+                }
+                if (FeatureFlags.projectsEnabled) {
+                    menuToggleAction("menu.view.projects", isProjectsVisible) {
+                        expandedMenu = null
+                        onToggleProjects?.invoke()
+                    }
+                }
+                menuDivider()
+                menuAction(if (isSidebarExpanded) "menu.view.hide.sidebar" else "menu.view.show.sidebar") {
+                    expandedMenu = null
+                    onToggleSidebar()
+                }
+                menuAction(if (isFullScreen) "menu.view.exit.fullscreen" else "menu.view.fullscreen") {
+                    expandedMenu = null
+                    onToggleFullScreen()
+                }
+                menuDivider()
+                menuAction("menu.view.bookmarks") {
+                    expandedMenu = null
+                    onNavigateToBookmarks()
+                }
+            }
+
+            menuAnchor(
+                label = stringResource("menu.terminal"),
+                expanded = expandedMenu == TopMenu.TERMINAL,
+                onExpandToggle = { expandedMenu = if (expandedMenu == TopMenu.TERMINAL) null else TopMenu.TERMINAL },
+                onDismiss = { expandedMenu = null },
+            ) {
+                menuAction("menu.terminal.new") {
+                    expandedMenu = null
+                    onOpenTerminal()
+                }
+            }
+
+            menuAnchor(
+                label = stringResource("menu.help"),
+                expanded = expandedMenu == TopMenu.HELP,
+                onExpandToggle = { expandedMenu = if (expandedMenu == TopMenu.HELP) null else TopMenu.HELP },
+                onDismiss = { expandedMenu = null },
+            ) {
+                menuAction("menu.documentation") {
+                    expandedMenu = null
+                    runCatching { if (Desktop.isDesktopSupported()) Desktop.getDesktop().browse(URI("https://$DOMAIN/docs/")) }
+                }
+                menuAction("menu.help.gettingstarted") {
+                    expandedMenu = null
+                    onShowGettingStarted()
+                }
+                menuAction("system.share.feedback") {
+                    expandedMenu = null
+                    onShareFeedback()
+                }
+                menuDivider()
+                menuAction("menu.help.release.notes") {
+                    expandedMenu = null
+                    runCatching { if (Desktop.isDesktopSupported()) Desktop.getDesktop().browse(URI("https://$DOMAIN/docs/changelogs/")) }
+                }
+                menuAction("menu.help.discord") {
+                    expandedMenu = null
+                    runCatching { if (Desktop.isDesktopSupported()) Desktop.getDesktop().browse(URI("https://discord.gg/eXSBR4fNmm")) }
+                }
+                menuAction("menu.help.support.askimo") {
+                    expandedMenu = null
+                    onSupportAskimo()
+                }
+                menuDivider()
+                menuAction("menu.help.check.updates") {
+                    expandedMenu = null
+                    onCheckForUpdates()
+                }
+                menuAction("menu.eventlog") {
+                    expandedMenu = null
+                    onShowEventLog()
+                }
+                menuAction("menu.help.model.capabilities") {
+                    expandedMenu = null
+                    runCatching {
+                        val file = AskimoHome.base().resolve("model-capabilities-cache.json").toFile()
+                        if (file.exists() && Desktop.isDesktopSupported()) Desktop.getDesktop().open(file)
+                    }
+                }
+                menuAction("menu.help.diagnostics") {
+                    expandedMenu = null
+                    onShowSystemDiagnostics()
+                }
+                val devConfig = AppConfig.developer
+                if (devConfig.enabled && devConfig.active && onClearAccountPreferences != null) {
+                    menuAction("menu.dev.clear.account.preferences") {
+                        expandedMenu = null
+                        onClearAccountPreferences()
+                    }
+                }
+                menuDivider()
+                menuAction("menu.about") {
+                    expandedMenu = null
+                    onShowAbout()
+                }
+            }
+        }
+        HorizontalDivider()
+    }
+}
+
+/**
+ * A top-menu anchor label that opens a [Popup] positioned pixel-exactly at the bottom
+ * of the label. Using [Popup] (not [DropdownMenu]) gives us full control over placement
+ * and avoids the gap that Material3's internal 8 dp top padding introduces.
+ */
+@Composable
+private fun menuAnchor(
+    label: String,
+    expanded: Boolean,
+    onExpandToggle: () -> Unit,
+    onDismiss: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    var anchorHeightPx by remember { mutableStateOf(0) }
+
+    Box {
+        Text(
+            text = label,
+            style = AppTextStyles.body,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier
+                .pointerHoverIcon(PointerIcon.Hand)
+                .clickableCard { onExpandToggle() }
+                // Measure height so the popup can be offset to exactly the bottom edge.
+                .onSizeChanged { anchorHeightPx = it.height }
+                .padding(horizontal = 8.dp, vertical = 6.dp),
+        )
+
+        if (expanded) {
+            // Popup escapes the parent's clipping bounds and renders as a real overlay.
+            // alignment = TopStart + offset(0, anchorHeight) puts the top-left corner of
+            // the popup panel flush against the bottom edge of the anchor label.
+            Popup(
+                alignment = Alignment.TopStart,
+                offset = IntOffset(x = 0, y = anchorHeightPx),
+                onDismissRequest = onDismiss,
+                properties = PopupProperties(focusable = true),
+            ) {
+                val borderColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                Surface(
+                    shape = RoundedCornerShape(bottomStart = 4.dp, bottomEnd = 4.dp, topStart = 0.dp, topEnd = 4.dp),
+                    color = MaterialTheme.colorScheme.surface,
+                    tonalElevation = 3.dp,
+                    modifier = Modifier
+                        .shadow(8.dp, RoundedCornerShape(4.dp))
+                        .border(1.dp, borderColor, RoundedCornerShape(4.dp)),
+                ) {
+                    Column(modifier = Modifier.width(IntrinsicSize.Max)) { content() }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun menuAction(key: String, onClick: () -> Unit) {
+    DropdownMenuItem(
+        text = { Text(stringResource(key)) },
+        onClick = onClick,
+        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 4.dp),
+        colors = AppComponents.menuItemColors(),
+    )
+}
+
+@Composable
+private fun menuToggleAction(key: String, isSelected: Boolean, onClick: () -> Unit) {
+    AppComponents.themedDropdownMenuItem(
+        text = { Text(stringResource(key)) },
+        onClick = onClick,
+        isSelected = isSelected,
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+    )
+}
+
+@Composable
+private fun menuDivider() {
+    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+}


### PR DESCRIPTION
- Implement Compose-based top menu bar to replace the old native menu bar
- Add exit fullscreen menu item and its handler logic
- Update i18n resources for exit fullscreen in all supported languages
- Refactor menu label helper and padding configuration for consistency