### PR TITLE
feat: Add protocol version validation and UI support

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/core/mcp/McpServerDefinitionValidator.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/core/mcp/McpServerDefinitionValidator.kt
@@ -74,6 +74,11 @@ val mcpServerDefinitionValidator = Validation {
         }
     }
 
+    // protocolVersion: if provided, must be a known MCP protocol version string
+    McpServerDefinition::protocolVersion ifPresent {
+        pattern("^\\d{4}-\\d{2}-\\d{2}$") hint "Protocol version must be a date string (e.g. \"2025-11-25\")"
+    }
+
     // HTTP: require a non-blank, well-formed urlTemplate
     McpServerDefinition::httpConfig ifPresent {
         HttpConfig::urlTemplate {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/AddMcpInstanceDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/AddMcpInstanceDialog.kt
@@ -21,6 +21,11 @@ import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -175,6 +180,14 @@ fun addMcpInstanceDialog(
         )
     }
 
+    // MCP protocol version — null means auto-detect (default)
+    var protocolVersion by remember {
+        mutableStateOf(
+            existingServerDef?.protocolVersion
+                ?: templateDefinition?.protocolVersion,
+        )
+    }
+
     // Connection test state
     var isTesting by remember { mutableStateOf(false) }
     var testSuccess by remember { mutableStateOf<Boolean?>(null) }
@@ -253,7 +266,7 @@ fun addMcpInstanceDialog(
             instanceId = serverId,
             instanceName = instanceName,
             paramValues = templateParamValues.value,
-        ).copy(description = description)
+        ).copy(description = description, protocolVersion = protocolVersion)
     } else if (transportType == TransportType.STDIO) {
         // Parse the command field as a complete command line
         val commandList = buildList {
@@ -276,6 +289,7 @@ fun addMcpInstanceDialog(
                 workingDirectory = workingDir.ifBlank { null },
             ),
             httpConfig = null,
+            protocolVersion = protocolVersion,
             tags = listOf("global"),
         )
     } else {
@@ -293,6 +307,7 @@ fun addMcpInstanceDialog(
                 headersTemplate = headersMap,
                 timeoutMs = timeout,
             ),
+            protocolVersion = protocolVersion,
             tags = listOf("global"),
         )
     }
@@ -517,6 +532,7 @@ fun addMcpInstanceDialog(
                     url = url, onUrlChange = { url = it },
                     headers = headers, onHeadersChange = { headers = it },
                     timeoutMs = timeoutMs, onTimeoutMsChange = { timeoutMs = it },
+                    protocolVersion = protocolVersion, onProtocolVersionChange = { protocolVersion = it },
                 )
             }
         } else {
@@ -530,6 +546,7 @@ fun addMcpInstanceDialog(
                 url = url, onUrlChange = { url = it },
                 headers = headers, onHeadersChange = { headers = it },
                 timeoutMs = timeoutMs, onTimeoutMsChange = { timeoutMs = it },
+                protocolVersion = protocolVersion, onProtocolVersionChange = { protocolVersion = it },
             )
         }
 
