### PR TITLE
feat(chat): Introduce per-project default chat directive

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/chat/repository/ProjectRepositoryIT.kt
+++ b/cli/src/test/kotlin/io/askimo/core/chat/repository/ProjectRepositoryIT.kt
@@ -202,6 +202,35 @@ class ProjectRepositoryIT {
     }
 
     @Test
+    fun `should set and clear default directive for a project`() {
+        val project = projectRepository.createProject(
+            Project(
+                id = "",
+                name = "Directive Project",
+                description = null,
+                knowledgeSources = emptyList(),
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+            ),
+        )
+        assertNull(project.defaultDirectiveId)
+
+        val setResult = projectRepository.setDefaultDirective(project.id, "directive-123")
+        assertTrue(setResult)
+        assertEquals("directive-123", projectRepository.getProject(project.id)?.defaultDirectiveId)
+
+        val clearResult = projectRepository.setDefaultDirective(project.id, null)
+        assertTrue(clearResult)
+        assertNull(projectRepository.getProject(project.id)?.defaultDirectiveId)
+    }
+
+    @Test
+    fun `should return false when setting default directive on non-existent project`() {
+        val result = projectRepository.setDefaultDirective("non-existent-id", "directive-123")
+        assertFalse(result)
+    }
+
+    @Test
     fun `should cascade delete sessions when project is deleted`() {
         // Create a project
         val project = projectRepository.createProject(

--- a/cli/src/test/kotlin/io/askimo/core/chat/service/ChatDirectiveServiceIT.kt
+++ b/cli/src/test/kotlin/io/askimo/core/chat/service/ChatDirectiveServiceIT.kt
@@ -1,0 +1,161 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.chat.service
+
+import io.askimo.core.chat.domain.ChatDirective
+import io.askimo.core.chat.domain.Project
+import io.askimo.core.chat.repository.ChatDirectiveRepository
+import io.askimo.core.chat.repository.ProjectRepository
+import io.askimo.core.db.DatabaseManager
+import io.askimo.core.user.repository.UserProfileRepository
+import io.askimo.core.util.AskimoHome
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.time.Instant
+
+/**
+ * Tests for default-directive resolution: project default > global default > none,
+ * and graceful fallback when a referenced directive no longer exists.
+ */
+class ChatDirectiveServiceIT {
+
+    @AfterEach
+    fun tearDown() {
+        projectRepository.getAllProjects().forEach { projectRepository.deleteProject(it.id) }
+        directiveRepository.list().forEach { directiveRepository.delete(it.id) }
+        userProfileRepository.clearProfile()
+        userProfileRepository.getProfile() // Recreate default profile row for the next test.
+    }
+
+    companion object {
+        private lateinit var testBaseScope: AskimoHome.TestBaseScope
+        private lateinit var databaseManager: DatabaseManager
+        private lateinit var directiveRepository: ChatDirectiveRepository
+        private lateinit var projectRepository: ProjectRepository
+        private lateinit var userProfileRepository: UserProfileRepository
+        private lateinit var service: ChatDirectiveService
+
+        @JvmStatic
+        @BeforeAll
+        fun setUpClass(@TempDir tempDir: Path) {
+            testBaseScope = AskimoHome.withTestBase(tempDir)
+            databaseManager = DatabaseManager.getInMemoryTestInstance(this)
+
+            directiveRepository = databaseManager.getChatDirectiveRepository()
+            projectRepository = databaseManager.getProjectRepository()
+            userProfileRepository = databaseManager.getUserProfileRepository()
+            userProfileRepository.getProfile() // Ensure the default profile row exists before setPreference calls.
+
+            service = ChatDirectiveService(
+                repository = directiveRepository,
+                userProfileRepository = userProfileRepository,
+                projectRepository = projectRepository,
+            )
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun tearDownClass() {
+            if (::databaseManager.isInitialized) {
+                databaseManager.close()
+            }
+            DatabaseManager.reset()
+            if (::testBaseScope.isInitialized) {
+                testBaseScope.close()
+            }
+        }
+    }
+
+    private fun createDirective(name: String): ChatDirective =
+        directiveRepository.save(ChatDirective(name = name, content = "Some instructions"))
+
+    private fun createProject(name: String, defaultDirectiveId: String? = null): Project {
+        val project = projectRepository.createProject(
+            Project(
+                id = "",
+                name = name,
+                description = null,
+                knowledgeSources = emptyList(),
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                defaultDirectiveId = defaultDirectiveId,
+            ),
+        )
+        if (defaultDirectiveId != null) {
+            projectRepository.setDefaultDirective(project.id, defaultDirectiveId)
+        }
+        return project
+    }
+
+    @Test
+    fun `resolves to null when no defaults are set`() {
+        assertNull(service.resolveDefaultDirectiveId(projectId = null))
+    }
+
+    @Test
+    fun `resolves to global default when set and no project given`() {
+        val directive = createDirective("global-default")
+        service.setGlobalDefaultDirectiveId(directive.id)
+
+        assertEquals(directive.id, service.resolveDefaultDirectiveId(projectId = null))
+    }
+
+    @Test
+    fun `resolves to project default over global default`() {
+        val globalDirective = createDirective("global-default")
+        val projectDirective = createDirective("project-default")
+        service.setGlobalDefaultDirectiveId(globalDirective.id)
+        val project = createProject("Project A", defaultDirectiveId = projectDirective.id)
+
+        assertEquals(projectDirective.id, service.resolveDefaultDirectiveId(projectId = project.id))
+    }
+
+    @Test
+    fun `falls back to global default when project has no default`() {
+        val globalDirective = createDirective("global-default")
+        service.setGlobalDefaultDirectiveId(globalDirective.id)
+        val project = createProject("Project B")
+
+        assertEquals(globalDirective.id, service.resolveDefaultDirectiveId(projectId = project.id))
+    }
+
+    @Test
+    fun `falls back to global default when project default directive was deleted`() {
+        val globalDirective = createDirective("global-default")
+        val projectDirective = createDirective("project-default")
+        service.setGlobalDefaultDirectiveId(globalDirective.id)
+        val project = createProject("Project C", defaultDirectiveId = projectDirective.id)
+
+        directiveRepository.delete(projectDirective.id)
+
+        assertEquals(globalDirective.id, service.resolveDefaultDirectiveId(projectId = project.id))
+    }
+
+    @Test
+    fun `resolves to null when global default directive was deleted`() {
+        val directive = createDirective("global-default")
+        service.setGlobalDefaultDirectiveId(directive.id)
+        directiveRepository.delete(directive.id)
+
+        assertNull(service.resolveDefaultDirectiveId(projectId = null))
+        assertNull(service.getGlobalDefaultDirectiveId())
+    }
+
+    @Test
+    fun `clearing global default resolves to null`() {
+        val directive = createDirective("global-default")
+        service.setGlobalDefaultDirectiveId(directive.id)
+        assertEquals(directive.id, service.getGlobalDefaultDirectiveId())
+
+        service.setGlobalDefaultDirectiveId(null)
+        assertNull(service.getGlobalDefaultDirectiveId())
+    }
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -335,8 +335,10 @@ fun chatInputField(
         KoinJavaComponent.get<ChatDirectiveService>(ChatDirectiveService::class.java)
     }
     var availableDirectives by remember { mutableStateOf<List<ChatDirective>>(emptyList()) }
+    var defaultDirectiveId by remember { mutableStateOf<String?>(null) }
     LaunchedEffect(Unit) {
         availableDirectives = directiveService.listAllDirectives()
+        defaultDirectiveId = directiveService.getGlobalDefaultDirectiveId()
     }
 
     // State for resizable text field.
@@ -1027,6 +1029,11 @@ fun chatInputField(
                 val result = directiveService.importFromJson(json)
                 availableDirectives = directiveService.listAllDirectives()
                 result
+            },
+            defaultDirectiveId = defaultDirectiveId,
+            onSetDefault = { id ->
+                directiveService.setGlobalDefaultDirectiveId(id)
+                defaultDirectiveId = directiveService.getGlobalDefaultDirectiveId()
             },
         )
     }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
@@ -16,6 +16,7 @@ import io.askimo.core.chat.dto.ToolApprovalRequest
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDTO
 import io.askimo.core.chat.repository.PaginationDirection
+import io.askimo.core.chat.service.ChatDirectiveService
 import io.askimo.core.chat.service.ChatSessionService
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
@@ -54,6 +55,7 @@ class ChatViewModel(
     private val sessionManager: SessionManager,
     private val scope: CoroutineScope,
     private val chatSessionService: ChatSessionService,
+    private val chatDirectiveService: ChatDirectiveService,
 ) : ChatActions {
     private val log = logger<ChatViewModel>()
 
@@ -104,7 +106,7 @@ class ChatViewModel(
     var isSearchMode by mutableStateOf(false)
         private set
 
-    var selectedDirective by mutableStateOf<String?>(null)
+    var selectedDirective by mutableStateOf<String?>(chatDirectiveService.resolveDefaultDirectiveId(projectId = null))
         private set
 
     var sessionTitle by mutableStateOf<String?>(null)
@@ -1235,8 +1237,8 @@ class ChatViewModel(
         // Clear search state
         clearSearch()
 
-        // Reset directive to null for new chat session
-        selectedDirective = null
+        // Reset directive to new chat's default: global default directive (no project context here).
+        selectedDirective = chatDirectiveService.resolveDefaultDirectiveId(projectId = null)
 
         // Clear the active session in the manager so that when the first message of the
         // new chat is sent (and SessionCreatedEvent fires), the manager correctly adopts

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
@@ -19,10 +19,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.FileUpload
 import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
@@ -72,6 +74,8 @@ fun manageDirectivesDialog(
     onDelete: (id: String) -> Unit,
     onExport: () -> String,
     onImport: (json: String) -> DirectiveImportResult,
+    defaultDirectiveId: String? = null,
+    onSetDefault: (id: String?) -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
     var showNewDirectiveDialog by remember { mutableStateOf(false) }
@@ -194,6 +198,29 @@ fun manageDirectivesDialog(
 
                                 if (directive.scope != DirectiveScope.TEAM) {
                                     Row(horizontalArrangement = Arrangement.spacedBy(Spacing.extraSmall)) {
+                                        val isDefault = directive.id == defaultDirectiveId
+                                        themedTooltip(
+                                            text = if (isDefault) {
+                                                stringResource("directive.default.unset")
+                                            } else {
+                                                stringResource("directive.default.set")
+                                            },
+                                        ) {
+                                            IconButton(
+                                                onClick = { onSetDefault(if (isDefault) null else directive.id) },
+                                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                            ) {
+                                                Icon(
+                                                    if (isDefault) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                                                    contentDescription = stringResource("directive.default.set"),
+                                                    tint = if (isDefault) {
+                                                        MaterialTheme.colorScheme.primary
+                                                    } else {
+                                                        AppTextStyles.primaryContent
+                                                    },
+                                                )
+                                            }
+                                        }
                                         IconButton(
                                             onClick = { editingDirective = directive },
                                             modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
@@ -14,6 +14,7 @@ import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.dto.ToolApprovalRequest
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.dto.ToolCallStatus
+import io.askimo.core.chat.service.ChatDirectiveService
 import io.askimo.core.chat.service.ChatSessionService
 import io.askimo.core.context.AppContext
 import io.askimo.core.event.EventBus
@@ -68,6 +69,7 @@ import java.util.concurrent.ConcurrentHashMap
 class SessionManager(
     private val chatSessionService: ChatSessionService,
     private val scope: CoroutineScope,
+    private val chatDirectiveService: ChatDirectiveService,
     private val mcpInstanceService: McpInstanceService? = null,
 ) {
     private val log = logger<SessionManager>()
@@ -556,6 +558,7 @@ class SessionManager(
             sessionManager = this,
             scope = scope,
             chatSessionService = chatSessionService,
+            chatDirectiveService = chatDirectiveService,
         )
 
         chatViewModels[sessionId] = viewModel

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -181,6 +181,8 @@ project.new.dialog.folder.browse=Select Folder to Process...
 project.new.dialog.file.browse=Select Files to Process...
 project.new.dialog.sources.label=Reference Materials (optional)
 project.new.dialog.sources.add=Add Source
+project.dialog.defaultDirective.label=Default Directive (optional)
+project.dialog.defaultDirective.none=None
 project.new.dialog.error.empty.name=Project name cannot be empty
 project.new.dialog.error.create.failed=Failed to create project: {0}
 project.new.dialog.name.error.empty=Project name cannot be empty
@@ -871,6 +873,8 @@ directive.import=Import
 directive.import.tooltip=Import directives from a JSON file
 directive.import.result=Import complete: {0} imported, {1} renamed, {2} skipped
 directive.import.error=Failed to import: invalid or unsupported file format
+directive.default.set=Set as default directive
+directive.default.unset=Unset as default directive
 
 # Log Levels
 log.level.error=Error

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -2018,6 +2018,9 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                 showEditProjectDialog = false
                                 editingProjectId = null
                             },
+                            onSetDefaultDirective = { projectId, directiveId ->
+                                projectsViewModel.setDefaultDirective(projectId, directiveId)
+                            },
                         )
                     }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/di/DesktopModule.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/di/DesktopModule.kt
@@ -49,6 +49,7 @@ val desktopModule = module {
     single { get<DatabaseManager>().getChatMessageRepository() }
     single { get<DatabaseManager>().getChatDirectiveRepository() }
     single { get<DatabaseManager>().getProjectRepository() }
+    single { get<DatabaseManager>().getUserProfileRepository() }
     single { get<DatabaseManager>().getPlanExecutionRepository() }
     single { get<DatabaseManager>().getLlmUsageRepository() }
 
@@ -79,7 +80,7 @@ val desktopModule = module {
             messageRepository = get(),
         )
     }
-    single { ChatDirectiveService(repository = get()) }
+    single { ChatDirectiveService(repository = get(), userProfileRepository = get(), projectRepository = get()) }
 
     single { McpClientFactory() }
     single { McpInstanceService(mcpClientFactory = get()) }
@@ -95,6 +96,7 @@ val desktopModule = module {
             chatSessionService = get(),
             scope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
             mcpInstanceService = get(),
+            chatDirectiveService = get(),
         )
     }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/EditProjectDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/EditProjectDialog.kt
@@ -45,8 +45,10 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
+import io.askimo.core.chat.domain.ChatDirective
 import io.askimo.core.chat.domain.KnowledgeSourceConfig
 import io.askimo.core.chat.domain.Project
+import io.askimo.core.chat.service.ChatDirectiveService
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.ProjectIndexRemovalEvent
@@ -73,6 +75,7 @@ fun editProjectDialog(
     projectId: String,
     onDismiss: () -> Unit,
     onSave: (projectId: String, name: String, description: String?, knowledgeSources: List<KnowledgeSourceConfig>) -> Unit,
+    onSetDefaultDirective: (projectId: String, directiveId: String?) -> Unit = { _, _ -> },
 ) {
     val projectRepository = remember { DatabaseManager.getInstance().getProjectRepository() }
 
@@ -151,6 +154,7 @@ fun editProjectDialog(
                 project = project!!,
                 onDismiss = onDismiss,
                 onSave = onSave,
+                onSetDefaultDirective = onSetDefaultDirective,
             )
         }
     }
@@ -164,9 +168,21 @@ private fun editProjectFormDialog(
     project: Project,
     onDismiss: () -> Unit,
     onSave: (projectId: String, name: String, description: String?, knowledgeSources: List<KnowledgeSourceConfig>) -> Unit,
+    onSetDefaultDirective: (projectId: String, directiveId: String?) -> Unit,
 ) {
     var projectName by remember { mutableStateOf(project.name) }
     var projectDescription by remember { mutableStateOf(project.description ?: "") }
+
+    val chatDirectiveService = remember { DatabaseManager.getInstance().let { ChatDirectiveService(repository = it.getChatDirectiveRepository()) } }
+    var availableDirectives by remember { mutableStateOf<List<ChatDirective>>(emptyList()) }
+    var selectedDefaultDirectiveId by remember { mutableStateOf(project.defaultDirectiveId) }
+    var showDirectiveMenu by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        availableDirectives = withContext(Dispatchers.IO) {
+            chatDirectiveService.listAllDirectives()
+        }
+    }
 
     // Parse existing knowledge sources into UI items
     val initialSources = remember {
@@ -354,6 +370,63 @@ private fun editProjectFormDialog(
                             }
                             if (index < KnowledgeSourceItem.availableTypes.lastIndex) {
                                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                            }
+                        }
+                    }
+                }
+
+                Spacer(Modifier.width(Spacing.small))
+
+                Text(
+                    text = stringResource("project.dialog.defaultDirective.label"),
+                    style = AppTextStyles.body,
+                )
+
+                Box {
+                    val selectedDirectiveName = availableDirectives
+                        .find { it.id == selectedDefaultDirectiveId }
+                        ?.name
+                        ?: stringResource("project.dialog.defaultDirective.none")
+
+                    OutlinedButton(
+                        onClick = { showDirectiveMenu = true },
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                    ) {
+                        Text(selectedDirectiveName, overflow = TextOverflow.Ellipsis, maxLines = 1)
+                        Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+                    }
+
+                    AppComponents.dropdownMenu(
+                        expanded = showDirectiveMenu,
+                        onDismissRequest = { showDirectiveMenu = false },
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    showDirectiveMenu = false
+                                    selectedDefaultDirectiveId = null
+                                    onSetDefaultDirective(project.id, null)
+                                }
+                                .pointerHoverIcon(PointerIcon.Hand)
+                                .padding(horizontal = Spacing.medium, vertical = Spacing.small),
+                        ) {
+                            Text(stringResource("project.dialog.defaultDirective.none"), style = AppTextStyles.body)
+                        }
+                        availableDirectives.forEach { directive ->
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        showDirectiveMenu = false
+                                        selectedDefaultDirectiveId = directive.id
+                                        onSetDefaultDirective(project.id, directive.id)
+                                    }
+                                    .pointerHoverIcon(PointerIcon.Hand)
+                                    .padding(horizontal = Spacing.medium, vertical = Spacing.small),
+                            ) {
+                                Text(directive.name, style = AppTextStyles.body, overflow = TextOverflow.Ellipsis, maxLines = 1)
                             }
                         }
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/NewProjectDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/NewProjectDialog.kt
@@ -40,7 +40,10 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.askimo.core.chat.domain.ChatDirective
+import io.askimo.core.chat.service.ChatDirectiveService
 import io.askimo.core.chat.service.ProjectService
+import io.askimo.core.db.DatabaseManager
 import io.askimo.core.logging.logger
 import io.askimo.ui.common.components.inlineErrorMessage
 import io.askimo.ui.common.components.primaryButton
@@ -51,8 +54,10 @@ import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.ui.util.FileDialogUtils
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.core.context.GlobalContext
 import java.util.UUID
 import kotlin.collections.plus
@@ -83,6 +88,18 @@ fun newProjectDialog(
     var showSuccess by remember { mutableStateOf(false) }
     var createdProjectName by remember { mutableStateOf("") }
     var countdown by remember { mutableStateOf(SUCCESS_COUNTDOWN_SECONDS) }
+
+    val chatDirectiveService = remember { DatabaseManager.getInstance().let { ChatDirectiveService(repository = it.getChatDirectiveRepository()) } }
+    val projectRepository = remember { DatabaseManager.getInstance().getProjectRepository() }
+    var availableDirectives by remember { mutableStateOf<List<ChatDirective>>(emptyList()) }
+    var selectedDefaultDirectiveId by remember { mutableStateOf<String?>(null) }
+    var showDirectiveMenu by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        availableDirectives = withContext(Dispatchers.IO) {
+            chatDirectiveService.listAllDirectives()
+        }
+    }
 
     val scope = rememberCoroutineScope()
     val dialogState = rememberDialogState()
@@ -156,6 +173,12 @@ fun newProjectDialog(
                     description = projectDescription.takeIf { it.isNotBlank() },
                     knowledgeSources = knowledgeSourceConfigs,
                 )
+
+                if (selectedDefaultDirectiveId != null) {
+                    withContext(Dispatchers.IO) {
+                        projectRepository.setDefaultDirective(createdProject.id, selectedDefaultDirectiveId)
+                    }
+                }
 
                 createdProjectName = projectName.trim()
                 showSuccess = true
@@ -322,6 +345,62 @@ fun newProjectDialog(
                                     HorizontalDivider(
                                         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
                                     )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // ── Default directive ───────────────────────────────────────────
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+                    Text(
+                        text = stringResource("project.dialog.defaultDirective.label"),
+                        style = AppTextStyles.body,
+                    )
+
+                    Box {
+                        val selectedDirectiveName = availableDirectives
+                            .find { it.id == selectedDefaultDirectiveId }
+                            ?.name
+                            ?: stringResource("project.dialog.defaultDirective.none")
+
+                        OutlinedButton(
+                            onClick = { showDirectiveMenu = true },
+                            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                        ) {
+                            Text(selectedDirectiveName)
+                            Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+                        }
+
+                        AppComponents.dropdownMenu(
+                            expanded = showDirectiveMenu,
+                            onDismissRequest = { showDirectiveMenu = false },
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        showDirectiveMenu = false
+                                        selectedDefaultDirectiveId = null
+                                    }
+                                    .pointerHoverIcon(PointerIcon.Hand)
+                                    .padding(horizontal = Spacing.medium, vertical = Spacing.small),
+                            ) {
+                                Text(stringResource("project.dialog.defaultDirective.none"), style = AppTextStyles.body)
+                            }
+                            availableDirectives.forEach { directive ->
+                                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            showDirectiveMenu = false
+                                            selectedDefaultDirectiveId = directive.id
+                                        }
+                                        .pointerHoverIcon(PointerIcon.Hand)
+                                        .padding(horizontal = Spacing.medium, vertical = Spacing.small),
+                                ) {
+                                    Text(directive.name, style = AppTextStyles.body)
                                 }
                             }
                         }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
