### PR TITLE
feat(config): Add support for XAI providers and migrate config files

### DIFF
--- a/cli/src/main/kotlin/io/askimo/cli/graal/AskimoFeature.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/graal/AskimoFeature.kt
@@ -62,7 +62,6 @@ class AskimoFeature : Feature {
             HasApiKey::class.java,
             HasBaseUrl::class.java,
             SettingField::class.java,
-            OpenAiSettings::class.java,
             AnthropicSettings::class.java,
             GeminiSettings::class.java,
             OpenAiSettings::class.java,

--- a/cli/src/main/kotlin/io/askimo/cli/graal/AskimoFeature.kt
+++ b/cli/src/main/kotlin/io/askimo/cli/graal/AskimoFeature.kt
@@ -26,6 +26,7 @@ import io.askimo.core.providers.anthropic.AnthropicSettings
 import io.askimo.core.providers.gemini.GeminiSettings
 import io.askimo.core.providers.openai.OpenAiSettings
 import io.askimo.core.providers.openaicompatible.OpenAiCompatibleSettings
+import io.askimo.core.providers.xai.XAiSettings
 import io.askimo.tools.fs.LocalFsTools
 import io.askimo.tools.git.GitTools
 import org.graalvm.nativeimage.hosted.Feature
@@ -65,6 +66,7 @@ class AskimoFeature : Feature {
             AnthropicSettings::class.java,
             GeminiSettings::class.java,
             OpenAiSettings::class.java,
+            XAiSettings::class.java,
             OpenAiCompatibleSettings::class.java,
             NoopProviderSettings::class.java,
         )

--- a/cli/src/main/resources/META-INF/native-image/io.askimo/cli/reachability-metadata.json
+++ b/cli/src/main/resources/META-INF/native-image/io.askimo/cli/reachability-metadata.json
@@ -5669,7 +5669,38 @@
       "parameterTypes": [ ]
     } ]
   }, {
-    "type": "io.askimo.core.providers.anthropic.AnthropicSettings"
+    "type": "io.askimo.core.providers.anthropic.AnthropicSettings",
+    "methods": [ {
+      "name": "getApiKey",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getBaseUrl",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getDefaultModel",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getEmbeddingModel",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getImageModel",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getMaxTokens",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getThinkingBudgetTokens",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getThinkingMaxTokens",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getUtilityModel",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getVisionModel",
+      "parameterTypes": [ ]
+    } ]
   }, {
     "type": "io.askimo.core.providers.gemini.GeminiModelFactoryTest",
     "allDeclaredFields": true,
@@ -5911,7 +5942,33 @@
       "parameterTypes": [ ]
     } ]
   }, {
-    "type": "io.askimo.core.providers.xai.XAiSettings"
+    "type": "io.askimo.core.providers.xai.XAiSettings",
+    "methods": [ {
+      "name": "getApiKey",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getBaseUrl",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getDefaultModel",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getEmbeddingModel",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getImageModel",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getUtilityModel",
+      "parameterTypes": [ ]
+    }, {
+      "name": "getVisionModel",
+      "parameterTypes": [ ]
+    } ]
+  }, {
+    "type": "io.askimo.core.providers.xai.XAiSettings$$serializer"
+  }, {
+    "type": "io.askimo.core.providers.xai.XAiSettings$Companion"
   }, {
     "type": "io.askimo.core.recipes.DefaultRecipeInitializerTest",
     "allDeclaredFields": true,

--- a/cli/src/test/kotlin/io/askimo/core/config/AppConfigTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/config/AppConfigTest.kt
@@ -7,7 +7,11 @@ package io.askimo.core.config
 import io.askimo.core.context.AppContextParams
 import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ProviderInstance
+import io.askimo.core.providers.anthropic.AnthropicSettings
 import io.askimo.core.providers.openai.OpenAiSettings
+import io.askimo.core.providers.openaicompatible.OpenAiCompatibleSettings
+import io.askimo.core.providers.openaicompatible.OpenAiCompatibleTemplate
+import io.askimo.core.providers.xai.XAiSettings
 import io.askimo.core.util.AskimoHome
 import io.askimo.test.extensions.AskimoTestHome
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -458,28 +462,59 @@ class AppConfigTest {
 
     @Test
     fun `saveContext overwrites a previously saved context`() {
-        val openAiInstance = ProviderInstance.create(
-            displayName = "OpenAI",
-            providerType = ModelProvider.OPENAI,
-            settings = OpenAiSettings(defaultModel = "gpt-4o"),
+        val xaiInstance = ProviderInstance.create(
+            displayName = "xAI",
+            providerType = ModelProvider.XAI,
+            // Fill all constructor args to ensure agent captures the full reflective signature.
+            settings = XAiSettings(
+                baseUrl = "https://api.x.ai/v1",
+                apiKey = "xai-test-key",
+                defaultModel = "grok-4",
+                utilityModel = "grok-4-fast",
+                visionModel = "grok-vision-beta",
+                imageModel = "grok-image-beta",
+                embeddingModel = "grok-embed-beta",
+            ),
         )
         val firstParams = AppContextParams(
-            currentInstanceId = openAiInstance.id,
-            providerInstances = mutableListOf(openAiInstance),
+            currentInstanceId = xaiInstance.id,
+            providerInstances = mutableListOf(xaiInstance),
         )
         AppConfig.saveContext(firstParams)
-        assertEquals(ModelProvider.OPENAI, AppConfig.context.activeProviderType)
+        assertEquals(ModelProvider.XAI, AppConfig.context.activeProviderType)
 
-        val geminiInstance = ProviderInstance.create(
-            displayName = "Gemini",
-            providerType = ModelProvider.GEMINI,
+        val anthropicInstance = ProviderInstance.create(
+            displayName = "Anthropic",
+            providerType = ModelProvider.ANTHROPIC,
+            settings = AnthropicSettings(defaultModel = "claude-sonnet-4-20250514"),
         )
         val secondParams = AppContextParams(
-            currentInstanceId = geminiInstance.id,
-            providerInstances = mutableListOf(geminiInstance),
+            currentInstanceId = anthropicInstance.id,
+            providerInstances = mutableListOf(anthropicInstance),
         )
         AppConfig.saveContext(secondParams)
+        assertEquals(ModelProvider.ANTHROPIC, AppConfig.context.activeProviderType)
 
-        assertEquals(ModelProvider.GEMINI, AppConfig.context.activeProviderType)
+        val ollamaSettings = OpenAiCompatibleSettings(
+            baseUrl = OpenAiCompatibleTemplate.OLLAMA.baseUrl,
+            defaultModel = "llama3.1",
+            apiMode = OpenAiCompatibleTemplate.OLLAMA.apiMode,
+            httpVersion = OpenAiCompatibleTemplate.OLLAMA.httpVersion,
+            isTemplate = true,
+            templateName = OpenAiCompatibleTemplate.OLLAMA.name,
+        )
+        val ollamaInstance = ProviderInstance.create(
+            displayName = "Ollama",
+            providerType = ModelProvider.OPENAI_COMPATIBLE,
+            settings = ollamaSettings,
+        )
+        val thirdParams = AppContextParams(
+            currentInstanceId = ollamaInstance.id,
+            providerInstances = mutableListOf(ollamaInstance),
+        )
+        AppConfig.saveContext(thirdParams)
+
+        assertEquals(ModelProvider.OPENAI_COMPATIBLE, AppConfig.context.activeProviderType)
+        assertEquals("llama3.1", AppConfig.context.activeInstance?.settings?.defaultModel)
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/config/AppConfig.kt
@@ -714,8 +714,40 @@ object AppConfig {
         val path = resolveOrCreateConfigPath()
         return if (path != null && path.isRegularFile()) {
             val raw = Files.readString(path)
+            // ── One-time migration for removed local provider enums ──────────────────────────
+            // 1) If a legacy provider instance still has template_name: null, set the matching
+            //    OpenAI-compatible template so the UI keeps the right preset.
+            // 2) Always migrate legacy provider_type values to OPENAI_COMPATIBLE.
+            val legacyWithNullTemplatePattern = Regex(
+                """(?ms)(-\s+id:.*?provider_type\s*:\s*"?)(DOCKER|LMSTUDIO|OLLAMA|LOCALAI)("?.*?template_name\s*:\s*)(null|~|""|'')(\s*(?:\n|$))""",
+            )
+            val withTemplateNames = legacyWithNullTemplatePattern.replace(raw) { m ->
+                val legacyType = m.groupValues[2]
+                val templateName = when (legacyType) {
+                    "DOCKER_AI" -> "DOCKER_AI"
+                    "LMSTUDIO" -> "LMSTUDIO"
+                    "OLLAMA" -> "OLLAMA"
+                    "LOCALAI" -> "LOCALAI"
+                    else -> ""
+                }
+                "${m.groupValues[1]}$legacyType${m.groupValues[3]}$templateName${m.groupValues[5]}"
+            }
+
+            val legacyTypePattern = Regex("""(provider_type\s*:\s*"?)(DOCKER_AI|LMSTUDIO|OLLAMA|LOCALAI)("?)""")
+            val migrated = legacyTypePattern.replace(withTemplateNames) { m ->
+                "${m.groupValues[1]}OPENAI_COMPATIBLE${m.groupValues[3]}"
+            }
+
+            if (migrated != raw) {
+                log.info("Migrated legacy provider instances (provider_type and template_name)")
+                try {
+                    Files.writeString(path, migrated)
+                } catch (e: Exception) {
+                    log.displayError("Failed to write migrated config", e)
+                }
+            }
             try {
-                val loaded = mapper.readValue<AppConfigData>(raw)
+                val loaded = mapper.readValue<AppConfigData>(migrated)
                 loaded.copy(memory = normalizeMemoryConfig(loaded.memory))
             } catch (e: Exception) {
                 log.displayError("Config parse failed at $path ", e)


### PR DESCRIPTION
- Enables integration with XAI provider settings and metadata.
- Automatically migrates legacy configuration entries to use OPENAI_COMPATIBLE provider type.
- Ensures configuration compatibility across provider updates.