### PR TITLE
feat(chat): Introduce structured content timelines for turns

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/chat/dto/TurnTimelineEntryCollapsedEffectiveToolsTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/chat/dto/TurnTimelineEntryCollapsedEffectiveToolsTest.kt
@@ -1,0 +1,167 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.chat.dto
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class TurnTimelineEntryCollapsedEffectiveToolsTest {
+
+    private fun tool(name: String, args: String? = null, status: ToolCallStatus = ToolCallStatus.DONE) = TurnTimelineEntry.Tool(ToolCallInfo(toolName = name, status = status, arguments = args))
+
+    private fun thinking(text: String) = TurnTimelineEntry.Thinking(text)
+    private fun token(text: String) = TurnTimelineEntry.Token(text)
+    private fun status(text: String) = TurnTimelineEntry.Status(text)
+
+    @Test
+    fun `no tool calls - passthrough unchanged`() {
+        val entries = listOf(thinking("t1"), token("hello"))
+        assertEquals(entries, entries.collapsedEffectiveTools())
+    }
+
+    @Test
+    fun `single tool call - kept regardless of preceding thinking`() {
+        val entries = listOf(thinking("reasoning"), tool("A", "args1"))
+        assertEquals(entries, entries.collapsedEffectiveTools())
+    }
+
+    @Test
+    fun `distinct tools each called once - all kept in order`() {
+        val entries = listOf(tool("A", "a1"), tool("B", "b1"), tool("C", "c1"))
+        assertEquals(entries, entries.collapsedEffectiveTools())
+    }
+
+    @Test
+    fun `A A B with different arguments - collapses to A(last) B`() {
+        // The classic retry: same tool, different arguments each attempt, since the AI is
+        // trying to guess the right parameters. Arguments must be ignored in the dedup key.
+        val a1 = tool("A", "args1")
+        val a2 = tool("A", "args2")
+        val b = tool("B", "argsB")
+        val result = listOf(a1, a2, b).collapsedEffectiveTools()
+        assertEquals(listOf(a2, b), result)
+    }
+
+    @Test
+    fun `A A B with identical arguments - still collapses to A(last) B`() {
+        val a1 = tool("A", "same")
+        val a2 = tool("A", "same")
+        val b = tool("B", "argsB")
+        val result = listOf(a1, a2, b).collapsedEffectiveTools()
+        assertEquals(listOf(a2, b), result)
+    }
+
+    @Test
+    fun `thinking-tool retry loop collapses to last thinking plus last tool`() {
+        // Thinking, ToolA(args1), Thinking, ToolA(args2), Thinking, ToolA(args3)
+        val t1 = thinking("guessing param set 1")
+        val a1 = tool("A", "args1")
+        val t2 = thinking("guessing param set 2")
+        val a2 = tool("A", "args2")
+        val t3 = thinking("finally the right params")
+        val a3 = tool("A", "args3")
+
+        val result = listOf(t1, a1, t2, a2, t3, a3).collapsedEffectiveTools()
+
+        // Only the reasoning immediately preceding the effective (last) call survives —
+        // earlier dead-end reasoning/attempts are dropped entirely.
+        assertEquals(listOf(t3, a3), result)
+    }
+
+    @Test
+    fun `retry loop for A followed by a distinct tool B keeps both steps`() {
+        val t1 = thinking("guess 1")
+        val a1 = tool("A", "args1")
+        val t2 = thinking("guess 2 - correct")
+        val a2 = tool("A", "args2")
+        val t3 = thinking("now call B")
+        val b = tool("B", "argsB")
+
+        val result = listOf(t1, a1, t2, a2, t3, b).collapsedEffectiveTools()
+
+        assertEquals(listOf(t2, a2, t3, b), result)
+    }
+
+    @Test
+    fun `back-to-back retries with no thinking between them still collapse`() {
+        val a1 = tool("A", "args1")
+        val a2 = tool("A", "args2")
+        val a3 = tool("A", "args3")
+        val result = listOf(a1, a2, a3).collapsedEffectiveTools()
+        assertEquals(listOf(a3), result)
+    }
+
+    @Test
+    fun `thinking not followed by any tool call is preserved`() {
+        // The AI just "thought out loud" without calling a tool afterwards — e.g. right before
+        // the final answer. This must NOT be dropped.
+        val t1 = thinking("no tool needed here")
+        val answer = token("Here's the answer.")
+        val result = listOf(t1, answer).collapsedEffectiveTools()
+        assertEquals(listOf(t1, answer), result)
+    }
+
+    @Test
+    fun `status and token entries pass through untouched around a retry loop`() {
+        val s = status("Connecting...")
+        val a1 = tool("A", "args1")
+        val a2 = tool("A", "args2")
+        val tok = token("Done.")
+        val result = listOf(s, a1, a2, tok).collapsedEffectiveTools()
+        assertEquals(listOf(s, a2, tok), result)
+    }
+
+    @Test
+    fun `interleaved retries of two different tools each collapse independently`() {
+        // A1, B1, A2, B2 — both A and B are retried once; only the last of each survives,
+        // in their original relative positions.
+        val a1 = tool("A", "a-args1")
+        val b1 = tool("B", "b-args1")
+        val a2 = tool("A", "a-args2")
+        val b2 = tool("B", "b-args2")
+        val result = listOf(a1, b1, a2, b2).collapsedEffectiveTools()
+        assertEquals(listOf(a2, b2), result)
+    }
+
+    @Test
+    fun `grouped() applies the same collapse before building groups`() {
+        val t1 = thinking("guess 1")
+        val a1 = tool("A", "args1")
+        val t2 = thinking("guess 2 - correct")
+        val a2 = tool("A", "args2")
+        val finalText = token("All done.")
+
+        val groups = listOf(t1, a1, t2, a2, finalText).grouped()
+
+        assertEquals(
+            listOf(
+                TurnTimelineGroup.ThinkingGroup("guess 2 - correct"),
+                TurnTimelineGroup.ToolGroup(listOf(a2)),
+                TurnTimelineGroup.TokenGroup("All done."),
+            ),
+            groups,
+        )
+    }
+
+    @Test
+    fun `grouped() still merges genuinely consecutive thinking chunks (no tool between them)`() {
+        // Two Thinking entries with nothing in between (e.g. streamed token-by-token) must
+        // still concatenate into a single ThinkingGroup — this is NOT a retry loop.
+        val chunks = listOf(thinking("Hello "), thinking("world"), token("answer"))
+        val groups = chunks.grouped()
+        assertEquals(
+            listOf(
+                TurnTimelineGroup.ThinkingGroup("Hello world"),
+                TurnTimelineGroup.TokenGroup("answer"),
+            ),
+            groups,
+        )
+    }
+
+    @Test
+    fun `empty list returns empty`() {
+        assertEquals(emptyList(), emptyList<TurnTimelineEntry>().collapsedEffectiveTools())
+    }
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,12 +21,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.PlayArrow
@@ -68,8 +71,13 @@ import io.askimo.core.agent.domain.Workspace
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.dto.ToolCallStatus
+import io.askimo.core.chat.dto.TurnTimelineEntry
+import io.askimo.core.chat.dto.TurnTimelineGroup
+import io.askimo.core.chat.dto.collapsedEffectiveTools
+import io.askimo.core.chat.dto.grouped
 import io.askimo.core.db.DatabaseManager
 import io.askimo.ui.chat.messageList
+import io.askimo.ui.chat.turnTimelineView
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.onImeAwarePreviewKeyEvent
@@ -79,7 +87,6 @@ import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
-import io.askimo.ui.common.ui.themedTooltip
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -95,16 +102,6 @@ private enum class AgentCardState {
     READY,
 }
 
-/** Appends [token] to the trailing streaming AI message, creating one first if none exists. */
-private fun List<ChatMessageDTO>.appendToken(token: String): List<ChatMessageDTO> {
-    val idx = indexOfLast { !it.isUser && it.id == null }
-    if (idx < 0) {
-        return this + ChatMessageDTO(id = null, content = token, isUser = false, timestamp = null)
-    }
-    val updated = this[idx].copy(content = this[idx].content + token)
-    return toMutableList().also { it[idx] = updated }
-}
-
 /** Ensures a (possibly empty) streaming AI placeholder message exists, so tool/thinking chips can render before the first token arrives. */
 private fun List<ChatMessageDTO>.ensureStreamingAiMessage(): List<ChatMessageDTO> {
     if (any { !it.isUser && it.id == null }) return this
@@ -116,11 +113,12 @@ private fun List<ChatMessageDTO>.finalizeStreamingAiMessage(
     finalContent: String,
     isFailed: Boolean,
     usage: AgentUsage? = null,
+    messageId: String = "ai-${System.nanoTime()}",
 ): List<ChatMessageDTO> {
     val idx = indexOfLast { !it.isUser && it.id == null }
     if (idx < 0) return this
     val updated = this[idx].copy(
-        id = "ai-${System.nanoTime()}",
+        id = messageId,
         content = finalContent,
         timestamp = Instant.now(),
         isFailed = isFailed,
@@ -145,6 +143,8 @@ internal fun agenticRunArea(
     onNavigateToSkillsSettings: () -> Unit = {},
     preloadRecord: AgentRunRecord? = null,
     onPreloadConsumed: () -> Unit = {},
+    onConversationStateChanged: (Boolean) -> Unit = {},
+    newConversationRequestKey: Int = 0,
 ) {
     val workDir = remember(workspace.path) { File(workspace.path) }
     val scope = rememberCoroutineScope()
@@ -194,9 +194,16 @@ internal fun agenticRunArea(
     var messages by remember { mutableStateOf<List<ChatMessageDTO>>(emptyList()) }
 
     // Ephemeral streaming state for the *current* turn only (mirrors ChatViewModel's
-    // activeToolCalls/activeThinkingContent) — applied to the trailing streaming AI message.
-    var activeToolCalls by remember { mutableStateOf<List<ToolCallInfo>>(emptyList()) }
-    var activeThinkingContent by remember { mutableStateOf("") }
+    // Chronologically-ordered timeline of everything the agent's stream reported for the
+    // *current* turn — tool calls, thinking chunks, response text chunks, and lifecycle
+    // status — in the exact order they arrived, so the UI can render them interleaved
+    // instead of bucketing into fixed thinking/tools/text sections regardless of timing.
+    var timeline by remember { mutableStateOf<List<TurnTimelineEntry>>(emptyList()) }
+    // Completed turns' groups, keyed by that turn's finalized AI message id — kept in memory
+    // for the current session; also reconstructable from `AgentRunRecord.contentBlocks` when
+    // preloading persisted history (tool calls + text only — thinking/status stay session-only,
+    // never persisted).
+    var completedGroups by remember { mutableStateOf<Map<String, List<TurnTimelineGroup>>>(emptyMap()) }
     // True from the moment a run starts until the first token/tool-call/thinking chunk
     // arrives — mirrors ChatViewModel.isThinking (shows the "Thinking…" spinner row).
     var isWaitingForFirstEvent by remember { mutableStateOf(false) }
@@ -248,8 +255,7 @@ internal fun agenticRunArea(
         val resumeSessionId = if (isNewConversation) null else activeAgentSessionId
         isRunning = true
         isWaitingForFirstEvent = true
-        activeToolCalls = emptyList()
-        activeThinkingContent = ""
+        timeline = emptyList()
         currentTurnResponse = ""
         if (isNewConversation) {
             messages = emptyList()
@@ -283,21 +289,27 @@ internal fun agenticRunArea(
                             scope.launch {
                                 isWaitingForFirstEvent = false
                                 currentTurnResponse += token
-                                messages = messages.appendToken(token)
+                                timeline = timeline + TurnTimelineEntry.Token(token)
+                            }
+                        },
+                        onToolCall = { toolName, detail ->
+                            scope.launch {
+                                isWaitingForFirstEvent = false
+                                timeline = timeline + TurnTimelineEntry.Tool(
+                                    ToolCallInfo(toolName = toolName, status = ToolCallStatus.DONE, arguments = detail),
+                                )
                             }
                         },
                         onStatus = { status ->
                             scope.launch {
                                 isWaitingForFirstEvent = false
-                                activeToolCalls = activeToolCalls + ToolCallInfo(toolName = status, status = ToolCallStatus.DONE)
-                                messages = messages.ensureStreamingAiMessage()
+                                timeline = timeline + TurnTimelineEntry.Status(status)
                             }
                         },
                         onThinking = { chunk ->
                             scope.launch {
                                 isWaitingForFirstEvent = false
-                                activeThinkingContent += chunk
-                                messages = messages.ensureStreamingAiMessage()
+                                timeline = timeline + TurnTimelineEntry.Thinking(chunk)
                             }
                         },
                     )
@@ -324,13 +336,21 @@ internal fun agenticRunArea(
 
             // Guarantee a bubble exists even if the run failed before any token/tool/thinking
             // event arrived, then finalize it (stable id, failure flag) so it stops "streaming".
+            val finalizedMessageId = "ai-${System.nanoTime()}"
             messages = messages
                 .ensureStreamingAiMessage()
                 .finalizeStreamingAiMessage(
                     finalContent = currentTurnResponse.ifBlank { errorText.orEmpty() },
                     isFailed = errorText != null,
                     usage = usage,
+                    messageId = finalizedMessageId,
                 )
+            // Keep this turn's ordered tool/thinking/text trail visible for the rest of the
+            // session (all kinds, including thinking) — in memory only, never written to
+            // AgentRunRecord/the database.
+            if (timeline.isNotEmpty()) {
+                completedGroups = completedGroups + (finalizedMessageId to timeline.grouped())
+            }
 
             val record = AgentRunRecord(
                 workspaceId = workspace.id,
@@ -339,7 +359,8 @@ internal fun agenticRunArea(
                 response = currentTurnResponse,
                 error = errorText,
                 agentSessionId = activeAgentSessionId,
-                activityLog = activeToolCalls.map { it.toolName },
+                activityLog = timeline.collapsedEffectiveTools().filterIsInstance<TurnTimelineEntry.Tool>().map { it.toolCall.toolName },
+                contentBlocks = timeline.collapsedEffectiveTools().filter { it is TurnTimelineEntry.Tool || it is TurnTimelineEntry.Token },
                 inputTokens = usage?.inputTokens,
                 outputTokens = usage?.outputTokens,
                 totalTokens = usage?.totalTokens,
@@ -366,11 +387,23 @@ internal fun agenticRunArea(
     fun startNewConversation() {
         inputText = TextFieldValue("")
         messages = emptyList()
-        activeToolCalls = emptyList()
-        activeThinkingContent = ""
+        timeline = emptyList()
+        completedGroups = emptyMap()
         currentTurnResponse = ""
         activeAgentSessionId = null
         activeConversationId = UUID.randomUUID().toString()
+    }
+
+    // Report "has active conversation" up to the header whenever it changes, so the header's
+    // "New chat" button can enable/disable itself without owning any transcript state.
+    LaunchedEffect(messages.isEmpty()) {
+        onConversationStateChanged(messages.isNotEmpty())
+    }
+
+    // Parent-driven reset — the header's "New chat" button bumps this key instead of calling
+    // into this composable directly, keeping this view the sole owner of `messages`/`timeline`.
+    LaunchedEffect(newConversationRequestKey) {
+        if (newConversationRequestKey > 0) startNewConversation()
     }
 
     LaunchedEffect(preloadRecord) {
@@ -401,8 +434,11 @@ internal fun agenticRunArea(
                     ),
                 )
             }
-            activeToolCalls = emptyList()
-            activeThinkingContent = ""
+            timeline = emptyList()
+            // Reconstruct each turn's ordered tool/text groups from its persisted
+            // `contentBlocks` — thinking/status were never persisted, so those groups simply
+            // won't reappear here (only for turns still live in this session).
+            completedGroups = turns.associate { r -> "${r.id}-ai" to r.contentBlocks.grouped() }.filterValues { it.isNotEmpty() }
             currentTurnResponse = turns.lastOrNull()?.response.orEmpty()
             activeConversationId = preloadRecord.conversationId
             // Restore the agent's own session id so a follow-up on a re-opened history
@@ -420,7 +456,7 @@ internal fun agenticRunArea(
     val transcriptScroll = rememberScrollState()
 
     // Auto-scroll to the bottom as new content streams in.
-    LaunchedEffect(messages.size, messages.lastOrNull()?.content, activeThinkingContent, activeToolCalls.size) {
+    LaunchedEffect(messages.size, messages.lastOrNull()?.content, timeline.size) {
         transcriptScroll.animateScrollTo(transcriptScroll.maxValue)
     }
 
@@ -500,7 +536,7 @@ internal fun agenticRunArea(
                             }
 
                             if (skillsListExpanded) {
-                                val skillsScrollState = rememberScrollState()
+                                val skillsListState = rememberLazyListState()
                                 Popup(
                                     alignment = Alignment.TopStart,
                                     offset = IntOffset(0, pillHeightPx + with(LocalDensity.current) { 4.dp.roundToPx() }),
@@ -517,15 +553,17 @@ internal fun agenticRunArea(
                                             shadowElevation = AppComponents.popupElevation,
                                         ) {
                                             Column {
-                                                // ── Scrollable skill list (height wraps content, capped) ──
-                                                Box(modifier = Modifier.heightIn(max = 320.dp)) {
-                                                    Column(
-                                                        modifier = Modifier
-                                                            .fillMaxWidth()
-                                                            .verticalScroll(skillsScrollState)
-                                                            .padding(vertical = Spacing.extraSmall),
+                                                Box(modifier = Modifier.fillMaxWidth().heightIn(max = 320.dp)) {
+                                                    LazyColumn(
+                                                        state = skillsListState,
+                                                        modifier = Modifier.fillMaxWidth(),
+                                                        contentPadding = PaddingValues(
+                                                            top = Spacing.extraSmall,
+                                                            bottom = Spacing.extraSmall,
+                                                            end = 10.dp,
+                                                        ),
                                                     ) {
-                                                        skills.forEach { skill ->
+                                                        items(skills) { skill ->
                                                             Row(
                                                                 modifier = Modifier
                                                                     .fillMaxWidth()
@@ -562,8 +600,8 @@ internal fun agenticRunArea(
                                                         }
                                                     }
                                                     VerticalScrollbar(
-                                                        adapter = rememberScrollbarAdapter(skillsScrollState),
-                                                        modifier = Modifier.matchParentSize().padding(end = 2.dp),
+                                                        adapter = rememberScrollbarAdapter(skillsListState),
+                                                        modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight().padding(end = 2.dp),
                                                         style = AppComponents.scrollbarStyle(),
                                                     )
                                                 }
@@ -651,9 +689,16 @@ internal fun agenticRunArea(
                             messages = messages,
                             isThinking = isWaitingForFirstEvent,
                             thinkingElapsedSeconds = elapsedSeconds,
-                            activeToolCalls = activeToolCalls,
-                            activeThinkingContent = activeThinkingContent,
+                            completedGroupsByMessageId = completedGroups,
                         )
+                        // Live, chronologically-ordered view of the *current* turn — tool
+                        // calls, thinking, response text, and status, interleaved exactly as
+                        // the agent's stream reported them, with consecutive same-kind items
+                        // collapsed into one group. Replaced by the finalized bubble in
+                        // `messages` once the run completes.
+                        if (isRunning && timeline.isNotEmpty()) {
+                            turnTimelineView(timeline.grouped())
+                        }
                     } else {
                         // ── Empty-state hint — shown before the first message is sent ────
                     }
@@ -756,7 +801,7 @@ internal fun agenticRunArea(
                         }
                     }
 
-                    // ── New-conversation + agent picker + elapsed timer + Send — overlaid bottom-right ──
+                    // ── Agent picker + Send — overlaid bottom-right ──
                     Row(
                         modifier = Modifier
                             .align(Alignment.BottomEnd)
@@ -764,34 +809,6 @@ internal fun agenticRunArea(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
-                        // Elapsed timer while running
-                        if (isRunning) {
-                            Text(
-                                text = "${elapsedSeconds}s",
-                                style = AppTextStyles.hint,
-                            )
-                        }
-
-                        // Start a new conversation — only relevant once one is underway.
-                        if (messages.isNotEmpty()) {
-                            themedTooltip(text = stringResource("chat.new")) {
-                                IconButton(
-                                    onClick = { startNewConversation() },
-                                    enabled = !isRunning,
-                                    modifier = Modifier
-                                        .size(30.dp)
-                                        .pointerHoverIcon(PointerIcon.Hand),
-                                ) {
-                                    Icon(
-                                        Icons.Default.Add,
-                                        contentDescription = stringResource("chat.new"),
-                                        modifier = Modifier.size(16.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                }
-                            }
-                        }
-
                         // Agent picker pill
                         Box {
                             Surface(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentView.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.FolderOpen
@@ -212,6 +213,8 @@ internal fun agentsPageHeader(
     showPanelToggle: Boolean = false,
     panelVisible: Boolean = false,
     onTogglePanel: () -> Unit = {},
+    hasActiveConversation: Boolean = false,
+    onNewChat: () -> Unit = {},
 ) {
     val runtimes = ExternalAgentLoader.displayNames()
     val runtimesLabel = runtimes.mapIndexed { i, r ->
@@ -230,6 +233,23 @@ internal fun agentsPageHeader(
             modifier = Modifier.weight(1f),
         )
         Row(verticalAlignment = Alignment.CenterVertically) {
+            themedTooltip(text = stringResource("chat.new")) {
+                IconButton(
+                    onClick = onNewChat,
+                    enabled = hasActiveConversation,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                ) {
+                    Icon(
+                        Icons.Default.Add,
+                        contentDescription = stringResource("chat.new"),
+                        tint = if (hasActiveConversation) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                        },
+                    )
+                }
+            }
             themedTooltip(text = stringResource("agents.view.docs.tooltip")) {
                 IconButton(
                     onClick = {
@@ -318,6 +338,9 @@ private fun agenticContent(
     preloadRecord: AgentRunRecord? = null,
     onPreloadConsumed: () -> Unit = {},
 ) {
+    var hasActiveConversation by remember { mutableStateOf(false) }
+    var newConversationRequestKey by remember { mutableStateOf(0) }
+
     Column(modifier = Modifier.fillMaxSize()) {
         // ── Page header (fixed — does not scroll with the conversation) ───
         Column(
@@ -332,6 +355,8 @@ private fun agenticContent(
                 showPanelToggle = showPanelToggle,
                 panelVisible = panelVisible,
                 onTogglePanel = onTogglePanel,
+                hasActiveConversation = hasActiveConversation,
+                onNewChat = { newConversationRequestKey++ },
             )
         }
 
@@ -345,6 +370,8 @@ private fun agenticContent(
                 onNavigateToSkillsSettings = onNavigateToSkillsSettings,
                 preloadRecord = preloadRecord,
                 onPreloadConsumed = onPreloadConsumed,
+                onConversationStateChanged = { hasActiveConversation = it },
+                newConversationRequestKey = newConversationRequestKey,
             )
         }
     }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatState.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatState.kt
@@ -7,7 +7,8 @@ package io.askimo.ui.chat
 import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.ToolApprovalRequest
-import io.askimo.core.chat.dto.ToolCallInfo
+import io.askimo.core.chat.dto.TurnTimelineEntry
+import io.askimo.core.chat.dto.TurnTimelineGroup
 import io.askimo.core.memory.MemoryPressureLevel
 
 /**
@@ -44,17 +45,20 @@ data class ChatState(
     val sessionTitle: String,
     val project: Project?,
 
-    // Tool call state — ephemeral, populated only during active streaming
-    val activeToolCalls: List<ToolCallInfo> = emptyList(),
+    // Ordered tool-call/text/thinking timeline for the *current* turn (this session only),
+    // preserving true chronological order — replaces the old activeToolCalls/
+    // activeThinkingContent pair. See SessionManager.StreamingThread.timeline.
+    val activeTimeline: List<TurnTimelineEntry> = emptyList(),
 
     // Pending tool approval — non-null when the AI wants to run a tool that requires user consent.
     // Cleared automatically once the user approves or denies.
     val pendingToolApproval: ToolApprovalRequest? = null,
 
-    // Thinking/reasoning content — ephemeral, streamed from models that expose reasoning.
-    // Populated during active streaming; cleared when a new message starts.
-    // Not persisted to the database — visible for the current session only.
-    val activeThinkingContent: String = "",
+    // Session-only per-message full timelines (incl. thinking) for turns completed earlier in
+    // this session — keyed by message id. Falls back to ChatMessageDTO.contentBlocks (tool
+    // calls + text only, no thinking) once a turn is no longer in this map (e.g. after an
+    // app restart).
+    val completedTimelines: Map<String, List<TurnTimelineGroup>> = emptyMap(),
 
     // Bookmark state — IDs of messages pinned by the user in this session
     val bookmarkedMessageIds: Set<String> = emptySet(),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -177,8 +177,8 @@ fun chatView(
     val selectedDirective = state.selectedDirective
     val sessionTitle = state.sessionTitle
     val project = state.project
-    val activeToolCalls = state.activeToolCalls
-    val activeThinkingContent = state.activeThinkingContent
+    val activeTimeline = state.activeTimeline
+    val completedTimelines = state.completedTimelines
     val bookmarkedMessageIds = state.bookmarkedMessageIds
     val pendingScrollToMessageId = state.pendingScrollToMessageId
     val pendingToolApproval = state.pendingToolApproval
@@ -1142,8 +1142,8 @@ fun chatView(
                                         onRetryMessage = { messageId -> actions.retryMessage(messageId, currentEnabledServerIds) },
                                         viewportTopY = viewportBounds?.top,
                                         projectId = project?.id,
-                                        activeToolCalls = activeToolCalls,
-                                        activeThinkingContent = activeThinkingContent,
+                                        activeTimeline = activeTimeline,
+                                        completedGroupsByMessageId = completedTimelines,
                                         bookmarkedMessageIds = bookmarkedMessageIds,
                                         onToggleBookmark = { messageId -> actions.toggleBookmark(messageId) },
                                         onForkFromMessage = { messageId -> actions.forkFromMessage(messageId) },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatViewModel.kt
@@ -13,7 +13,9 @@ import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.dto.ToolApprovalRequest
-import io.askimo.core.chat.dto.ToolCallInfo
+import io.askimo.core.chat.dto.TurnTimelineEntry
+import io.askimo.core.chat.dto.TurnTimelineGroup
+import io.askimo.core.chat.dto.grouped
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDTO
 import io.askimo.core.chat.repository.PaginationDirection
 import io.askimo.core.chat.service.ChatDirectiveService
@@ -117,13 +119,16 @@ class ChatViewModel(
     var project by mutableStateOf<Project?>(null)
         private set
 
-    var activeToolCalls by mutableStateOf<List<ToolCallInfo>>(emptyList())
+    var activeTimeline by mutableStateOf<List<TurnTimelineEntry>>(emptyList())
         private set
 
     var pendingToolApproval by mutableStateOf<ToolApprovalRequest?>(null)
         private set
 
-    var activeThinkingContent by mutableStateOf("")
+    // Session-only per-message full timelines (incl. thinking) for turns completed earlier in
+    // this session, keyed by message id — mirrors AgentRunArea's completedGroups. Falls back
+    // to ChatMessageDTO.contentBlocks (persisted, tool+text only) once no longer in this map.
+    var completedTimelines by mutableStateOf<Map<String, List<TurnTimelineGroup>>>(emptyMap())
         private set
 
     var bookmarkedMessageIds by mutableStateOf<Set<String>>(emptySet())
@@ -169,9 +174,9 @@ class ChatViewModel(
             selectedDirective = selectedDirective,
             sessionTitle = sessionTitle ?: "",
             project = project,
-            activeToolCalls = activeToolCalls,
+            activeTimeline = activeTimeline,
             pendingToolApproval = pendingToolApproval,
-            activeThinkingContent = activeThinkingContent,
+            completedTimelines = completedTimelines,
             bookmarkedMessageIds = bookmarkedMessageIds,
             pendingScrollToMessageId = pendingScrollToMessageId,
             memoryPressureLevel = memoryPressureLevel,
@@ -374,13 +379,13 @@ class ChatViewModel(
             val subscriptionScope = CoroutineScope(scope.coroutineContext + subscriptionJob)
             activeSubscriptions[sessionId] = subscriptionJob
 
-            val hasChunks = activeThread.chunks.value.isNotEmpty()
+            val hasEvents = activeThread.timeline.value.isNotEmpty()
 
-            if (!hasChunks) {
+            if (!hasEvents) {
                 isThinking = true
                 startThinkingTimer(activeThread.startTimeMillis)
             } else {
-                val streamingContent = activeThread.chunks.value.joinToString("")
+                val streamingContent = activeThread.timeline.value.filterIsInstance<TurnTimelineEntry.Token>().joinToString("") { it.text }
                 val newAiMessage = ChatMessageDTO(
                     content = streamingContent,
                     isUser = false,
@@ -392,19 +397,26 @@ class ChatViewModel(
                 insertAiMessage(newAiMessage)
             }
 
-            // Create a single job for this SPECIFIC threadId's subscription
+            // Single collector for the unified, chronologically-ordered timeline — tokens,
+            // tool calls, and thinking chunks all arrive through this one flow, preserving
+            // true interleaving order (see SessionManager.StreamingThread.timeline).
             subscriptionScope.launch {
-                var firstTokenReceived = hasChunks
+                var firstEventReceived = hasEvents
 
-                activeThread.chunks.collect { chunks ->
-                    if (currentSessionId.value == sessionId && chunks.isNotEmpty()) {
-                        if (!firstTokenReceived) {
-                            firstTokenReceived = true
+                activeThread.timeline.collect { timeline ->
+                    if (currentSessionId.value == sessionId && timeline.isNotEmpty()) {
+                        if (!firstEventReceived) {
+                            firstEventReceived = true
                             isThinking = false
                             stopThinkingTimer()
                         }
 
-                        val streamingContent = chunks.joinToString("")
+                        activeTimeline = timeline
+                        // Ensure a placeholder bubble exists so tool/thinking chips are visible
+                        // even before the first response token arrives.
+                        ensurePlaceholderAiMessage()
+
+                        val streamingContent = timeline.filterIsInstance<TurnTimelineEntry.Token>().joinToString("") { it.text }
                         currentResponse = streamingContent
 
                         val newAiMessage = ChatMessageDTO(
@@ -420,35 +432,10 @@ class ChatViewModel(
                 }
             }
 
-            // Subscribe to tool call state for the streaming message.
-            // When a tool fires before any text token arrives (no id=null message exists yet),
-            // inject a placeholder AI message so the bubble appears and can render tool chips.
-            subscriptionScope.launch {
-                activeThread.toolCalls.collect { calls ->
-                    if (currentSessionId.value == sessionId) {
-                        activeToolCalls = calls // No streaming bubble yet — create placeholder so tool chips are visible
-                        if (calls.isNotEmpty()) ensurePlaceholderAiMessage()
-                    }
-                }
-            }
-
-            // Subscribe to thinking/reasoning tokens streamed by models that expose reasoning.
-            // Accumulate chunks into a single string; UI renders them in a collapsible section.
             subscriptionScope.launch {
                 activeThread.pendingApproval.collect { request ->
                     if (currentSessionId.value == sessionId) {
                         pendingToolApproval = request
-                    }
-                }
-            }
-
-            subscriptionScope.launch {
-                activeThread.thinkingChunks.collect { chunks ->
-                    if (currentSessionId.value == sessionId) {
-                        activeThinkingContent = chunks.joinToString("")
-                        // Ensure a placeholder bubble exists so the thinking section is visible
-                        // even before the first response token arrives.
-                        if (chunks.isNotEmpty()) ensurePlaceholderAiMessage()
                     }
                 }
             }
@@ -496,6 +483,15 @@ class ChatViewModel(
                                 savedMessage.id,
                                 retryInsertPosition ?: "end",
                             )
+
+                            // Keep this turn's full ordered timeline (incl. thinking) visible for
+                            // the rest of the session, keyed by its now-stable message id — in
+                            // memory only, never written to the database (only Tool/Token blocks
+                            // are persisted, via ChatMessageDTO.contentBlocks).
+                            val finalTimeline = activeThread.timeline.value
+                            if (finalTimeline.isNotEmpty()) {
+                                completedTimelines = completedTimelines + (savedMessage.id to finalTimeline.grouped())
+                            }
                         } else {
                             log.warn("Saved message not available in StreamingThread for session $sessionId")
                         }
@@ -503,7 +499,7 @@ class ChatViewModel(
                         // Clear retry position tracker
                         retryInsertPosition = null
 
-                        // NOTE: activeToolCalls is NOT cleared here — chips stay visible on the
+                        // NOTE: activeTimeline is NOT cleared here — chips stay visible on the
                         // completed message until the user sends the next message.
 
                         // Refresh session title (in case it was auto-generated from first message)
@@ -514,9 +510,8 @@ class ChatViewModel(
                         // past its coroutine completion specifically for this read.
                         sessionManager.removeThread(sessionId)
 
-                        // Cancel and clean up ALL collectors (chunks, toolCalls,
-                        // pendingApproval, thinkingChunks, isComplete) for this session
-                        // now that the thread is done.
+                        // Cancel and clean up ALL collectors (timeline, pendingApproval,
+                        // isComplete) for this session now that the thread is done.
                         activeSubscriptions[sessionId]?.cancel()
                         activeSubscriptions.remove(sessionId)
                     }
@@ -628,9 +623,8 @@ class ChatViewModel(
                 thinkingElapsedSeconds = 0
 
                 // Clear tool chips and thinking content from the previous response before retrying
-                activeToolCalls = emptyList()
+                activeTimeline = emptyList()
                 pendingToolApproval = null
-                activeThinkingContent = ""
 
                 startThinkingTimer()
 
@@ -710,9 +704,8 @@ class ChatViewModel(
         if (message.isBlank() || isLoading) return
 
         // Clear tool chips and thinking content from the previous response now that a new message is starting
-        activeToolCalls = emptyList()
+        activeTimeline = emptyList()
         pendingToolApproval = null
-        activeThinkingContent = ""
 
         // Session ID must be set by this point (from resumeSession)
         val sessionId = currentSessionId.value ?: run {
@@ -1311,8 +1304,9 @@ class ChatViewModel(
         sessionTitle = null
         project = null
 
-        // Clear ephemeral tool call state
-        activeToolCalls = emptyList()
+        // Clear ephemeral tool/thinking timeline state
+        activeTimeline = emptyList()
+        completedTimelines = emptyMap()
 
         // Clear search state
         clearSearch()

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -88,6 +89,9 @@ import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.dto.ToolCallStatus
+import io.askimo.core.chat.dto.TurnTimelineEntry
+import io.askimo.core.chat.dto.TurnTimelineGroup
+import io.askimo.core.chat.dto.grouped
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.RunCodeEvent
 import io.askimo.core.event.internal.parseFilePreviewRequestEvent
@@ -137,8 +141,16 @@ fun messageList(
     onRetryMessage: ((String) -> Unit)? = null,
     viewportTopY: Float? = null,
     projectId: String? = null,
-    activeToolCalls: List<ToolCallInfo> = emptyList(),
-    activeThinkingContent: String = "",
+    // Ordered tool-call/text/thinking timeline for the *currently streaming/last* AI turn
+    // (this session only) — replaces the old activeToolCalls/activeThinkingContent pair so
+    // true chronological interleaving can be rendered. See SessionManager.StreamingThread.
+    activeTimeline: List<TurnTimelineEntry> = emptyList(),
+    // Session-only per-message lookup so completed AI messages (this session, or reloaded from
+    // persisted `AgentRunRecord.contentBlocks`/`ChatMessageDTO.contentBlocks`) can show their
+    // ordered tool/thinking/text timeline — e.g. an agentic run (or regular chat) keeping this
+    // visible for every past turn, not just the current "last" message (which instead uses
+    // activeTimeline above).
+    completedGroupsByMessageId: Map<String, List<TurnTimelineGroup>> = emptyMap(),
     bookmarkedMessageIds: Set<String> = emptySet(),
     onToggleBookmark: ((String) -> Unit)? = null,
     onForkFromMessage: ((String) -> Unit)? = null,
@@ -201,18 +213,41 @@ fun messageList(
                     }
 
                     val isActiveResult = searchQuery.isNotBlank() && messageIndex == currentSearchResultIndex
-                    // A message is streaming when it's the last AI message still without a persisted ID
+                    // A message is streaming when it's the last AI message still without a persisted ID.
                     val isStreamingMessage = !group.message.isUser && group.message.id == null
-                    // Show tool chips on the last AI message whether streaming (id=null) or already
-                    // persisted (real id). Matching by id covers both cases:
-                    //   • streaming  → both ids are null        → matched
-                    //   • completed  → real id matches          → matched
-                    //   • older msg  → id differs               → emptyList
+                    // "Last AI message" — used for the *live* activeTimeline. ChatViewModel
+                    // deliberately keeps this populated even after the message is finalized (real
+                    // id assigned) "until the user sends the next message" — so this must match by
+                    // id once finalized, not just while streaming (id == null).
                     val lastAiMessageId = messages.lastOrNull { !it.isUser }?.id
                     val isLastAiMsg = !group.message.isUser && (
                         (group.message.id != null && group.message.id == lastAiMessageId) ||
                             (group.message.id == null && lastAiMessageId == null)
                         )
+                    // Resolve the ordered timeline for this AI message, preferring (in order):
+                    // 1. the live in-progress timeline, if this is the current/last turn
+                    // 2. the session-only completed-timeline cache (keyed by message id)
+                    // 3. the persisted tool/text blocks on the message itself (survives restarts)
+                    val resolvedGroups: List<TurnTimelineGroup> = if (group.message.isUser) {
+                        emptyList()
+                    } else if (isLastAiMsg && activeTimeline.isNotEmpty()) {
+                        activeTimeline.grouped()
+                    } else {
+                        group.message.id?.let { completedGroupsByMessageId[it] }
+                            ?: group.message.contentBlocks.grouped()
+                    }
+                    val hasToolCalls = resolvedGroups.any { it is TurnTimelineGroup.ToolGroup }
+                    // Only switch to the ordered-timeline renderer when there's an actual tool
+                    // call to show — otherwise keep the existing rich-text rendering path
+                    // (streaming reveal, run-code dialog, link clicks, attachments) for the
+                    // common tool-free case.
+                    val fallbackThinkingContent = if (!hasToolCalls && isLastAiMsg) {
+                        resolvedGroups
+                            .filterIsInstance<TurnTimelineGroup.ThinkingGroup>()
+                            .joinToString("") { it.text }
+                    } else {
+                        ""
+                    }
                     messageBubble(
                         message = group.message,
                         searchQuery = searchQuery,
@@ -232,8 +267,17 @@ fun messageList(
                         },
                         isStreaming = isStreamingMessage,
                         projectId = projectId,
-                        toolCalls = if (isLastAiMsg) activeToolCalls else emptyList(),
-                        thinkingContent = if (isLastAiMsg) activeThinkingContent else "",
+                        toolCalls = emptyList(),
+                        thinkingContent = fallbackThinkingContent,
+                        // Any AI message with a resolved tool-call timeline (live, session-cached,
+                        // or persisted) renders the ordered timeline instead of the fixed
+                        // thinking-then-tools-then-text layout — for every past turn, not just
+                        // the last one.
+                        customBody = if (!group.message.isUser && hasToolCalls) {
+                            { turnTimelineView(resolvedGroups) }
+                        } else {
+                            null
+                        },
                         bookmarkedMessageIds = bookmarkedMessageIds,
                         onToggleBookmark = onToggleBookmark,
                         onForkFromMessage = onForkFromMessage,
@@ -333,6 +377,10 @@ fun messageBubble(
     projectId: String? = null,
     toolCalls: List<ToolCallInfo> = emptyList(),
     thinkingContent: String = "",
+    // When non-null, rendered instead of the built-in thinking/toolCalls/text sections —
+    // used to show an ordered (chronological) tool/thinking/text timeline for a message
+    // instead of the fixed thinking-then-tools-then-text layout. See `turnTimelineView`.
+    customBody: (@Composable () -> Unit)? = null,
     bookmarkedMessageIds: Set<String> = emptySet(),
     onToggleBookmark: ((String) -> Unit)? = null,
     onForkFromMessage: ((String) -> Unit)? = null,
@@ -373,6 +421,7 @@ fun messageBubble(
                 projectId = projectId,
                 toolCalls = toolCalls,
                 thinkingContent = thinkingContent,
+                customBody = customBody,
                 isBookmarked = message.id != null && message.id in bookmarkedMessageIds,
                 onToggleBookmark = if (message.id != null) onToggleBookmark else null,
                 onForkFromMessage = if (message.id != null) onForkFromMessage else null,
@@ -643,6 +692,7 @@ private fun aiMessageBubble(
     projectId: String? = null,
     toolCalls: List<ToolCallInfo> = emptyList(),
     thinkingContent: String = "",
+    customBody: (@Composable () -> Unit)? = null,
     isBookmarked: Boolean = false,
     onToggleBookmark: ((String) -> Unit)? = null,
     onForkFromMessage: ((String) -> Unit)? = null,
@@ -728,97 +778,101 @@ private fun aiMessageBubble(
                             ),
                     ) {
                         Column {
-                            // Thinking/reasoning collapsible section — shown when the model exposes reasoning
-                            if (thinkingContent.isNotEmpty()) {
-                                thinkingSection(
-                                    thinkingContent = thinkingContent,
-                                    isStreaming = isStreaming,
-                                    isExpanded = thinkingExpanded,
-                                    onToggle = { thinkingExpanded = !thinkingExpanded },
-                                )
-                            }
-
-                            // Tool call collapsible section — shown only during streaming
-                            if (toolCalls.isNotEmpty()) {
-                                toolCallsSection(
-                                    toolCalls = toolCalls,
-                                    isExpanded = toolCallsExpanded,
-                                    onToggle = { toolCallsExpanded = !toolCallsExpanded },
-                                )
-                            }
-
-                            if (message.attachments.isNotEmpty()) {
-                                Column(
-                                    modifier = Modifier.padding(start = Spacing.medium, end = Spacing.medium, top = Spacing.medium),
-                                    verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
-                                ) {
-                                    message.attachments.forEach { attachment ->
-                                        fileAttachmentChip(attachment = attachment, onDownload = onDownloadAttachment)
-                                    }
-                                }
-                            }
-
-                            if (searchQuery.isNotBlank()) {
-                                SelectionContainer {
-                                    Text(
-                                        text = highlightSearchText(
-                                            text = markdownToPlainText(message.content),
-                                            query = searchQuery,
-                                            highlightColor = Color(0xFFFFD54F),
-                                            isActiveResult = isActiveSearchResult,
-                                            activeHighlightColor = Color(0xFFFF8F00),
-                                        ),
-                                        modifier = Modifier.padding(start = Spacing.medium, end = 48.dp, top = Spacing.medium, bottom = Spacing.medium),
-                                        style = AppTextStyles.body,
+                            if (customBody != null) {
+                                customBody()
+                            } else {
+                                // Thinking/reasoning collapsible section — shown when the model exposes reasoning
+                                if (thinkingContent.isNotEmpty()) {
+                                    thinkingSection(
+                                        thinkingContent = thinkingContent,
+                                        isStreaming = isStreaming,
+                                        isExpanded = thinkingExpanded,
+                                        onToggle = { thinkingExpanded = !thinkingExpanded },
                                     )
                                 }
-                            } else {
-                                val onLinkClickHandler: (String) -> Unit = { url ->
-                                    if (url.startsWith("file://")) {
-                                        if (projectId != null) {
-                                            // Project chat — let the side panel handle it in the file viewer
-                                            EventBus.post(parseFilePreviewRequestEvent(url))
-                                        } else {
-                                            // Non-project chat — fall back to OS file browser
-                                            try {
-                                                val filePath = parseFilePreviewRequestEvent(url).filePath
-                                                val file = File(filePath)
-                                                if (file.exists() && Desktop.isDesktopSupported()) {
-                                                    Desktop.getDesktop().open(file)
-                                                }
-                                            } catch (_: Exception) {}
+
+                                // Tool call collapsible section — shown only during streaming
+                                if (toolCalls.isNotEmpty()) {
+                                    toolCallsSection(
+                                        toolCalls = toolCalls,
+                                        isExpanded = toolCallsExpanded,
+                                        onToggle = { toolCallsExpanded = !toolCallsExpanded },
+                                    )
+                                }
+
+                                if (message.attachments.isNotEmpty()) {
+                                    Column(
+                                        modifier = Modifier.padding(start = Spacing.medium, end = Spacing.medium, top = Spacing.medium),
+                                        verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+                                    ) {
+                                        message.attachments.forEach { attachment ->
+                                            fileAttachmentChip(attachment = attachment, onDownload = onDownloadAttachment)
                                         }
                                     }
                                 }
-                                if (isStreaming) {
-                                    markdownText(
-                                        markdown = message.content,
-                                        modifier = Modifier.padding(start = Spacing.medium, end = 48.dp, top = Spacing.medium, bottom = Spacing.medium),
-                                        viewportTopY = viewportTopY,
-                                        isStreaming = true,
-                                        onRunRequest = { cmd, lang -> pendingRunRequest = Pair(cmd, lang) },
-                                        messageId = message.id,
-                                        onLinkClick = onLinkClickHandler,
-                                    )
+
+                                if (searchQuery.isNotBlank()) {
+                                    SelectionContainer {
+                                        Text(
+                                            text = highlightSearchText(
+                                                text = markdownToPlainText(message.content),
+                                                query = searchQuery,
+                                                highlightColor = Color(0xFFFFD54F),
+                                                isActiveResult = isActiveSearchResult,
+                                                activeHighlightColor = Color(0xFFFF8F00),
+                                            ),
+                                            modifier = Modifier.padding(start = Spacing.medium, end = 48.dp, top = Spacing.medium, bottom = Spacing.medium),
+                                            style = AppTextStyles.body,
+                                        )
+                                    }
                                 } else {
-                                    revealingMarkdownText(
-                                        markdown = message.content,
-                                        modifier = Modifier.padding(start = Spacing.medium, end = 48.dp, top = Spacing.medium, bottom = Spacing.medium),
-                                        onRunRequest = { cmd, lang -> pendingRunRequest = Pair(cmd, lang) },
-                                        messageId = message.id,
-                                        onLinkClick = onLinkClickHandler,
+                                    val onLinkClickHandler: (String) -> Unit = { url ->
+                                        if (url.startsWith("file://")) {
+                                            if (projectId != null) {
+                                                // Project chat — let the side panel handle it in the file viewer
+                                                EventBus.post(parseFilePreviewRequestEvent(url))
+                                            } else {
+                                                // Non-project chat — fall back to OS file browser
+                                                try {
+                                                    val filePath = parseFilePreviewRequestEvent(url).filePath
+                                                    val file = File(filePath)
+                                                    if (file.exists() && Desktop.isDesktopSupported()) {
+                                                        Desktop.getDesktop().open(file)
+                                                    }
+                                                } catch (_: Exception) {}
+                                            }
+                                        }
+                                    }
+                                    if (isStreaming) {
+                                        markdownText(
+                                            markdown = message.content,
+                                            modifier = Modifier.padding(start = Spacing.medium, end = 48.dp, top = Spacing.medium, bottom = Spacing.medium),
+                                            viewportTopY = viewportTopY,
+                                            isStreaming = true,
+                                            onRunRequest = { cmd, lang -> pendingRunRequest = Pair(cmd, lang) },
+                                            messageId = message.id,
+                                            onLinkClick = onLinkClickHandler,
+                                        )
+                                    } else {
+                                        revealingMarkdownText(
+                                            markdown = message.content,
+                                            modifier = Modifier.padding(start = Spacing.medium, end = 48.dp, top = Spacing.medium, bottom = Spacing.medium),
+                                            onRunRequest = { cmd, lang -> pendingRunRequest = Pair(cmd, lang) },
+                                            messageId = message.id,
+                                            onLinkClick = onLinkClickHandler,
+                                        )
+                                    }
+                                }
+
+                                if (isOutdatedMessage) {
+                                    Text(
+                                        text = stringResource("outdated.label"),
+                                        style = AppTextStyles.hint,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                        fontStyle = FontStyle.Italic,
+                                        modifier = Modifier.padding(start = Spacing.medium, end = Spacing.medium, bottom = Spacing.small, top = Spacing.extraSmall),
                                     )
                                 }
-                            }
-
-                            if (isOutdatedMessage) {
-                                Text(
-                                    text = stringResource("outdated.label"),
-                                    style = AppTextStyles.hint,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                                    fontStyle = FontStyle.Italic,
-                                    modifier = Modifier.padding(start = Spacing.medium, end = Spacing.medium, bottom = Spacing.small, top = Spacing.extraSmall),
-                                )
                             }
                         }
                     }
@@ -1156,7 +1210,7 @@ private fun aiMessageBubble(
  * The body uses a muted italic style visually distinct from the main response.
  */
 @Composable
-private fun thinkingSection(
+internal fun thinkingSection(
     thinkingContent: String,
     isStreaming: Boolean,
     isExpanded: Boolean,
@@ -1259,12 +1313,73 @@ private fun thinkingSection(
 }
 
 /**
+ * Renders timeline groups in chronological order — tool-call and thinking groups reuse this
+ * file's own collapsible sections ([toolCallsSection]/[thinkingSection]); token groups render
+ * as normal markdown; status groups show as a small muted subtitle. Each group gets its own
+ * remembered expand/collapse state, keyed by position — stable since groups are only ever
+ * appended at the end for a given message.
+ *
+ * Used both for the live streaming turn (agentic runs) and for finalized/historical AI
+ * messages (via [messageBubble]'s `customBody`), so order is preserved identically in both.
+ */
+@Composable
+internal fun turnTimelineView(groups: List<TurnTimelineGroup>) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+    ) {
+        groups.forEachIndexed { index, group ->
+            key(index) {
+                when (group) {
+                    is TurnTimelineGroup.StatusGroup -> {
+                        Text(
+                            text = group.entries.last().text,
+                            style = AppTextStyles.caption,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            maxLines = 1,
+                            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+
+                    is TurnTimelineGroup.ToolGroup -> {
+                        var expanded by remember { mutableStateOf(true) }
+                        toolCallsSection(
+                            toolCalls = group.entries.map { it.toolCall },
+                            isExpanded = expanded,
+                            onToggle = { expanded = !expanded },
+                        )
+                    }
+
+                    is TurnTimelineGroup.ThinkingGroup -> {
+                        var expanded by remember { mutableStateOf(true) }
+                        thinkingSection(
+                            thinkingContent = group.text,
+                            isStreaming = false,
+                            isExpanded = expanded,
+                            onToggle = { expanded = !expanded },
+                        )
+                    }
+
+                    is TurnTimelineGroup.TokenGroup -> {
+                        markdownText(
+                            markdown = group.text,
+                            modifier = Modifier.fillMaxWidth().padding(start = Spacing.medium, end = 48.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
  * Collapsible section that displays AI tool calls above the response text.
  * Shows "▶ Running tool…" when any tool is active, "▶ Used N tool(s)" when all are done.
  * Expands automatically when a tool starts running; collapses manually by the user.
  */
 @Composable
-private fun toolCallsSection(
+internal fun toolCallsSection(
     toolCalls: List<ToolCallInfo>,
     isExpanded: Boolean,
     onToggle: () -> Unit,
@@ -1471,18 +1586,20 @@ private fun toolCallDetailSection(
             style = AppTextStyles.hint,
             color = labelColor ?: MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
         )
-        Text(
-            text = content,
-            style = AppTextStyles.codeSecondary,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f),
-                    shape = RoundedCornerShape(4.dp),
-                )
-                .padding(horizontal = Spacing.extraSmall, vertical = 2.dp),
-        )
+        SelectionContainer {
+            Text(
+                text = content,
+                style = AppTextStyles.codeSecondary,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f),
+                        shape = RoundedCornerShape(4.dp),
+                    )
+                    .padding(horizontal = Spacing.extraSmall, vertical = 2.dp),
+            )
+        }
     }
 }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -4,12 +4,11 @@
  */
 package io.askimo.ui.common.theme
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.MarqueeAnimationMode
 import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
@@ -31,7 +30,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
@@ -78,20 +76,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -1022,21 +1016,13 @@ object AppComponents {
 
     /**
      * Single-line text that reveals content clipped by ellipsis/truncation when hovered,
-     * by scrolling horizontally at a constant speed and holding at the end — the classic
-     * "marquee on hover" pattern used for long list-item titles (session names, project
-     * names, tab titles, etc.).
+     * by scrolling horizontally at a constant speed — the classic "marquee on hover" pattern
+     * used for long list-item titles (session names, project names, tab titles, etc.).
      *
-     * Both the container width and the text's natural (unbounded) width are captured from
-     * the *same actual layout pass* (via [Modifier.onSizeChanged] on the container, and on
-     * the [Text] itself measured with [Modifier.wrapContentWidth] `unbounded = true`) —
-     * deliberately avoiding a separate `rememberTextMeasurer` estimate, since that can
-     * subtly diverge from the real rendered width and cause the scroll to over/undershoot
-     * the true end of the text. Text that already fits never moves.
+     * Text that already fits the available width never scrolls.
      *
-     * On hover-exit, animates back to the start position so the caller's own truncation
-     * (e.g. `TextOverflow.Ellipsis` used elsewhere for the resting state) reads correctly again.
-     *
-     * @param isHovered Drives the scroll: `true` starts/holds the scroll, `false` resets it.
+     * @param isHovered Drives the scroll: `true` starts/holds the scroll, `false` stops it
+     * immediately and the caller's own truncation (`TextOverflow.Ellipsis`) applies.
      */
     @Composable
     fun marqueeText(
@@ -1046,45 +1032,23 @@ object AppComponents {
         style: TextStyle = LocalTextStyle.current,
         color: Color = Color.Unspecified,
     ) {
-        var containerWidthPx by remember { mutableIntStateOf(0) }
-        var textWidthPx by remember { mutableIntStateOf(0) }
-
-        val overflowPx = (textWidthPx - containerWidthPx).coerceAtLeast(0)
-        val shouldScroll = isHovered && overflowPx > 0
-
-        val offsetPx by animateFloatAsState(
-            targetValue = if (shouldScroll) -overflowPx.toFloat() else 0f,
-            animationSpec = if (shouldScroll) {
-                tween(durationMillis = (overflowPx * 26).coerceAtLeast(1), easing = LinearEasing)
-            } else {
-                tween(durationMillis = 250)
-            },
-            label = "marqueeOffset",
-        )
-
-        Box(
-            modifier = modifier
-                .clipToBounds()
-                .onSizeChanged { containerWidthPx = it.width },
-        ) {
-            Text(
-                text = text,
-                style = style,
-                color = color,
-                maxLines = 1,
-                softWrap = false,
-                overflow = TextOverflow.Clip,
-                modifier = Modifier
-                    // Let the Text measure at its true, full natural width regardless of the
-                    // parent's constraint (e.g. from a Row `weight(1f)`) — otherwise it would be
-                    // clipped down to the container width, leaving nothing to reveal when
-                    // translating. `onSizeChanged` then reports that exact same width used for
-                    // drawing, guaranteeing the scroll ends precisely when the last character
-                    // reaches the visible (clipped) right edge — no separate estimate involved.
-                    .wrapContentWidth(align = androidx.compose.ui.Alignment.Start, unbounded = true)
-                    .onSizeChanged { textWidthPx = it.width }
-                    .graphicsLayer { translationX = offsetPx },
+        val marqueeModifier = if (isHovered) {
+            Modifier.basicMarquee(
+                iterations = Int.MAX_VALUE,
+                animationMode = MarqueeAnimationMode.Immediately,
+                velocity = 40.dp,
+                initialDelayMillis = 0,
             )
+        } else {
+            Modifier
         }
+        Text(
+            text = text,
+            style = style,
+            color = color,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = modifier.then(marqueeModifier),
+        )
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionManager.kt
@@ -16,6 +16,8 @@ import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.dto.ToolApprovalRequest
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.dto.ToolCallStatus
+import io.askimo.core.chat.dto.TurnTimelineEntry
+import io.askimo.core.chat.dto.collapsedEffectiveTools
 import io.askimo.core.chat.service.ChatDirectiveService
 import io.askimo.core.chat.service.ChatSessionService
 import io.askimo.core.context.AppContext
@@ -136,17 +138,21 @@ class SessionManager(
     /**
      * Represents a single streaming thread for ONE question-answer pair.
      * Thread closes automatically after completion or failure.
+     *
+     * [_timeline] is the single source of truth for everything the model's stream reported —
+     * response-text tokens, tool calls (running → done), and thinking chunks — kept in the
+     * exact chronological order they arrived, mirroring [io.askimo.core.chat.dto.TurnTimelineEntry]'s
+     * use in agentic runs. This lets the UI render true interleaving (e.g. text → tool call →
+     * more text) instead of bucketing everything into fixed thinking/tools/text sections.
      */
     data class StreamingThread(
         val threadId: String,
         val sessionId: String,
         var job: Job,
-        private val _chunks: MutableStateFlow<List<String>>,
+        private val _timeline: MutableStateFlow<List<TurnTimelineEntry>>,
         private val _isComplete: MutableStateFlow<Boolean>,
         private val _hasFailed: MutableStateFlow<Boolean>,
         private val _savedMessage: MutableStateFlow<ChatMessage?> = MutableStateFlow(null),
-        private val _toolCalls: MutableStateFlow<List<ToolCallInfo>> = MutableStateFlow(emptyList()),
-        private val _thinkingChunks: MutableStateFlow<List<String>> = MutableStateFlow(emptyList()),
         private val _pendingApproval: MutableStateFlow<ToolApprovalRequest?> = MutableStateFlow(null),
         // Wall-clock time the thread started "thinking" (before the first chunk arrives).
         // Used to compute the correct elapsed "thinking" time when a ViewModel re-subscribes
@@ -154,11 +160,9 @@ class SessionManager(
         // resetting the on-screen timer to 0.
         val startTimeMillis: Long = System.currentTimeMillis(),
     ) {
-        val chunks: StateFlow<List<String>> = _chunks.asStateFlow()
+        val timeline: StateFlow<List<TurnTimelineEntry>> = _timeline.asStateFlow()
         val isComplete: StateFlow<Boolean> = _isComplete.asStateFlow()
         val savedMessage: StateFlow<ChatMessage?> = _savedMessage.asStateFlow()
-        val toolCalls: StateFlow<List<ToolCallInfo>> = _toolCalls.asStateFlow()
-        val thinkingChunks: StateFlow<List<String>> = _thinkingChunks.asStateFlow()
         val pendingApproval: StateFlow<ToolApprovalRequest?> = _pendingApproval.asStateFlow()
 
         /** Sets the pending approval request, surfacing Approve/Deny buttons in the UI. */
@@ -173,15 +177,16 @@ class SessionManager(
 
         private val mutex = Mutex()
 
+        /** Appends a response-text chunk as a Token entry, at its true chronological position. */
         suspend fun appendChunk(chunk: String) {
             mutex.withLock {
-                _chunks.value += chunk
+                _timeline.value += TurnTimelineEntry.Token(chunk)
             }
         }
 
         suspend fun appendThinkingChunk(chunk: String) {
             mutex.withLock {
-                _thinkingChunks.value += chunk
+                _timeline.value += TurnTimelineEntry.Thinking(chunk)
             }
         }
 
@@ -203,40 +208,39 @@ class SessionManager(
             }
         }
 
-        /** Mark a tool as RUNNING. Deduplicates: no-op if already tracked. */
+        /** Appends a RUNNING tool entry at its true chronological position. Deduplicates: no-op if already tracked as RUNNING. */
         suspend fun markToolRunning(toolName: String, arguments: String?) {
             mutex.withLock {
-                if (_toolCalls.value.none { it.toolName == toolName }) {
-                    _toolCalls.value += ToolCallInfo(
-                        toolName = toolName,
-                        status = ToolCallStatus.RUNNING,
-                        arguments = arguments,
+                val alreadyRunning = _timeline.value.any {
+                    it is TurnTimelineEntry.Tool && it.toolCall.toolName == toolName && it.toolCall.status == ToolCallStatus.RUNNING
+                }
+                if (!alreadyRunning) {
+                    _timeline.value += TurnTimelineEntry.Tool(
+                        ToolCallInfo(toolName = toolName, status = ToolCallStatus.RUNNING, arguments = arguments),
                     )
                 }
             }
         }
 
-        /** Mark a tool as DONE. Replaces existing RUNNING entry, or appends if not found. */
+        /** Flips the matching RUNNING tool entry to DONE in-place, preserving its original chronological position. */
         suspend fun markToolDone(toolName: String, arguments: String?, result: String?, hasFailed: Boolean) {
             mutex.withLock {
-                val existing = _toolCalls.value
-                val idx = existing.indexOfFirst { it.toolName == toolName }
-                val updated = ToolCallInfo(
-                    toolName = toolName,
-                    status = ToolCallStatus.DONE,
-                    arguments = arguments,
-                    result = result,
-                    hasFailed = hasFailed,
+                val list = _timeline.value
+                val idx = list.indexOfLast {
+                    it is TurnTimelineEntry.Tool && it.toolCall.toolName == toolName && it.toolCall.status == ToolCallStatus.RUNNING
+                }
+                val updated = TurnTimelineEntry.Tool(
+                    ToolCallInfo(toolName = toolName, status = ToolCallStatus.DONE, arguments = arguments, result = result, hasFailed = hasFailed),
                 )
-                _toolCalls.value = if (idx >= 0) {
-                    existing.toMutableList().also { it[idx] = updated }
+                _timeline.value = if (idx >= 0) {
+                    list.toMutableList().also { it[idx] = updated }
                 } else {
-                    existing + updated
+                    list + updated
                 }
             }
         }
 
-        fun getCurrentContent(): String = _chunks.value.joinToString("")
+        fun getCurrentContent(): String = _timeline.value.filterIsInstance<TurnTimelineEntry.Token>().joinToString("") { it.text }
     }
 
     /**
@@ -301,7 +305,7 @@ class SessionManager(
             threadId = threadId,
             sessionId = sessionId,
             job = Job(),
-            _chunks = MutableStateFlow(emptyList()),
+            _timeline = MutableStateFlow(emptyList()),
             _isComplete = MutableStateFlow(false),
             _hasFailed = MutableStateFlow(false),
         )
@@ -429,6 +433,8 @@ class SessionManager(
                         outputTokens = capturedOutputTokens,
                         totalTokens = capturedTotalTokens,
                         durationMs = capturedDurationMs,
+                        contentBlocks = thread.timeline.value.collapsedEffectiveTools()
+                            .filter { it is TurnTimelineEntry.Tool || it is TurnTimelineEntry.Token },
                     )
                     thread.setSavedMessage(savedMessage)
                     log.debug("Streaming thread $threadId completed successfully. Saved response to session $sessionId.")
@@ -494,7 +500,13 @@ class SessionManager(
                     )
                 }
 
-                val savedMessage = chatSessionService.saveAiResponse(sessionId, failedResponse, isFailed = true)
+                val savedMessage = chatSessionService.saveAiResponse(
+                    sessionId,
+                    failedResponse,
+                    isFailed = true,
+                    contentBlocks = thread.timeline.value.collapsedEffectiveTools()
+                        .filter { it is TurnTimelineEntry.Tool || it is TurnTimelineEntry.Token },
+                )
                 thread.setSavedMessage(savedMessage)
 
                 if (failedResponse != partialResponse && failedResponse.length > partialResponse.length) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -86,6 +87,7 @@ import io.askimo.ui.session.SessionsViewModel
 import io.askimo.ui.session.deleteSessionDialog
 import io.askimo.ui.session.sessionTooltip
 import io.askimo.ui.util.Platform
+import kotlinx.coroutines.launch
 import java.io.File
 import java.net.URI
 import java.net.http.HttpClient
@@ -160,6 +162,30 @@ fun navigationSidebar(
         animationSpec = tween(durationMillis = 300),
     )
 
+    val scope = rememberCoroutineScope()
+
+    // Optimistic UI override for the selected session.
+    //
+    // `onResumeSession` is async and the caller's `currentSessionId` state only updates once
+    // that navigation completes, which can make the sidebar selection feel laggy on click.
+    // To avoid that, `navigateToSession` sets this immediately on click so the item is
+    // highlighted instantly, while the real navigation happens in the background. Once the
+    // caller's `currentSessionId` catches up (see the LaunchedEffect below), this override is
+    // cleared and the real state takes over again.
+    var optimisticSessionId by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(currentSessionId) {
+        // Once the real state (from the caller) catches up, drop the optimistic override.
+        optimisticSessionId = null
+    }
+    val effectiveSessionId = optimisticSessionId ?: currentSessionId
+    val navigateToSession = remember(onResumeSession) {
+        { sessionId: String ->
+            optimisticSessionId = sessionId // 1. set selected background — instant
+            scope.launch { onResumeSession(sessionId) } // 2. async "navigation" event — loads later
+            Unit
+        }
+    }
+
     if (isExpanded) {
         expandedNavigationSidebar(
             animatedWidth = animatedWidth,
@@ -169,13 +195,13 @@ fun navigationSidebar(
             projectsState = projectsState,
             pinnedState = pinnedState,
             sessionsViewModel = sessionsViewModel,
-            currentSessionId = currentSessionId,
+            currentSessionId = effectiveSessionId,
             onToggleExpand = onToggleExpand,
             onNewChat = onNewChat,
             onToggleSessions = onToggleSessions,
             onNavigateToSessions = onNavigateToSessions,
             onSelectProject = onSelectProject,
-            onResumeSession = onResumeSession,
+            onResumeSession = navigateToSession,
             onDeleteSession = onDeleteSession,
             onStarSession = onStarSession,
             onStarProject = onStarProject,

--- a/shared/src/main/kotlin/io/askimo/core/agent/AntigravityAgent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/AntigravityAgent.kt
@@ -138,6 +138,7 @@ class AntigravityAgent : ExternalAgentTemplate() {
     override fun parseStdoutLine(
         line: String,
         onToken: (String) -> Unit,
+        onToolCall: (toolName: String, detail: String?) -> Unit,
         onStatus: (String) -> Unit,
         onThinking: (String) -> Unit,
         output: StringBuilder,
@@ -167,6 +168,10 @@ class AntigravityAgent : ExternalAgentTemplate() {
                     }
 
                     // "user_input DONE" is just an ack of our own prompt — nothing to surface.
+                    // TODO: some `stepType`s here likely correspond to actual tool invocations
+                    // (e.g. file read/write, shell exec) rather than generic lifecycle status —
+                    // revisit and route those through onToolCall once the exact stream-json
+                    // shape for Antigravity's tool-call steps is confirmed against a real CLI run.
                     stepType != null && stepType != "user_input" -> {
                         onStatus(if (state != null) "$stepType ($state)" else stepType)
                     }

--- a/shared/src/main/kotlin/io/askimo/core/agent/ClaudeAgent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ClaudeAgent.kt
@@ -146,6 +146,7 @@ class ClaudeAgent : ExternalAgentTemplate() {
     override fun parseStdoutLine(
         line: String,
         onToken: (String) -> Unit,
+        onToolCall: (toolName: String, detail: String?) -> Unit,
         onStatus: (String) -> Unit,
         onThinking: (String) -> Unit,
         output: StringBuilder,
@@ -192,21 +193,17 @@ class ClaudeAgent : ExternalAgentTemplate() {
 
                             @Suppress("UNCHECKED_CAST")
                             val input = fields["input"] as? Map<String, Any>
-                            val summary = buildString {
-                                append("tool: $toolName")
-                                if (input != null) {
-                                    val detail = (input["file_path"] ?: input["command"] ?: input.values.firstOrNull())
-                                        ?.toString()?.let {
-                                            if (it.length > 80) it.take(77) + "…" else it
-                                        }
-                                    if (detail != null) append(" → $detail")
-                                }
-                            }
-                            onStatus(summary)
+                            val detail = input
+                                ?.let { it["file_path"] ?: it["command"] ?: it.values.firstOrNull() }
+                                ?.toString()
+                            onToolCall(toolName, detail)
                         }
 
                         "thinking" -> {
                             val thinking = fields["thinking"] as? String ?: continue
+                            if (thinking.isBlank()) {
+                                continue
+                            }
                             log.debug("claude thinking: {}", thinking.take(200))
                             onThinking(thinking)
                         }

--- a/shared/src/main/kotlin/io/askimo/core/agent/CodexAgent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/CodexAgent.kt
@@ -154,10 +154,14 @@ class CodexAgent : ExternalAgentTemplate() {
     override fun parseStdoutLine(
         line: String,
         onToken: (String) -> Unit,
+        onToolCall: (toolName: String, detail: String?) -> Unit,
         onStatus: (String) -> Unit,
         onThinking: (String) -> Unit,
         output: StringBuilder,
     ) {
+        // TODO: Codex prints raw stdout lines rather than structured tool-call events —
+        // no reliable way yet to distinguish an actual tool invocation from plain text, so
+        // everything still streams via onToken. Revisit if Codex CLI adds structured events.
         captureSessionId(line)
         output.appendLine(line)
         onToken(line + "\n")

--- a/shared/src/main/kotlin/io/askimo/core/agent/CursorAgent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/CursorAgent.kt
@@ -98,10 +98,15 @@ class CursorAgent : ExternalAgentTemplate() {
     override fun parseStdoutLine(
         line: String,
         onToken: (String) -> Unit,
+        onToolCall: (toolName: String, detail: String?) -> Unit,
         onStatus: (String) -> Unit,
         onThinking: (String) -> Unit,
         output: StringBuilder,
     ) {
+        // TODO: Cursor's stream-json events are rendered as generic status text via
+        // CursorStreamJsonEventParser.renderStatus — no structured tool-name/args extraction
+        // yet, so real tool invocations aren't routed through onToolCall. Revisit once the
+        // exact event shape for Cursor's tool calls is confirmed against a real CLI run.
         val event = CursorStreamJsonEventParser.parse(line)
         if (event == null) {
             log.debug("cursor unparseable line: {}", line)

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgent.kt
@@ -141,8 +141,16 @@ interface ExternalAgent {
      *                        to resume instead of starting a new conversation. `null` starts fresh.
      *                        Agents that do not support resuming ignore this.
      * @param onToken         Called for each content token as it arrives (pure response text).
-     * @param onStatus        Called with a short human-readable status string when the agent
-     *                        performs a tool call (e.g. "Using tool: readFile"). Defaults to no-op.
+     * @param onToolCall       Called when the agent actually invokes a tool (e.g. reads a file,
+     *                        runs a command) — `toolName` is the tool's name, `detail` is an
+     *                        optional short, human-readable summary of its arguments (e.g. the
+     *                        file path or command being run), truncated for display. Defaults
+     *                        to no-op. This is distinct from [onStatus]: a tool call is a
+     *                        discrete, structured event the UI renders as a "tool call" chip.
+     * @param onStatus        Called with a short human-readable status string for non-tool
+     *                        lifecycle/informational events (e.g. session init, run summary).
+     *                        Defaults to no-op. Never called for actual tool invocations — see
+     *                        [onToolCall] for those.
      * @return The complete stdout output, or a [Result.failure] on error.
      */
     fun run(
@@ -151,6 +159,7 @@ interface ExternalAgent {
         workDir: File? = null,
         resumeSessionId: String? = null,
         onToken: (String) -> Unit = {},
+        onToolCall: (toolName: String, detail: String?) -> Unit = { _, _ -> },
         onStatus: (String) -> Unit = {},
         onThinking: (String) -> Unit = {},
     ): Result<String>
@@ -165,11 +174,12 @@ interface ExternalAgent {
         workDir: File? = null,
         resumeSessionId: String? = null,
         onToken: (String) -> Unit = {},
+        onToolCall: (toolName: String, detail: String?) -> Unit = { _, _ -> },
         onStatus: (String) -> Unit = {},
         onThinking: (String) -> Unit = {},
     ): Result<String> {
         val startMs = System.currentTimeMillis()
-        val result = run(systemPrompt, userInput, workDir, resumeSessionId, onToken, onStatus, onThinking)
+        val result = run(systemPrompt, userInput, workDir, resumeSessionId, onToken, onToolCall, onStatus, onThinking)
         val durationMs = System.currentTimeMillis() - startMs
         Analytics.track(
             AnalyticsEvent.SKILL_AGENT_RUN,

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
@@ -118,16 +118,19 @@ abstract class ExternalAgentTemplate : ExternalAgent {
     /**
      * Parses a single line from process stdout.
      * Called for each non-blank line as it arrives.
-     * Should call [onToken] to stream response text and [onStatus] for status updates.
+     * Should call [onToken] to stream response text, [onToolCall] when the agent actually
+     * invokes a tool, and [onStatus] for non-tool lifecycle/status updates.
      *
      * @param line      A non-blank line from stdout.
      * @param onToken   Callback to emit response text tokens.
-     * @param onStatus  Callback to emit status messages (e.g., "Using tool: readFile").
+     * @param onToolCall Callback to emit a discrete tool invocation (name + optional detail).
+     * @param onStatus  Callback to emit non-tool status messages (e.g. session init, run summary).
      * @param output    StringBuilder accumulating all processed output (append final result).
      */
     protected abstract fun parseStdoutLine(
         line: String,
         onToken: (String) -> Unit,
+        onToolCall: (toolName: String, detail: String?) -> Unit,
         onStatus: (String) -> Unit,
         onThinking: (String) -> Unit,
         output: StringBuilder,
@@ -204,6 +207,7 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         workDir: File?,
         resumeSessionId: String?,
         onToken: (String) -> Unit,
+        onToolCall: (toolName: String, detail: String?) -> Unit,
         onStatus: (String) -> Unit,
         onThinking: (String) -> Unit,
     ): Result<String> = runCatching {
@@ -281,7 +285,7 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         val output = StringBuilder()
         process.inputStream.bufferedReader().forEachLine { line ->
             if (line.isBlank()) return@forEachLine
-            parseStdoutLine(line, onToken, onStatus, onThinking, output)
+            parseStdoutLine(line, onToken, onToolCall, onStatus, onThinking, output)
         }
 
         // Wait for stdin to finish (it is almost always done by the time stdout is drained).

--- a/shared/src/main/kotlin/io/askimo/core/agent/domain/AgentRunRecord.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/domain/AgentRunRecord.kt
@@ -4,6 +4,7 @@
  */
 package io.askimo.core.agent.domain
 
+import io.askimo.core.chat.dto.TurnTimelineEntry
 import io.askimo.core.db.sqliteInstant
 import org.jetbrains.exposed.v1.core.Table
 import java.time.Instant
@@ -25,7 +26,14 @@ import java.util.UUID
  * @param response    The full AI-generated response text; empty if the run failed.
  * @param error       Error message if the run failed; null on success.
  * @param agentSessionId Optional external agent session identifier (if the runtime exposes one).
- * @param activityLog Ordered list of agent status/tool events emitted during this turn.
+ * @param activityLog Ordered list of agent status/tool events emitted during this turn — plain
+ *                    tool names only, kept for backward compatibility. See [contentBlocks] for
+ *                    the richer, order-preserving version.
+ * @param contentBlocks Ordered content blocks for this turn — tool calls and response-text
+ *                    chunks, in the exact order they occurred, so history can reconstruct
+ *                    interleaving (e.g. text → tool → text) instead of bucketing tools above
+ *                    text. Deliberately excludes [TurnTimelineEntry.Thinking]/[TurnTimelineEntry.Status] —
+ *                    reasoning/lifecycle text stays session-only, never persisted.
  * @param inputTokens  Best-effort input token count reported by the agent, if any.
  * @param outputTokens Best-effort output token count reported by the agent, if any.
  * @param totalTokens  Best-effort total token count reported by the agent, if any.
@@ -34,6 +42,7 @@ import java.util.UUID
  */
 data class AgentRunRecord(
     val id: String = UUID.randomUUID().toString(),
+
     val workspaceId: String,
     val conversationId: String,
     val userInput: String,
@@ -41,6 +50,7 @@ data class AgentRunRecord(
     val error: String?,
     val agentSessionId: String? = null,
     val activityLog: List<String>,
+    val contentBlocks: List<TurnTimelineEntry> = emptyList(),
     val inputTokens: Int? = null,
     val outputTokens: Int? = null,
     val totalTokens: Int? = null,
@@ -52,6 +62,8 @@ data class AgentRunRecord(
  * Exposed table definition for agent_run_history.
  *
  * [activityLog] is stored as a newline-delimited text block — no JSON dependency needed.
+ * [contentJson] stores the richer [AgentRunRecord.contentBlocks] list as JSON; nullable so
+ * older rows (created before this column existed) simply decode to an empty list.
  * Token usage columns are nullable — older rows and agents that don't expose structured
  * usage (e.g. Codex today) simply have `null` here.
  */
@@ -66,6 +78,9 @@ object AgentRunHistoryTable : Table("agent_run_history") {
 
     /** Newline-delimited activity log entries. */
     val activityLog = text("activity_log").default("")
+
+    /** JSON-encoded `List<TurnTimelineEntry>` (Tool + Token only) — ordered content blocks. */
+    val contentJson = text("content_json").nullable()
 
     val inputTokens = integer("input_tokens").nullable()
     val outputTokens = integer("output_tokens").nullable()

--- a/shared/src/main/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepository.kt
@@ -6,9 +6,13 @@ package io.askimo.core.agent.repository
 
 import io.askimo.core.agent.domain.AgentRunHistoryTable
 import io.askimo.core.agent.domain.AgentRunRecord
+import io.askimo.core.chat.dto.TurnTimelineEntry
 import io.askimo.core.db.AbstractSQLiteRepository
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.logging.logger
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.eq
@@ -28,6 +32,7 @@ class AgentRunHistoryRepository internal constructor(
 ) : AbstractSQLiteRepository(databaseManager) {
 
     private val log = logger<AgentRunHistoryRepository>()
+    private val json = Json { ignoreUnknownKeys = true }
 
     /**
      * Persists a new run record. The [record.id] must already be set (UUID).
@@ -43,6 +48,7 @@ class AgentRunHistoryRepository internal constructor(
                 it[error] = record.error
                 it[agentSessionId] = record.agentSessionId
                 it[activityLog] = encodeLog(record.activityLog)
+                it[contentJson] = if (record.contentBlocks.isEmpty()) null else json.encodeToString(record.contentBlocks)
                 it[inputTokens] = record.inputTokens
                 it[outputTokens] = record.outputTokens
                 it[totalTokens] = record.totalTokens
@@ -135,6 +141,7 @@ class AgentRunHistoryRepository internal constructor(
         error = row[AgentRunHistoryTable.error],
         agentSessionId = row[AgentRunHistoryTable.agentSessionId],
         activityLog = decodeLog(row[AgentRunHistoryTable.activityLog]),
+        contentBlocks = decodeContentBlocks(row[AgentRunHistoryTable.contentJson]),
         inputTokens = row[AgentRunHistoryTable.inputTokens],
         outputTokens = row[AgentRunHistoryTable.outputTokens],
         totalTokens = row[AgentRunHistoryTable.totalTokens],
@@ -147,5 +154,12 @@ class AgentRunHistoryRepository internal constructor(
     private fun decodeLog(raw: String): List<String> {
         if (raw.isBlank()) return emptyList()
         return raw.lines().map { it.replace("\\n", "\n") }
+    }
+
+    private fun decodeContentBlocks(raw: String?): List<TurnTimelineEntry> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return runCatching { json.decodeFromString<List<TurnTimelineEntry>>(raw) }
+            .onFailure { e -> log.warn("Failed to decode content_json: {}", e.message) }
+            .getOrDefault(emptyList())
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/chat/domain/ChatMessage.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/domain/ChatMessage.kt
@@ -4,6 +4,7 @@
  */
 package io.askimo.core.chat.domain
 
+import io.askimo.core.chat.dto.TurnTimelineEntry
 import io.askimo.core.context.MessageRole
 import io.askimo.core.db.sqliteInstant
 import org.jetbrains.exposed.v1.core.ReferenceOption
@@ -26,6 +27,9 @@ data class ChatMessage(
     val totalTokens: Int? = null,
     val durationMs: Long? = null,
     val isBookmarked: Boolean = false,
+    // Ordered tool-call + response-text content blocks (Tool + Token only) — see
+    // ChatMessageDTO.contentBlocks for the full rationale.
+    val contentBlocks: List<TurnTimelineEntry> = emptyList(),
 )
 
 /**
@@ -54,6 +58,9 @@ object ChatMessagesTable : Table("chat_messages") {
     val totalTokens = integer("total_tokens").nullable()
     val durationMs = long("duration_ms").nullable()
     val isBookmarked = integer("is_bookmarked").default(0)
+
+    /** JSON-encoded `List<TurnTimelineEntry>` (Tool + Token only) — mirrors agent_run_history.content_json. */
+    val contentJson = text("content_json").nullable()
 
     val syncedAt = varchar("synced_at", 32).nullable()
 

--- a/shared/src/main/kotlin/io/askimo/core/chat/dto/ChatMessageDTO.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/dto/ChatMessageDTO.kt
@@ -25,4 +25,9 @@ data class ChatMessageDTO(
     val totalTokens: Int? = null,
     val durationMs: Long? = null,
     val isBookmarked: Boolean = false,
+    // Ordered tool-call + response-text content blocks for this message, in the exact order
+    // they occurred (e.g. text → tool → text) — mirrors AgentRunRecord.contentBlocks.
+    // Excludes Thinking/Status: reasoning/lifecycle text stays session-only, never persisted.
+    // Cleared (empty) whenever the message is edited — see ChatMessageRepository.updateMessageContent.
+    val contentBlocks: List<TurnTimelineEntry> = emptyList(),
 )

--- a/shared/src/main/kotlin/io/askimo/core/chat/dto/ToolCallInfo.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/dto/ToolCallInfo.kt
@@ -4,9 +4,12 @@
  */
 package io.askimo.core.chat.dto
 
+import kotlinx.serialization.Serializable
+
 /**
  * Status of a single tool call made by the AI during a streaming response.
  */
+@Serializable
 enum class ToolCallStatus {
     /** The tool has been requested and is currently executing. */
     RUNNING,
@@ -18,8 +21,11 @@ enum class ToolCallStatus {
 /**
  * Represents a single tool call made by the AI during a streaming response.
  *
- * This is ephemeral state — it exists only for the duration of the active
- * streaming session and is not persisted to the database.
+ * Persisted as part of a turn's ordered content blocks — see [TurnTimelineEntry] — for both
+ * agentic runs ([io.askimo.core.agent.domain.AgentRunRecord]) and regular chat
+ * ([io.askimo.core.chat.domain.ChatMessage]), since knowing which tools were used — in order —
+ * is a useful audit trail. Raw "thinking"/reasoning content is deliberately NOT persisted
+ * alongside it (session-only).
  *
  * @param toolName  The name of the tool being called (e.g. "weather_lookup", "read_file")
  * @param status    Current execution status: [ToolCallStatus.RUNNING] or [ToolCallStatus.DONE]
@@ -27,6 +33,7 @@ enum class ToolCallStatus {
  * @param result    Tool output text; null while still running or if the tool produced no output
  * @param hasFailed Whether the tool execution ended with an error
  */
+@Serializable
 data class ToolCallInfo(
     val toolName: String,
     val status: ToolCallStatus,

--- a/shared/src/main/kotlin/io/askimo/core/chat/dto/TurnTimelineEntry.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/dto/TurnTimelineEntry.kt
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.chat.dto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A single chronologically-ordered event captured during one AI response turn — a real
+ * tool invocation, a chunk of visible reasoning ("thinking"), a chunk of the final response
+ * text, or a non-tool lifecycle status update.
+ *
+ * Used by BOTH agentic runs ([io.askimo.core.agent.domain.AgentRunRecord]) and regular chat
+ * turns ([io.askimo.core.chat.domain.ChatMessage]) — not agent-specific despite this file's
+ * historical name, since both flows stream the same kind of ordered tool/thinking/text events.
+ *
+ * Kept in arrival order so the UI can render exactly what happened, when it happened, instead
+ * of bucketing everything into fixed thinking/tools/text sections regardless of when each
+ * actually occurred (e.g. tool call → some text → another tool call → more text).
+ *
+ * `@Serializable` so [Tool]/[Token] entries (never [Thinking]/[Status]) can be persisted as
+ * JSON in [io.askimo.core.agent.domain.AgentRunRecord.contentBlocks] and
+ * [io.askimo.core.chat.domain.ChatMessage.contentBlocks].
+ */
+@Serializable
+sealed interface TurnTimelineEntry {
+    @Serializable
+    data class Status(val text: String) : TurnTimelineEntry
+
+    @Serializable
+    data class Tool(val toolCall: ToolCallInfo) : TurnTimelineEntry
+
+    @Serializable
+    data class Thinking(val text: String) : TurnTimelineEntry
+
+    @Serializable
+    data class Token(val text: String) : TurnTimelineEntry
+}
+
+/**
+ * A run of one or more consecutive [TurnTimelineEntry]s of the same kind, collapsed into a
+ * single group for rendering — e.g. three tool calls in a row become one collapsible
+ * "3 tool calls" group instead of three separate rows.
+ */
+sealed interface TurnTimelineGroup {
+    data class StatusGroup(val entries: List<TurnTimelineEntry.Status>) : TurnTimelineGroup
+    data class ToolGroup(val entries: List<TurnTimelineEntry.Tool>) : TurnTimelineGroup
+    data class ThinkingGroup(val text: String) : TurnTimelineGroup
+    data class TokenGroup(val text: String) : TurnTimelineGroup
+}
+
+/**
+ * Collapses a "retry loop" — the AI calling the same tool repeatedly, often with different
+ * arguments each time while it tries to guess the right parameters — down to only the LAST,
+ * *effective* attempt, keyed by [ToolCallInfo.toolName] alone (arguments are ignored, since
+ * they're exactly what changes between retries).
+ *
+ * Any [TurnTimelineEntry.Thinking] entries that led up to a superseded (non-last) attempt are
+ * discarded along with it — they were reasoning about a dead-end attempt, not useful once a
+ * later attempt replaces it. The [TurnTimelineEntry.Thinking] immediately preceding the *kept*
+ * (last) attempt for a tool is preserved as-is.
+ *
+ * E.g. `Thinking, ToolA(args1), Thinking, ToolA(args2), Thinking, ToolA(args3), ToolB` collapses
+ * to `Thinking, ToolA(args3), ToolB` — the two earlier thinking/attempt pairs for tool A are
+ * dropped entirely; only the reasoning that led to the final, effective call survives.
+ *
+ * Applied before persisting (so `content_json` only ever stores effective tool calls, not every
+ * retry) and again inside [grouped] when rendering, so historical rows saved before this existed
+ * are also cleaned up on display.
+ */
+fun List<TurnTimelineEntry>.collapsedEffectiveTools(): List<TurnTimelineEntry> {
+    val lastToolIndexByName = HashMap<String, Int>()
+    forEachIndexed { index, entry ->
+        if (entry is TurnTimelineEntry.Tool) {
+            lastToolIndexByName[entry.toolCall.toolName] = index
+        }
+    }
+
+    val result = ArrayList<TurnTimelineEntry>(size)
+    val pendingThinking = mutableListOf<TurnTimelineEntry.Thinking>()
+
+    forEachIndexed { index, entry ->
+        when (entry) {
+            is TurnTimelineEntry.Thinking -> {
+                // Buffered — only kept if it turns out to precede the *effective* tool call.
+                pendingThinking.add(entry)
+            }
+
+            is TurnTimelineEntry.Tool -> {
+                if (lastToolIndexByName[entry.toolCall.toolName] == index) {
+                    // The effective (last) attempt for this tool — keep the reasoning that led
+                    // to it, then the call itself.
+                    result.addAll(pendingThinking)
+                    pendingThinking.clear()
+                    result.add(entry)
+                } else {
+                    // A superseded retry — discard the reasoning that led to this dead-end
+                    // attempt along with the attempt itself.
+                    pendingThinking.clear()
+                }
+            }
+
+            else -> {
+                // Status/Token entries are never part of a "retry loop" — flush any pending
+                // reasoning first (it wasn't followed by a tool call, e.g. the AI just thought
+                // out loud), then pass the entry through untouched.
+                result.addAll(pendingThinking)
+                pendingThinking.clear()
+                result.add(entry)
+            }
+        }
+    }
+    result.addAll(pendingThinking)
+    return result
+}
+
+/**
+ * Collapses consecutive same-kind entries into groups, preserving overall chronological order.
+ * Repeated tool retries are first collapsed to their last effective call — see
+ * [collapsedEffectiveTools].
+ */
+fun List<TurnTimelineEntry>.grouped(): List<TurnTimelineGroup> {
+    val entries = this.collapsedEffectiveTools()
+    val groups = mutableListOf<TurnTimelineGroup>()
+    var i = 0
+    while (i < entries.size) {
+        when (entries[i]) {
+            is TurnTimelineEntry.Status -> {
+                var j = i
+                val run = mutableListOf<TurnTimelineEntry.Status>()
+                while (j < entries.size) {
+                    val e = entries[j] as? TurnTimelineEntry.Status ?: break
+                    run.add(e)
+                    j++
+                }
+                groups.add(TurnTimelineGroup.StatusGroup(run))
+                i = j
+            }
+
+            is TurnTimelineEntry.Tool -> {
+                var j = i
+                val run = mutableListOf<TurnTimelineEntry.Tool>()
+                while (j < entries.size) {
+                    val e = entries[j] as? TurnTimelineEntry.Tool ?: break
+                    run.add(e)
+                    j++
+                }
+                groups.add(TurnTimelineGroup.ToolGroup(run))
+                i = j
+            }
+
+            is TurnTimelineEntry.Thinking -> {
+                var j = i
+                val text = StringBuilder()
+                while (j < entries.size) {
+                    val e = entries[j] as? TurnTimelineEntry.Thinking ?: break
+                    text.append(e.text)
+                    j++
+                }
+                groups.add(TurnTimelineGroup.ThinkingGroup(text.toString()))
+                i = j
+            }
+
+            is TurnTimelineEntry.Token -> {
+                var j = i
+                val text = StringBuilder()
+                while (j < entries.size) {
+                    val e = entries[j] as? TurnTimelineEntry.Token ?: break
+                    text.append(e.text)
+                    j++
+                }
+                groups.add(TurnTimelineGroup.TokenGroup(text.toString()))
+                i = j
+            }
+        }
+    }
+    return groups
+}

--- a/shared/src/main/kotlin/io/askimo/core/chat/mapper/ChatMessageMapper.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/mapper/ChatMessageMapper.kt
@@ -34,6 +34,7 @@ object ChatMessageMapper {
         totalTokens = this.totalTokens,
         durationMs = this.durationMs,
         isBookmarked = this.isBookmarked,
+        contentBlocks = this.contentBlocks,
     )
 
     /**

--- a/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatMessageRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatMessageRepository.kt
@@ -10,12 +10,16 @@ import io.askimo.core.chat.domain.ChatMessagesTable
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.chat.domain.ChatSessionsTable
 import io.askimo.core.chat.domain.FileAttachment
+import io.askimo.core.chat.dto.TurnTimelineEntry
 import io.askimo.core.context.MessageRole
 import io.askimo.core.db.AbstractSQLiteRepository
 import io.askimo.core.db.DatabaseManager
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.internal.PushDataToServerEvent
 import io.askimo.core.logging.logger
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -56,6 +60,16 @@ enum class SearchSortBy {
 /**
  * Extension function to map an Exposed ResultRow to a ChatMessage object.
  */
+private val chatContentJson = Json { ignoreUnknownKeys = true }
+
+private fun decodeChatContentBlocks(raw: String?): List<TurnTimelineEntry> {
+    if (raw.isNullOrBlank()) return emptyList()
+    return runCatching { chatContentJson.decodeFromString<List<TurnTimelineEntry>>(raw) }
+        .getOrDefault(emptyList())
+}
+
+private fun encodeChatContentBlocks(blocks: List<TurnTimelineEntry>): String? = if (blocks.isEmpty()) null else chatContentJson.encodeToString(blocks)
+
 private fun ResultRow.toChatMessage(): ChatMessage = ChatMessage(
     id = this[ChatMessagesTable.id],
     sessionId = this[ChatMessagesTable.sessionId],
@@ -71,6 +85,7 @@ private fun ResultRow.toChatMessage(): ChatMessage = ChatMessage(
     totalTokens = this[ChatMessagesTable.totalTokens],
     durationMs = this[ChatMessagesTable.durationMs],
     isBookmarked = this[ChatMessagesTable.isBookmarked] == 1,
+    contentBlocks = decodeChatContentBlocks(this[ChatMessagesTable.contentJson]),
 )
 
 /**
@@ -122,6 +137,7 @@ class ChatMessageRepository internal constructor(
                 it[ChatMessagesTable.outputTokens] = messageWithInjectedFields.outputTokens
                 it[ChatMessagesTable.totalTokens] = messageWithInjectedFields.totalTokens
                 it[ChatMessagesTable.durationMs] = messageWithInjectedFields.durationMs
+                it[ChatMessagesTable.contentJson] = encodeChatContentBlocks(messageWithInjectedFields.contentBlocks)
                 // Set syncedAt during INSERT when the message is already on the server —
                 // avoids a separate markSynced() UPDATE call.
                 if (syncedAt != null) it[ChatMessagesTable.syncedAt] = syncedAt.toString()
@@ -174,6 +190,7 @@ class ChatMessageRepository internal constructor(
                     it[ChatMessagesTable.outputTokens] = msg.outputTokens
                     it[ChatMessagesTable.totalTokens] = msg.totalTokens
                     it[ChatMessagesTable.durationMs] = msg.durationMs
+                    it[ChatMessagesTable.contentJson] = encodeChatContentBlocks(msg.contentBlocks)
                 }
 
                 if (msg.attachments.isNotEmpty()) {
@@ -462,6 +479,11 @@ class ChatMessageRepository internal constructor(
      * Update the content of a message and mark it as edited.
      * This is used when a user edits an AI response message.
      *
+     * Clears any persisted `content_json` (tool-call/text timeline) — once the text is
+     * user-edited, the recorded interleaving no longer matches the displayed content, so
+     * the message falls back to plain-text rendering instead of showing a stale tool-call
+     * timeline alongside the new text.
+     *
      * @param messageId The ID of the message to update
      * @param newContent The new content for the message
      * @return Number of messages updated (should be 1)
@@ -470,6 +492,7 @@ class ChatMessageRepository internal constructor(
         ChatMessagesTable.update({ ChatMessagesTable.id eq messageId }) {
             it[content] = newContent
             it[isEdited] = 1
+            it[contentJson] = null
         }
     }
 
@@ -570,6 +593,7 @@ class ChatMessageRepository internal constructor(
                     it[outputTokens] = message.outputTokens
                     it[totalTokens] = message.totalTokens
                     it[durationMs] = message.durationMs
+                    it[contentJson] = encodeChatContentBlocks(message.contentBlocks)
                     it[syncedAt] = message.createdAt.toString()
                 }
             }

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -13,6 +13,7 @@ import io.askimo.core.chat.domain.ChatMessage
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.chat.domain.Project
 import io.askimo.core.chat.dto.ChatMessageDTO
+import io.askimo.core.chat.dto.TurnTimelineEntry
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDTO
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDTOs
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDomain
@@ -614,6 +615,10 @@ class ChatSessionService(
         outputTokens: Int? = null,
         totalTokens: Int? = null,
         durationMs: Long? = null,
+        // Ordered tool-call + response-text content blocks for this turn (Tool + Token only,
+        // no Thinking/Status) — mirrors AgentRunRecord.contentBlocks. See
+        // SessionManager.StreamingThread.timeline for the source.
+        contentBlocks: List<TurnTimelineEntry> = emptyList(),
     ): ChatMessage {
         // When a stable messageId was supplied and the message is not a failure, the server
         // already persisted the assistant message. Pre-mark synced at INSERT time so no
@@ -631,6 +636,7 @@ class ChatSessionService(
                 outputTokens = outputTokens,
                 totalTokens = totalTokens,
                 durationMs = durationMs,
+                contentBlocks = contentBlocks,
             ),
             syncedAt = if (isPreSynced) Instant.now() else null,
         )

--- a/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
@@ -371,6 +371,12 @@ class DatabaseManager private constructor(
                 // Column already exists — safe to ignore.
             }
 
+            try {
+                stmt.executeUpdate("ALTER TABLE chat_messages ADD COLUMN content_json TEXT")
+            } catch (_: Exception) {
+                // Column already exists — safe to ignore.
+            }
+
             // Create composite index for efficient session-based queries with time ordering
             stmt.executeUpdate(
                 """
@@ -745,6 +751,12 @@ class DatabaseManager private constructor(
                 ON agent_run_history (conversation_id, created_at)
                 """.trimIndent(),
             )
+
+            try {
+                stmt.executeUpdate("ALTER TABLE agent_run_history ADD COLUMN content_json TEXT")
+            } catch (_: Exception) {
+                // Column already exists — safe to ignore.
+            }
         }
     }
 


### PR DESCRIPTION
- Persist ordered sequences of tool calls and response tokens into the database.
- Enables accurate auditing of agent interactions and tool usage history.
- Updates desktop UI to display completed turn timelines for the user.
- Refines agent interfaces to explicitly differentiate between status updates and tool invocations.