@@ -715,7 +732,10 @@ private fun templateParameterFields(
 /**
  * The transport configuration fields (STDIO / HTTP tabs + all raw inputs).
  * Shared between manual mode and the Advanced section in template mode.
+ *
+ * [protocolVersion] is `null` when auto-detection is desired (the default).
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun advancedTransportFields(
     selectedTab: Int,
@@ -734,7 +754,13 @@ private fun advancedTransportFields(
     onHeadersChange: (String) -> Unit,
     timeoutMs: String,
     onTimeoutMsChange: (String) -> Unit,
+    protocolVersion: String?,
+    onProtocolVersionChange: (String?) -> Unit,
 ) {
+    // Known protocol versions — null sentinel = auto-detect
+    val versions: List<String?> = listOf(null, "2025-11-25", "2024-11-05")
+    var protocolVersionExpanded by remember { mutableStateOf(false) }
+
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.medium)) {
         Text(
             text = stringResource("mcp.instance.field.transport"),
@@ -843,6 +869,41 @@ private fun advancedTransportFields(
                     singleLine = true,
                     colors = AppComponents.outlinedTextFieldColors(),
                 )
+            }
+        }
+
+        HorizontalDivider()
+
+        // ── Protocol version ──────────────────────────────────────────────
+        ExposedDropdownMenuBox(
+            expanded = protocolVersionExpanded,
+            onExpandedChange = { protocolVersionExpanded = it },
+        ) {
+            OutlinedTextField(
+                value = protocolVersion ?: stringResource("mcp.instance.protocol.version.auto"),
+                onValueChange = {},
+                readOnly = true,
+                label = { Text(stringResource("mcp.instance.protocol.version.label")) },
+                supportingText = { Text(stringResource("mcp.instance.protocol.version.hint")) },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = protocolVersionExpanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                colors = AppComponents.outlinedTextFieldColors(),
+            )
+            ExposedDropdownMenu(
+                expanded = protocolVersionExpanded,
+                onDismissRequest = { protocolVersionExpanded = false },
+            ) {
+                versions.forEach { v ->
+                    DropdownMenuItem(
+                        text = { Text(v ?: stringResource("mcp.instance.protocol.version.auto")) },
+                        onClick = {
+                            onProtocolVersionChange(v)
+                            protocolVersionExpanded = false
+                        },
+                    )
+                }
             }
         }
     }

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1353,8 +1353,12 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=Format: Header-Name=value or Header-Name={{parameter}} (one per line)
 mcp.instance.http.timeout.label=Timeout (ms)
 mcp.instance.http.timeout.hint=Request timeout in milliseconds
+mcp.instance.protocol.version.label=Protocol Version
+mcp.instance.protocol.version.hint=Set explicitly only if auto-detection times out. Leave on "Auto-detect" for most servers.
+mcp.instance.protocol.version.auto=Auto-detect
 mcp.instance.validation.error.empty.url=URL cannot be empty
 mcp.instance.validation.error.invalid.url=URL must start with http:// or https://
+
 
 # MCP Integrations (Project View)
 mcp.instance.delete.tooltip=Delete MCP instance

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1353,6 +1353,9 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=Format: Header-Name=wert oder Header-Name={{parameter}} (einer pro Zeile)
 mcp.instance.http.timeout.label=Timeout (ms)
 mcp.instance.http.timeout.hint=Anfrage-Timeout in Millisekunden
+mcp.instance.protocol.version.label=Protokollversion
+mcp.instance.protocol.version.hint=Nur explizit festlegen, wenn die automatische Erkennung ein Timeout hat. Für die meisten Server bei „Automatisch erkennen" belassen.
+mcp.instance.protocol.version.auto=Automatisch erkennen
 mcp.instance.validation.error.empty.url=Die URL-Vorlage darf nicht leer sein
 mcp.instance.validation.error.invalid.url=Die URL-Vorlage muss mit http:// oder https:// beginnen
 

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1353,6 +1353,9 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=Formato: Nombre-Encabezado=valor o Nombre-Encabezado={{parameter}} (uno por línea)
 mcp.instance.http.timeout.label=Tiempo de espera (ms)
 mcp.instance.http.timeout.hint=Tiempo de espera de la solicitud en milisegundos
+mcp.instance.protocol.version.label=Versión del protocolo
+mcp.instance.protocol.version.hint=Establézca esto explícitamente solo si la detección automática agota el tiempo. Déjelo en "Detección automática" para la mayoría de los servidores.
+mcp.instance.protocol.version.auto=Detección automática
 mcp.instance.validation.error.empty.url=La plantilla de URL no puede estar vacía
 mcp.instance.validation.error.invalid.url=La plantilla de URL debe comenzar con http:// o https://
 

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1353,6 +1353,9 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=Format : Nom-en-tête=valeur ou Nom-en-tête={{parameter}} (une par ligne)
 mcp.instance.http.timeout.label=Délai (ms)
 mcp.instance.http.timeout.hint=Délai de la requête en millisecondes
+mcp.instance.protocol.version.label=Version du protocole
+mcp.instance.protocol.version.hint=À définir explicitement uniquement si la détection automatique expire. Laissez sur « Détection automatique » pour la plupart des serveurs.
+mcp.instance.protocol.version.auto=Détection automatique
 mcp.instance.validation.error.empty.url=Le modèle d'URL ne peut pas être vide
 mcp.instance.validation.error.invalid.url=Le modèle d'URL doit commencer par http:// ou https://
 

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1353,6 +1353,9 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=書式: ヘッダー名=値 または ヘッダー名={{parameter}} (1行に1組)
 mcp.instance.http.timeout.label=タイムアウト (ms)
 mcp.instance.http.timeout.hint=ミリ秒単位のリクエストタイムアウト
+mcp.instance.protocol.version.label=プロトコルバージョン
+mcp.instance.protocol.version.hint=自動検出がタイムアウトした場合のみ明示的に設定してください。ほとんどのサーバーでは「自動検出」のままにしてください。
+mcp.instance.protocol.version.auto=自動検出
 mcp.instance.validation.error.empty.url=URLテンプレートは空にできません
 mcp.instance.validation.error.invalid.url=URLテンプレートはhttp://またはhttps://で始める必要があります
 

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1353,6 +1353,9 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=형식: 헤더 이름=값 또는 헤더 이름={{parameter}} (1줄에 1쌍)
 mcp.instance.http.timeout.label=시간 초과 (ms)
 mcp.instance.http.timeout.hint=요청 시간 초과를 밀리초 단위로 지정하세요
+mcp.instance.protocol.version.label=프로토콜 버전
+mcp.instance.protocol.version.hint=자동 감지 시간이 초과된 경우에만 명시적으로 설정하세요. 대부분의 서버에는 "자동 감지"로 두세요.
+mcp.instance.protocol.version.auto=자동 감지
 mcp.instance.validation.error.empty.url=URL 템플릿은 비워둘 수 없습니다
 mcp.instance.validation.error.invalid.url=URL 템플릿은 http:// 또는 https://로 시작해야 합니다
 

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1353,6 +1353,9 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=Formato: Nome-Cabeçalho=valor ou Nome-Cabeçalho={{parameter}} (um por linha)
 mcp.instance.http.timeout.label=Tempo Limite (ms)
 mcp.instance.http.timeout.hint=Tempo limite da solicitação em milissegundos
+mcp.instance.protocol.version.label=Versão do protocolo
+mcp.instance.protocol.version.hint=Defina explicitamente apenas se a detecção automática expirar. Deixe em "Detectar automaticamente" para a maioria dos servidores.
+mcp.instance.protocol.version.auto=Detectar automaticamente
 mcp.instance.validation.error.empty.url=O template de URL não pode estar vazio
 mcp.instance.validation.error.invalid.url=O template de URL deve começar com http:// ou https://
 

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1353,6 +1353,9 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=Định dạng: Tên-Tiêu đề=giá trị hoặc Tên-Tiêu đề={{parameter}} (mỗi dòng một cặp)
 mcp.instance.http.timeout.label=Thời gian chờ (ms)
 mcp.instance.http.timeout.hint=Thời gian chờ yêu cầu bằng mili giây
+mcp.instance.protocol.version.label=Phiên bản giao thức
+mcp.instance.protocol.version.hint=Chỉ đặt rõ ràng nếu tự động phát hiện hết thời gian chờ. Để ở "Tự động phát hiện" cho hầu hết các máy chủ.
+mcp.instance.protocol.version.auto=Tự động phát hiện
 mcp.instance.validation.error.empty.url=Mẫu URL không được để trống
 mcp.instance.validation.error.invalid.url=Mẫu URL phải bắt đầu bằng http:// hoặc https://
 

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1353,6 +1353,9 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=格式: 头部名称=值 或 头部名称={{parameter}} (每行一个)
 mcp.instance.http.timeout.label=超时时间 (ms)
 mcp.instance.http.timeout.hint=请求超时时间（毫秒）
+mcp.instance.protocol.version.label=协议版本
+mcp.instance.protocol.version.hint=仅在自动检测超时时才显式设置。对于大多数服务器，请保持"自动检测"。
+mcp.instance.protocol.version.auto=自动检测
 mcp.instance.validation.error.empty.url=URL 模板不能为空
 mcp.instance.validation.error.invalid.url=URL 模板必须以 http:// 或 https:// 开头
 

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1353,6 +1353,9 @@ mcp.instance.http.headers.placeholder=Authorization=Bearer {{apiKey}}\nX-Tenant-
 mcp.instance.http.headers.hint=格式: 標頭名稱=值 或 標頭名稱={{parameter}} (每行一個)
 mcp.instance.http.timeout.label=逾時時間 (ms)
 mcp.instance.http.timeout.hint=請求逾時時間（毫秒）
+mcp.instance.protocol.version.label=協議版本
+mcp.instance.protocol.version.hint=僅在自動偵測逾時時才明確設定。對於大多數伺服器，請保持「自動偵測」。
+mcp.instance.protocol.version.auto=自動偵測
 mcp.instance.validation.error.empty.url=URL 範本不能為空
 mcp.instance.validation.error.invalid.url=URL 範本必須以 http:// 或 https:// 開頭
 

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpClientFactory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpClientFactory.kt
@@ -70,10 +70,14 @@ class McpClientFactory(
             }
 
             log.trace("Creating MCP client for instance '${instance.name}'")
-            val client = DefaultMcpClient.builder()
+            val builder = DefaultMcpClient.builder()
                 .key(clientKey)
                 .transport(transport)
-                .build()
+            resolvedDefinition.protocolVersion?.let {
+                log.debug("Using explicit MCP protocol version '{}' for '{}'", it, instance.name)
+                builder.protocolVersion(it)
+            }
+            val client = builder.build()
 
             log.debug("Successfully created MCP client for '${instance.name}'")
             Result.success(client)

--- a/shared/src/main/kotlin/io/askimo/core/mcp/McpServerDefinition.kt
+++ b/shared/src/main/kotlin/io/askimo/core/mcp/McpServerDefinition.kt
@@ -25,7 +25,15 @@ data class McpServerDefinition(
     val parameters: List<Parameter> = emptyList(),
 
     // Metadata
-    val version: String = "1.0.0",
+    /**
+     * MCP protocol version to use for this server.
+     *
+     * When `null` (the default), the client attempts automatic protocol detection.
+     * Set this explicitly when a server times out during detection, e.g.:
+     * - `"2025-11-25"` — current stable protocol
+     * - `"2024-11-05"` — legacy protocol
+     */
+    val protocolVersion: String? = null,
     val author: String? = null,
     val tags: List<String> = emptyList(),
 ) {


### PR DESCRIPTION
In my use case, the MCP server use the old protocol version and it requires explicitly declaration, so Askimo should allow user can set the protocol version

- Add validation for MCP protocol version in `McpServerDefinitionValidator.kt`.
- Update `AddMcpInstanceDialog.kt` to include a dropdown menu for selecting the protocol version.
- Update i18n files to include new messages for protocol version.
- Refactor `McpClientFactory.kt` to use a builder for creating clients.
- Update `McpServerDefinition.kt` to include a `protocolVersion` field with documentation.

Screenshot:
<img width="891" height="1114" alt="Screenshot 2026-08-31 at 10 31 16 AM" src="https://github.com/user-attachments/assets/b4c8ba65-6ce2-4a98-8885-737042015648" />