@@ -72,6 +72,7 @@ import io.askimo.core.chat.domain.LocalFoldersKnowledgeSourceConfig
 import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.domain.UrlKnowledgeSourceConfig
 import io.askimo.core.chat.dto.FileAttachmentDTO
+import io.askimo.core.chat.service.ChatDirectiveService
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.ProjectIndexingRequestedEvent
@@ -1086,7 +1087,13 @@ private fun projectChatInputFooter(
     var inputText by remember { mutableStateOf(TextFieldValue("")) }
     var attachments by remember { mutableStateOf<List<FileAttachmentDTO>>(emptyList()) }
     var currentEnabledServerIds by remember { mutableStateOf(emptySet<String>()) }
-    var selectedDirective by remember { mutableStateOf<String?>(null) }
+    // Pre-select this project's default directive (falling back to the user's global
+    // default) so new chats in this project start with the right instructions.
+    var selectedDirective by remember(projectId) {
+        mutableStateOf(
+            GlobalContext.get().get<ChatDirectiveService>().resolveDefaultDirectiveId(projectId),
+        )
+    }
     var webSearchInRag by remember { mutableStateOf(false) }
 
     Box(

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsViewModel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsViewModel.kt
@@ -214,6 +214,19 @@ class ProjectsViewModel(
     }
 
     /**
+     * Set (or clear) the default directive automatically applied to new chats
+     * started within this project.
+     */
+    fun setDefaultDirective(projectId: String, directiveId: String?) {
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                projectRepository.setDefaultDirective(projectId, directiveId)
+            }
+            refresh()
+        }
+    }
+
+    /**
      * Delete a project by ID.
      */
     fun deleteProject(projectId: String) {

--- a/shared/src/main/kotlin/io/askimo/core/chat/domain/Project.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/domain/Project.kt
@@ -32,6 +32,11 @@ data class Project(
     val spaceId: String? = null,
     /** Display name of the Space, denormalised for offline access. Null for personal projects. */
     val spaceName: String? = null,
+    /**
+     * Id of the directive automatically applied to new chats started within this project.
+     * Takes precedence over the user's global default directive. Null means no project-level default.
+     */
+    val defaultDirectiveId: String? = null,
 )
 
 /**
@@ -49,6 +54,7 @@ object ProjectsTable : Table("projects") {
     val isStarred = integer("is_starred").default(0)
     val spaceId = varchar("space_id", 36).nullable()
     val spaceName = varchar("space_name", 255).nullable()
+    val defaultDirectiveId = varchar("default_directive_id", 36).nullable()
 
     override val primaryKey = PrimaryKey(id)
 }

--- a/shared/src/main/kotlin/io/askimo/core/chat/repository/ProjectRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/repository/ProjectRepository.kt
@@ -44,6 +44,7 @@ private fun ResultRow.toProject(): Project = Project(
     isStarred = this[ProjectsTable.isStarred] == 1,
     spaceId = this[ProjectsTable.spaceId],
     spaceName = this[ProjectsTable.spaceName],
+    defaultDirectiveId = this[ProjectsTable.defaultDirectiveId],
 )
 
 /**
@@ -73,6 +74,7 @@ class ProjectRepository internal constructor(
                 it[knowledgeSourcesConfig] = KnowledgeSourceSerializer.serialize(projectWithInjectedFields.knowledgeSources)
                 it[createdAt] = projectWithInjectedFields.createdAt
                 it[updatedAt] = projectWithInjectedFields.updatedAt
+                it[defaultDirectiveId] = projectWithInjectedFields.defaultDirectiveId
             }
         }
 
@@ -170,6 +172,27 @@ class ProjectRepository internal constructor(
         if (updated) {
             log.debug("Updated project $projectId")
             EventBus.post(PushDataToServerEvent(reason = "project updated"))
+        }
+        updated
+    }
+
+    /**
+     * Set (or clear) the default directive automatically applied to new chats started
+     * within this project. Pass `null` to clear the project-level default.
+     *
+     * @param projectId The project id
+     * @param directiveId The directive id to use as default, or null to clear it
+     * @return true if updated successfully
+     */
+    fun setDefaultDirective(projectId: String, directiveId: String?): Boolean = transaction(database) {
+        val updated = ProjectsTable.update({ ProjectsTable.id eq projectId }) {
+            it[ProjectsTable.defaultDirectiveId] = directiveId
+            it[updatedAt] = Instant.now()
+        } > 0
+
+        if (updated) {
+            log.debug("Set default directive for project $projectId to $directiveId")
+            EventBus.post(PushDataToServerEvent(reason = "project default directive updated"))
         }
         updated
     }
@@ -333,6 +356,7 @@ class ProjectRepository internal constructor(
                         it[syncedAt] = nowStr
                         it[spaceId] = project.spaceId
                         it[spaceName] = project.spaceName
+                        it[defaultDirectiveId] = project.defaultDirectiveId
                     }
                     log.debug("upsertFromServer: inserted project {}", project.id)
                 } else if (project.updatedAt.isAfter(storedUpdatedAt)) {
@@ -344,6 +368,7 @@ class ProjectRepository internal constructor(
                         it[syncedAt] = nowStr
                         it[spaceId] = project.spaceId
                         it[spaceName] = project.spaceName
+                        it[defaultDirectiveId] = project.defaultDirectiveId
                     }
                     log.debug("upsertFromServer: updated project {} (server newer)", project.id)
                 } else {

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatDirectiveService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatDirectiveService.kt
@@ -7,8 +7,11 @@ package io.askimo.core.chat.service
 import io.askimo.core.chat.domain.ChatDirective
 import io.askimo.core.chat.domain.DirectiveScope
 import io.askimo.core.chat.repository.ChatDirectiveRepository
+import io.askimo.core.chat.repository.ProjectRepository
+import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.DirectiveDeletedEvent
+import io.askimo.core.user.repository.UserProfileRepository
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -48,7 +51,50 @@ private val json = Json {
  */
 class ChatDirectiveService(
     private val repository: ChatDirectiveRepository,
+    private val userProfileRepository: UserProfileRepository = DatabaseManager.getInstance().getUserProfileRepository(),
+    private val projectRepository: ProjectRepository = DatabaseManager.getInstance().getProjectRepository(),
 ) {
+    companion object {
+        /** User-preference key used to persist the global default directive id. */
+        const val PREF_DEFAULT_DIRECTIVE_ID = "default_directive_id"
+    }
+
+    /**
+     * Get the id of the user's global default directive, if one is set and still exists.
+     */
+    fun getGlobalDefaultDirectiveId(): String? {
+        val id = userProfileRepository.getPreference(PREF_DEFAULT_DIRECTIVE_ID) ?: return null
+        return if (repository.exists(id)) id else null
+    }
+
+    /**
+     * Set (or clear) the user's global default directive, applied to new chats
+     * that aren't started within a project (or whose project has no default).
+     */
+    fun setGlobalDefaultDirectiveId(directiveId: String?) {
+        userProfileRepository.setPreference(PREF_DEFAULT_DIRECTIVE_ID, directiveId ?: "")
+    }
+
+    /**
+     * Resolve the directive that should be pre-selected for a new chat, following
+     * this priority:
+     *  1. The project's default directive (if [projectId] is given and it has one set)
+     *  2. The user's global default directive
+     *  3. null (no directive pre-selected)
+     *
+     * Stale references (e.g. to a deleted directive) are ignored and fall through
+     * to the next priority level.
+     */
+    fun resolveDefaultDirectiveId(projectId: String?): String? {
+        if (projectId != null) {
+            val projectDefault = projectRepository.getProject(projectId)?.defaultDirectiveId
+            if (projectDefault != null && repository.exists(projectDefault)) {
+                return projectDefault
+            }
+        }
+        return getGlobalDefaultDirectiveId()
+    }
+
     /**
      * Create a new directive.
      */

--- a/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
@@ -219,6 +219,14 @@ class DatabaseManager private constructor(
             } catch (_: Exception) {
                 // Column already exists — safe to ignore.
             }
+
+            try {
+                stmt.executeUpdate(
+                    "ALTER TABLE projects ADD COLUMN default_directive_id TEXT",
+                )
+            } catch (_: Exception) {
+                // Column already exists — safe to ignore.
+            }
         }
     }
 


### PR DESCRIPTION
- Allows projects to define a specific default directive.
- Project-level directives take precedence over the global default directive.
- Updates UI components to manage and utilize these project settings.
- Database schema and domain models are updated to support this feature.