### PR TITLE
feat(tools): Allow selective tool enablement per instance

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -1089,7 +1089,7 @@ private fun toolsIndicatorButton(
         mcpServers = withContext(Dispatchers.IO) {
             // Load global MCP servers with their tools
             globalMcpService?.getInstances()?.filter { it.enabled }?.forEach { instance ->
-                val tools = globalMcpService.listTools(instance.id)
+                val tools = globalMcpService.listActiveTools(instance.id)
                     .getOrElse { e ->
                         log.error("Error loading tools for global server ${instance.name}", e)
                         EventBus.emit(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpToolsDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpToolsDialog.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,6 +41,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
@@ -340,7 +342,9 @@ fun mcpToolsDialog(
                 } else {
                     filteredTools.forEach { tool ->
                         Card(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .alpha(if (tool.enabled) 1f else 0.5f),
                             colors = CardDefaults.cardColors(
                                 containerColor = MaterialTheme.colorScheme.surfaceVariant,
                             ),
@@ -351,11 +355,39 @@ fun mcpToolsDialog(
                                     .padding(Spacing.medium),
                                 verticalArrangement = Arrangement.spacedBy(Spacing.small),
                             ) {
-                                SelectionContainer {
-                                    Text(
-                                        text = tool.specification.name(),
-                                        style = AppTextStyles.sectionTitle,
-                                    )
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    SelectionContainer {
+                                        Text(
+                                            text = tool.specification.name(),
+                                            style = AppTextStyles.sectionTitle,
+                                        )
+                                    }
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+                                    ) {
+                                        Text(
+                                            text = stringResource("mcp.tool.enabled.label"),
+                                            style = AppTextStyles.caption,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                        Switch(
+                                            checked = tool.enabled,
+                                            onCheckedChange = { enabled ->
+                                                // Reflect change locally so the UI updates instantly
+                                                tools = tools?.map { t ->
+                                                    if (t.specification.name() == tool.specification.name()) t.copy(enabled = enabled) else t
+                                                }
+                                                scope.launch(Dispatchers.IO) {
+                                                    mcpInstanceService.setToolEnabled(instance.id, tool.specification.name(), enabled)
+                                                }
+                                            },
+                                        )
+                                    }
                                 }
                                 tool.specification.description()?.let { desc ->
                                     SelectionContainer {

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1380,6 +1380,7 @@ mcp.tool.approval.require_approval=Require approval
 mcp.tool.approval.default=Auto
 mcp.tool.approval.default.hint=Runs automatically. Write-like categories (file write, execute, git, messaging) require approval by default.
 mcp.tool.approval.require_approval.hint=Always pauses and asks for your confirmation before the AI executes this tool.
+mcp.tool.enabled.label=Enabled
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Available Tools - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1385,6 +1385,7 @@ mcp.tool.approval.require_approval=Freigabe erforderlich
 mcp.tool.approval.default=Automatisch
 mcp.tool.approval.default.hint=Läuft automatisch. Schreibähnliche Kategorien (Datei schreiben, Ausführen, Git, Messaging) erfordern standardmäßig eine Freigabe.
 mcp.tool.approval.require_approval.hint=Hält immer an und bittet um Ihre Bestätigung, bevor die KI dieses Tool ausführt.
+mcp.tool.enabled.label=Aktiviert
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Verfügbare Tools - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1385,6 +1385,7 @@ mcp.tool.approval.require_approval=Requerir aprobación
 mcp.tool.approval.default=Automatique
 mcp.tool.approval.default.hint=Se ejecuta automáticamente. Las categorías de escritura (escritura de archivos, ejecución, git, mensajería) requieren aprobación por defecto.
 mcp.tool.approval.require_approval.hint=Siempre se detiene y pide confirmación antes de que la IA ejecute esta herramienta.
+mcp.tool.enabled.label=Activado
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Herramientas disponibles - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1385,6 +1385,7 @@ mcp.tool.approval.require_approval=Exiger une approbation
 mcp.tool.approval.default=Automatique
 mcp.tool.approval.default.hint=S'exécute automatiquement. Les catégories d'écriture (écriture de fichiers, exécution, git, messagerie) nécessitent une approbation par défaut.
 mcp.tool.approval.require_approval.hint=Se met toujours en pause et demande votre confirmation avant que l'IA n'exécute cet outil.
+mcp.tool.enabled.label=Activé
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Outils disponibles - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1384,6 +1384,7 @@ mcp.tool.approval.require_approval=承認を必要とする
 mcp.tool.approval.default=自動
 mcp.tool.approval.default.hint=自動的に実行されます。書き込み系のカテゴリ（ファイルの書き込み、実行、git、メッセージング）はデフォルトで承認が必要です。
 mcp.tool.approval.require_approval.hint=AIがこのツールを実行する前に、常に一時停止して確認を求めます。
+mcp.tool.enabled.label=有効
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=利用可能なツール - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1384,6 +1384,7 @@ mcp.tool.approval.require_approval=승인 필요
 mcp.tool.approval.default=자동
 mcp.tool.approval.default.hint=자동으로 실행됩니다. 쓰기 관련 범주(파일 쓰기, 실행, git, 메시징)는 기본적으로 승인이 필요합니다.
 mcp.tool.approval.require_approval.hint=AI가 이 도구를 실행하기 전에 항상 일시 중지하고 확인을 요청합니다.
+mcp.tool.enabled.label=활성화됨
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=사용 가능한 도구 - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1384,6 +1384,7 @@ mcp.tool.approval.require_approval=Exigir aprovação
 mcp.tool.approval.default=Automático
 mcp.tool.approval.default.hint=É executado automaticamente. Categorias de gravação (gravação de arquivos, execução, git, mensagens) exigem aprovação por padrão.
 mcp.tool.approval.require_approval.hint=Sempre pausa e pede sua confirmação antes que a IA execute esta ferramenta.
+mcp.tool.enabled.label=Ativado
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Ferramentas Disponíveis - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1384,6 +1384,7 @@ mcp.tool.approval.require_approval=Yêu cầu phê duyệt
 mcp.tool.approval.default=Tự động
 mcp.tool.approval.default.hint=Chạy tự động. Các danh mục có tính chất ghi (ghi tệp, thực thi, git, nhắn tin) yêu cầu phê duyệt theo mặc định.
 mcp.tool.approval.require_approval.hint=Luôn tạm dừng và yêu cầu bạn xác nhận trước khi AI thực thi công cụ này.
+mcp.tool.enabled.label=Đã bật
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=Các công cụ có sẵn - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1384,6 +1384,7 @@ mcp.tool.approval.require_approval=需要批准
 mcp.tool.approval.default=自动
 mcp.tool.approval.default.hint=自动运行。类似写入的操作类别（文件写入、执行、git、消息传递）默认需要批准。
 mcp.tool.approval.require_approval.hint=在 AI 执行此工具之前，总是会暂停并征求您的确认。
+mcp.tool.enabled.label=已启用
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=可用工具 - {0}

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1384,6 +1384,7 @@ mcp.tool.approval.require_approval=需要批准
 mcp.tool.approval.default=自動
 mcp.tool.approval.default.hint=自動執行。類似寫入的操作類別（檔案寫入、執行、git、訊息傳遞）預設需要批准。
 mcp.tool.approval.require_approval.hint=在 AI 執行此工具之前，總是會暫停並徵求您的確認。
+mcp.tool.enabled.label=已啟用
 
 # MCP Tools Dialog
 mcp.tools.dialog.title=可用工具 - {0}

--- a/shared/src/main/kotlin/io/askimo/core/intent/ToolConfig.kt
+++ b/shared/src/main/kotlin/io/askimo/core/intent/ToolConfig.kt
@@ -21,6 +21,11 @@ data class ToolConfig(
      * [ToolApprovalPolicy.DEFAULT] means the runtime falls back to [ToolCategory.defaultApprovalPolicy].
      */
     val approvalPolicy: ToolApprovalPolicy = ToolApprovalPolicy.DEFAULT,
+    /**
+     * Whether this tool is included in the tool context forwarded to the AI.
+     * Disabled tools are still fetched and shown in the UI, but excluded from model requests.
+     */
+    val enabled: Boolean = true,
 )
 
 /**

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpInstanceService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpInstanceService.kt
@@ -48,6 +48,11 @@ private data class ToolConfigData(
      * ([ToolCategory.defaultApprovalPolicy]).
      */
     val approvalPolicy: ToolApprovalPolicy? = null,
+    /**
+     * Whether this tool is included in the tool context forwarded to the AI.
+     * Defaults to true so existing behavior is preserved for tools without an explicit setting.
+     */
+    val enabled: Boolean = true,
 )
 
 private data class GlobalToolsConfigWrapper(val tools: List<ToolConfigData>)
@@ -250,6 +255,7 @@ class McpInstanceService(
         instance: McpInstance,
         userConfigs: Map<String, ToolConfigData> = emptyMap(),
         newlyInferredConfigs: MutableList<ToolConfigData> = mutableListOf(),
+        filterDisabled: Boolean = false,
     ): Result<List<ToolConfig>> {
         val clientKey = "global_tools_${instance.id}"
         val mcpClient = mcpClientFactory.createMcpClient(instance, clientKey)
@@ -264,51 +270,53 @@ class McpInstanceService(
 
         log.debug("Fetched ${toolSpecs.size} tools from global instance '${instance.name}'")
 
-        return Result.success(
-            toolSpecs.map { toolSpec ->
-                val toolName = toolSpec.name()
-                val compositeKey = "${instance.id}:$toolName"
-                val userConfig = userConfigs[compositeKey]
+        val allTools = toolSpecs.map { toolSpec ->
+            val toolName = toolSpec.name()
+            val compositeKey = "${instance.id}:$toolName"
+            val userConfig = userConfigs[compositeKey]
 
-                if (userConfig != null && !userConfig.autoInferred) {
-                    log.trace("Using user-customized config for tool '{}': {}, {}", toolName, userConfig.category, userConfig.strategy)
-                    val category = ToolCategory.valueOf(userConfig.category)
-                    ToolConfig(
-                        specification = toolSpec,
-                        category = category,
-                        strategy = userConfig.strategy,
-                        source = ToolSource.MCP_EXTERNAL,
-                        serverId = instance.id,
-                        approvalPolicy = userConfig.approvalPolicy ?: category.defaultApprovalPolicy(),
-                    )
-                } else {
-                    val inferredCategory = inferToolCategory(toolSpec)
-                    val inferredStrategy = inferToolStrategy(toolSpec)
-                    log.trace("Auto-inferred global tool '{}': {}, {}", toolName, inferredCategory, inferredStrategy)
+            if (userConfig != null && !userConfig.autoInferred) {
+                log.trace("Using user-customized config for tool '{}': {}, {}", toolName, userConfig.category, userConfig.strategy)
+                val category = ToolCategory.valueOf(userConfig.category)
+                ToolConfig(
+                    specification = toolSpec,
+                    category = category,
+                    strategy = userConfig.strategy,
+                    source = ToolSource.MCP_EXTERNAL,
+                    serverId = instance.id,
+                    approvalPolicy = userConfig.approvalPolicy ?: category.defaultApprovalPolicy(),
+                    enabled = userConfig.enabled,
+                )
+            } else {
+                val inferredCategory = inferToolCategory(toolSpec)
+                val inferredStrategy = inferToolStrategy(toolSpec)
+                log.trace("Auto-inferred global tool '{}': {}, {}", toolName, inferredCategory, inferredStrategy)
 
-                    if (userConfig == null) {
-                        newlyInferredConfigs.add(
-                            ToolConfigData(
-                                toolName = toolName,
-                                instanceId = instance.id,
-                                category = inferredCategory.name,
-                                strategy = inferredStrategy,
-                                autoInferred = true,
-                            ),
-                        )
-                    }
-
-                    ToolConfig(
-                        specification = toolSpec,
-                        category = inferredCategory,
-                        strategy = inferredStrategy,
-                        source = ToolSource.MCP_EXTERNAL,
-                        serverId = instance.id,
-                        approvalPolicy = userConfig?.approvalPolicy ?: inferredCategory.defaultApprovalPolicy(),
+                if (userConfig == null) {
+                    newlyInferredConfigs.add(
+                        ToolConfigData(
+                            toolName = toolName,
+                            instanceId = instance.id,
+                            category = inferredCategory.name,
+                            strategy = inferredStrategy,
+                            autoInferred = true,
+                        ),
                     )
                 }
-            },
-        )
+
+                ToolConfig(
+                    specification = toolSpec,
+                    category = inferredCategory,
+                    strategy = inferredStrategy,
+                    source = ToolSource.MCP_EXTERNAL,
+                    serverId = instance.id,
+                    approvalPolicy = userConfig?.approvalPolicy ?: inferredCategory.defaultApprovalPolicy(),
+                    enabled = userConfig?.enabled ?: true,
+                )
+            }
+        }
+
+        return Result.success(if (filterDisabled) allTools.filter { it.enabled } else allTools)
     }
 
     suspend fun getGlobalTools(): Result<List<ToolConfig>> = runCatching {
@@ -331,7 +339,7 @@ class McpInstanceService(
         val allTools = mutableListOf<ToolConfig>()
 
         instances.forEach { instance ->
-            val tools = fetchToolsFromInstance(instance, userConfigs, newlyInferredConfigs)
+            val tools = fetchToolsFromInstance(instance, userConfigs, newlyInferredConfigs, filterDisabled = true)
                 .getOrElse { e ->
                     log.warn("Skipping global instance '${instance.name}': ${e.message}")
                     return@forEach
@@ -362,29 +370,73 @@ class McpInstanceService(
     }
 
     /**
+     * Returns only the tools on this instance that are enabled for AI use — i.e. excludes
+     * any tool the user has explicitly disabled via [setToolEnabled]. This is the source of
+     * truth for "what tools does the AI actually see for this instance", used both when
+     * assembling the tool context sent to the model ([getGlobalTools]) and by any UI surface
+     * (e.g. the chat input tools popup) that needs to reflect the same active set.
+     */
+    suspend fun listActiveTools(instanceId: String): Result<List<ToolConfig>> {
+        val instance = getInstance(instanceId)
+            ?: return Result.failure(IllegalArgumentException("Instance not found: $instanceId"))
+        val userConfigs = loadToolConfigs()
+        return fetchToolsFromInstance(instance, userConfigs, filterDisabled = true)
+    }
+
+    /**
      * Persists a user-defined [ToolApprovalPolicy] for a specific tool on an instance.
      * Invalidates the global tools cache so the change takes effect immediately.
      */
     fun setToolApproval(instanceId: String, toolName: String, policy: ToolApprovalPolicy) {
+        upsertToolConfig(instanceId, toolName) {
+            copy(
+                approvalPolicy = policy,
+                autoInferred = false,
+                updatedAt = LocalDateTime.now(),
+            )
+        }
+        log.debug("Set approval policy for tool '{}' on instance '{}': {}", toolName, instanceId, policy)
+    }
+
+    /**
+     * Persists whether a specific tool on an instance is included in the tool context
+     * forwarded to the AI. Disabled tools remain visible in the UI but are excluded from
+     * model requests. Invalidates the global tools cache so the change takes effect immediately.
+     */
+    fun setToolEnabled(instanceId: String, toolName: String, enabled: Boolean) {
+        upsertToolConfig(instanceId, toolName) {
+            copy(
+                enabled = enabled,
+                autoInferred = false,
+                updatedAt = LocalDateTime.now(),
+            )
+        }
+        log.debug("Set enabled={} for tool '{}' on instance '{}'", enabled, toolName, instanceId)
+    }
+
+    /**
+     * Loads the current tool config map, applies [update] to the existing entry for
+     * `instanceId:toolName` (or a freshly-inferred default if none exists yet), persists the
+     * result, and invalidates the tools cache. Shared by [setToolApproval] and [setToolEnabled]
+     * to avoid duplicating the load/default/copy/save/invalidate sequence.
+     */
+    private fun upsertToolConfig(
+        instanceId: String,
+        toolName: String,
+        update: ToolConfigData.() -> ToolConfigData,
+    ) {
         val configs = loadToolConfigs().toMutableMap()
         val key = "$instanceId:$toolName"
-        val existing = configs[key]
-        configs[key] = (
-            existing ?: ToolConfigData(
-                toolName = toolName,
-                instanceId = instanceId,
-                category = ToolCategory.OTHER.name,
-                strategy = io.askimo.core.intent.ToolStrategy.INTENT_BASED,
-                autoInferred = true,
-            )
-            ).copy(
-            approvalPolicy = policy,
-            autoInferred = false,
-            updatedAt = LocalDateTime.now(),
+        val existing = configs[key] ?: ToolConfigData(
+            toolName = toolName,
+            instanceId = instanceId,
+            category = ToolCategory.OTHER.name,
+            strategy = io.askimo.core.intent.ToolStrategy.INTENT_BASED,
+            autoInferred = true,
         )
+        configs[key] = existing.update()
         saveGlobalToolConfigs(configs)
         invalidateCache()
-        log.debug("Set approval policy for tool '{}' on instance '{}': {}", toolName, instanceId, policy)
     }
 
     fun getMcpClientForTool(toolName: String): DefaultMcpClient? = mcpClientsByToolCache.getIfPresent(toolName)


### PR DESCRIPTION
- Implements functionality to enable or disable specific tools for a given MCP instance.
- Persists tool configuration state via `McpInstanceService` and `ToolConfig`.
- Updates UI components to allow users to manage tool visibility and status.
- Adds necessary internationalization resources for tool status labels.

Ref: https://github.com/askimo-ai/askimo/issues/656
Screenshot:

<img width="869" height="943" alt="Screenshot 2026-08-22 at 1 14 43 PM" src="https://github.com/user-attachments/assets/457ac083-85bf-4654-901b-5168d2bdfd84" />
