### PR TITLE
feat(agent): Introduce persistent title for agent run records

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepositoryIT.kt
+++ b/cli/src/test/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepositoryIT.kt
@@ -259,6 +259,38 @@ class AgentRunHistoryRepositoryIT {
     }
 
     @Test
+    fun `should update title on every turn belonging to a conversation`() {
+        val conversationId = "conv-title-${System.nanoTime()}"
+        val turn1 = newRecord(conversationId = conversationId, title = "Original title", userInput = "turn 1")
+        val turn2 = newRecord(conversationId = conversationId, title = "Original title", userInput = "turn 2")
+        val turn3 = newRecord(conversationId = conversationId, title = "Original title", userInput = "turn 3")
+        historyRepository.save(turn1)
+        historyRepository.save(turn2)
+        historyRepository.save(turn3)
+
+        historyRepository.updateTitleForConversation(conversationId, "AI-refined title")
+
+        val thread = historyRepository.findByConversationId(conversationId)
+        assertEquals(3, thread.size)
+        assertTrue(thread.all { it.title == "AI-refined title" })
+    }
+
+    @Test
+    fun `should not update title on turns from other conversations`() {
+        val conversationId = "conv-target-title-${System.nanoTime()}"
+        val otherConversationId = "conv-other-title-${System.nanoTime()}"
+        val target = newRecord(conversationId = conversationId, title = "Original title")
+        val other = newRecord(conversationId = otherConversationId, title = "Original title")
+        historyRepository.save(target)
+        historyRepository.save(other)
+
+        historyRepository.updateTitleForConversation(conversationId, "AI-refined title")
+
+        assertEquals("AI-refined title", historyRepository.findByConversationId(conversationId).single().title)
+        assertEquals("Original title", historyRepository.findByConversationId(otherConversationId).single().title)
+    }
+
+    @Test
     fun `should delete a single record by id`() {
         val record = newRecord()
         historyRepository.save(record)

--- a/cli/src/test/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepositoryIT.kt
+++ b/cli/src/test/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepositoryIT.kt
@@ -70,6 +70,7 @@ class AgentRunHistoryRepositoryIT {
 
     private fun newRecord(
         conversationId: String = "conv-${System.nanoTime()}",
+        title: String = "Do something",
         userInput: String = "Do something",
         response: String = "Done",
         error: String? = null,
@@ -83,6 +84,7 @@ class AgentRunHistoryRepositoryIT {
     ) = AgentRunRecord(
         workspaceId = testWorkspace.id,
         conversationId = conversationId,
+        title = title,
         userInput = userInput,
         response = response,
         error = error,
@@ -213,6 +215,7 @@ class AgentRunHistoryRepositoryIT {
             val other = AgentRunRecord(
                 workspaceId = otherWorkspace.id,
                 conversationId = "other-conv",
+                title = "other input",
                 userInput = "other input",
                 response = "other response",
                 error = null,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentHistoryPanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentHistoryPanel.kt
@@ -107,9 +107,9 @@ private fun skillRunHistoryPanelRow(
                     timeLabel,
                     style = AppTextStyles.hint,
                 )
-                if (record.userInput.isNotBlank()) {
+                if (record.title.isNotBlank()) {
                     Text(
-                        record.userInput,
+                        record.title,
                         style = AppTextStyles.hint,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                         maxLines = 1,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,73 +63,21 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
-import io.askimo.core.agent.AgentUsage
-import io.askimo.core.agent.ExternalAgent
-import io.askimo.core.agent.ExternalAgentLoader
 import io.askimo.core.agent.domain.AgentRunRecord
 import io.askimo.core.agent.domain.SkillDefinition
 import io.askimo.core.agent.domain.Workspace
-import io.askimo.core.chat.dto.ChatMessageDTO
-import io.askimo.core.chat.dto.ToolCallInfo
-import io.askimo.core.chat.dto.ToolCallStatus
-import io.askimo.core.chat.dto.TurnTimelineEntry
-import io.askimo.core.chat.dto.TurnTimelineGroup
-import io.askimo.core.chat.dto.collapsedEffectiveTools
 import io.askimo.core.chat.dto.grouped
-import io.askimo.core.db.DatabaseManager
 import io.askimo.ui.chat.messageList
 import io.askimo.ui.chat.turnTimelineView
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.onImeAwarePreviewKeyEvent
-import io.askimo.ui.common.preferences.ApplicationPreferences
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.io.File
-import java.time.Instant
-import java.util.UUID
-import kotlin.time.Duration.Companion.milliseconds
-
-private enum class AgentCardState {
-    NOT_INSTALLED,
-    NEEDS_SETUP,
-    READY,
-}
-
-/** Ensures a (possibly empty) streaming AI placeholder message exists, so tool/thinking chips can render before the first token arrives. */
-private fun List<ChatMessageDTO>.ensureStreamingAiMessage(): List<ChatMessageDTO> {
-    if (any { !it.isUser && it.id == null }) return this
-    return this + ChatMessageDTO(id = null, content = "", isUser = false, timestamp = null)
-}
-
-/** Finalizes the trailing streaming AI message: assigns a stable id and marks failure/content/usage. */
-private fun List<ChatMessageDTO>.finalizeStreamingAiMessage(
-    finalContent: String,
-    isFailed: Boolean,
-    usage: AgentUsage? = null,
-    messageId: String = "ai-${System.nanoTime()}",
-): List<ChatMessageDTO> {
-    val idx = indexOfLast { !it.isUser && it.id == null }
-    if (idx < 0) return this
-    val updated = this[idx].copy(
-        id = messageId,
-        content = finalContent,
-        timestamp = Instant.now(),
-        isFailed = isFailed,
-        inputTokens = usage?.inputTokens,
-        outputTokens = usage?.outputTokens,
-        totalTokens = usage?.totalTokens,
-        durationMs = usage?.durationMs,
-    )
-    return toMutableList().also { it[idx] = updated }
-}
+import io.askimo.ui.common.ui.themedTooltip
 
 /**
  * Autonomous run area — user selects an agent and describes a goal;
@@ -146,306 +95,49 @@ internal fun agenticRunArea(
     onConversationStateChanged: (Boolean) -> Unit = {},
     newConversationRequestKey: Int = 0,
 ) {
-    val workDir = remember(workspace.path) { File(workspace.path) }
     val scope = rememberCoroutineScope()
-    val historyRepo = remember { DatabaseManager.getInstance().getAgentRunHistoryRepository() }
-
-    // ── Agent state ──────────────────────────────────────────────────────────
-    val allAgents = remember { ExternalAgentLoader.all() }
-    var agentStateVersion by remember { mutableStateOf(0) }
-    var agentStateMap by remember { mutableStateOf(mapOf<String, AgentCardState>()) }
-    LaunchedEffect(agentStateVersion) {
-        val map = withContext(Dispatchers.IO) {
-            allAgents.associate { agent ->
-                agent.id to when {
-                    !agent.isBinaryAvailable() -> AgentCardState.NOT_INSTALLED
-                    !agent.isConfigured() -> AgentCardState.NEEDS_SETUP
-                    else -> AgentCardState.READY
-                }
-            }
-        }
-        agentStateMap = map
+    val latestOnRunCompleted = rememberUpdatedState(onRunCompleted)
+    val viewModel = remember(workspace.id) {
+        AgentRunViewModel(
+            workspace = workspace,
+            skills = skills,
+            scope = scope,
+            onRunCompleted = { latestOnRunCompleted.value() },
+        )
     }
 
-    var selectedAgentId by remember {
-        mutableStateOf(ApplicationPreferences.getSelectedAgentId())
-    }
-    // Resolve selected agent; fall back to first ready one if saved pref is unavailable
-    val selectedAgent = remember(selectedAgentId, allAgents, agentStateMap) {
-        allAgents.firstOrNull { it.id == selectedAgentId && agentStateMap[it.id] == AgentCardState.READY }
-            ?: allAgents.firstOrNull { agentStateMap[it.id] == AgentCardState.READY }
-    }
-
-    val selectedAgentRaw = remember(selectedAgentId, allAgents) {
-        allAgents.firstOrNull { it.id == selectedAgentId } ?: allAgents.firstOrNull()
-    }
-    val selectedAgentReady = agentStateMap[selectedAgent?.id] == AgentCardState.READY
-    var agentDropdownExpanded by remember { mutableStateOf(false) }
-
-    // ── Run state ────────────────────────────────────────────────────────────
-    // Single persistent chat input — mirrors chatView's inputText: the first send
-    // starts a new conversation, every subsequent send is a follow-up in the same
-    // conversation (continued via the agent's own session, see activeAgentSessionId).
+    // ── Local, pure-UI state (not part of AgentRunViewModel) ────────────────
     var inputText by remember { mutableStateOf(TextFieldValue("")) }
-    var isRunning by remember { mutableStateOf(false) }
-
-    // The conversation transcript — rendered with ChatView's own messageList/messageBubble
-    // components so an agentic run looks and behaves exactly like a normal chat.
-    var messages by remember { mutableStateOf<List<ChatMessageDTO>>(emptyList()) }
-
-    // Ephemeral streaming state for the *current* turn only (mirrors ChatViewModel's
-    // Chronologically-ordered timeline of everything the agent's stream reported for the
-    // *current* turn — tool calls, thinking chunks, response text chunks, and lifecycle
-    // status — in the exact order they arrived, so the UI can render them interleaved
-    // instead of bucketing into fixed thinking/tools/text sections regardless of timing.
-    var timeline by remember { mutableStateOf<List<TurnTimelineEntry>>(emptyList()) }
-    // Completed turns' groups, keyed by that turn's finalized AI message id — kept in memory
-    // for the current session; also reconstructable from `AgentRunRecord.contentBlocks` when
-    // preloading persisted history (tool calls + text only — thinking/status stay session-only,
-    // never persisted).
-    var completedGroups by remember { mutableStateOf<Map<String, List<TurnTimelineGroup>>>(emptyMap()) }
-    // True from the moment a run starts until the first token/tool-call/thinking chunk
-    // arrives — mirrors ChatViewModel.isThinking (shows the "Thinking…" spinner row).
-    var isWaitingForFirstEvent by remember { mutableStateOf(false) }
-
-    // Accumulates this turn's raw response text — used only to build the AgentRunRecord
-    // saved to history; the displayed transcript is `messages`.
-    var currentTurnResponse by remember { mutableStateOf("") }
-
-    var elapsedSeconds by remember { mutableStateOf(0) }
+    var agentDropdownExpanded by remember { mutableStateOf(false) }
     var skillsListExpanded by remember { mutableStateOf(false) }
 
-    // Native session id of the currently active conversation, captured from the agent's own
-    // execution metadata (e.g. Claude Code's session_id). The external agent — not Askimo —
-    // owns the conversation memory/context for this id; follow-up turns pass it back so the
-    // agent's CLI can resume that same conversation (e.g. `claude --resume <id>`) instead of
-    // Askimo reconstructing/replaying prior turns as text.
-    var activeAgentSessionId by remember { mutableStateOf<String?>(null) }
-
-    // Askimo-side identifier grouping every turn of the current conversation together in
-    // history (see AgentRunRecord.conversationId) — independent of the agent's own session id
-    // above, so history stays grouped even for agents that don't expose a session id.
-    var activeConversationId by remember { mutableStateOf(UUID.randomUUID().toString()) }
-
-    LaunchedEffect(isRunning) {
-        if (isRunning) {
-            elapsedSeconds = 0
-            while (isRunning) {
-                delay(1_000.milliseconds)
-                elapsedSeconds++
-            }
-        }
-    }
-
-    // Build the combined skills catalog once; re-builds only when skills list changes
-    val agenticSystemPrompt = remember(skills) { buildAgenticSystemPrompt(skills) }
-
-    // ── Execution ────────────────────────────────────────────────────────────
-
-    /**
-     * Runs one turn of an agentic conversation.
-     *
-     * When [isNewConversation] is `true` this starts a brand-new conversation (fresh
-     * transcript, no resume id). Otherwise it continues the conversation identified by
-     * [activeAgentSessionId] via the agent's native resume mechanism — Askimo does not
-     * replay prior [messages] back to the agent as text; the agent's own CLI session
-     * owns that context.
-     */
-    fun executeAgentic(agent: ExternalAgent, input: String, isNewConversation: Boolean) {
-        val resumeSessionId = if (isNewConversation) null else activeAgentSessionId
-        isRunning = true
-        isWaitingForFirstEvent = true
-        timeline = emptyList()
-        currentTurnResponse = ""
-        if (isNewConversation) {
-            messages = emptyList()
-            activeAgentSessionId = null
-            activeConversationId = UUID.randomUUID().toString()
-        }
-
-        val userMessage = ChatMessageDTO(
-            id = "user-${System.nanoTime()}",
-            content = input,
-            isUser = true,
-            timestamp = Instant.now(),
-        )
-        messages = messages + userMessage
-
-        scope.launch {
-            val result = withContext(Dispatchers.IO) {
-                // Materialize every skill in the catalog into the agent's own native
-                // skill-discovery location (e.g. Claude Code's `.claude/skills/<name>/`) so its
-                // built-in Skill tool can find and invoke them — not just rely on the full skill
-                // text injected into agenticSystemPrompt below, which the agent can only read as
-                // background instructions, not "run" as a discrete skill.
-                val materialized = skills.map { skill -> agent.materializeSkill(skill, workDir) }
-                try {
-                    agent.runTracked(
-                        systemPrompt = agenticSystemPrompt,
-                        userInput = input,
-                        workDir = workDir,
-                        resumeSessionId = resumeSessionId,
-                        onToken = { token ->
-                            scope.launch {
-                                isWaitingForFirstEvent = false
-                                currentTurnResponse += token
-                                timeline = timeline + TurnTimelineEntry.Token(token)
-                            }
-                        },
-                        onToolCall = { toolName, detail ->
-                            scope.launch {
-                                isWaitingForFirstEvent = false
-                                timeline = timeline + TurnTimelineEntry.Tool(
-                                    ToolCallInfo.truncated(toolName = toolName, status = ToolCallStatus.DONE, arguments = detail),
-                                )
-                            }
-                        },
-                        onStatus = { status ->
-                            scope.launch {
-                                isWaitingForFirstEvent = false
-                                timeline = timeline + TurnTimelineEntry.Status(status)
-                            }
-                        },
-                        onThinking = { chunk ->
-                            scope.launch {
-                                isWaitingForFirstEvent = false
-                                timeline = timeline + TurnTimelineEntry.Thinking(chunk)
-                            }
-                        },
-                    )
-                } finally {
-                    materialized.forEach { it.close() }
-                }
-            }
-            // Update state on the same coroutine, right after the run completes, so the
-            // error (if any) is guaranteed to be captured before we build the history record
-            // below — no race with a separately-launched coroutine.
-            val errorText = result.exceptionOrNull()?.message
-            isRunning = false
-            isWaitingForFirstEvent = false
-
-            // Capture (or keep) the session id so the next follow-up turn can resume this
-            // exact conversation. Falls back to the id we resumed with in case this agent's
-            // CLI doesn't re-emit one on every turn.
-            activeAgentSessionId = agent.lastExecutionSessionId ?: resumeSessionId
-
-            // Best-effort token usage / duration reported by the agent's own stream for this
-            // turn (e.g. Claude's/Antigravity's "result" event). Null fields are hidden by
-            // MessageComponents' token-usage row — not every agent (e.g. Codex) exposes this.
-            val usage = agent.lastExecutionUsage
-
-            // Guarantee a bubble exists even if the run failed before any token/tool/thinking
-            // event arrived, then finalize it (stable id, failure flag) so it stops "streaming".
-            val finalizedMessageId = "ai-${System.nanoTime()}"
-            messages = messages
-                .ensureStreamingAiMessage()
-                .finalizeStreamingAiMessage(
-                    finalContent = currentTurnResponse.ifBlank { errorText.orEmpty() },
-                    isFailed = errorText != null,
-                    usage = usage,
-                    messageId = finalizedMessageId,
-                )
-            // Keep this turn's ordered tool/thinking/text trail visible for the rest of the
-            // session (all kinds, including thinking) — in memory only, never written to
-            // AgentRunRecord/the database.
-            if (timeline.isNotEmpty()) {
-                completedGroups = completedGroups + (finalizedMessageId to timeline.grouped())
-            }
-
-            val record = AgentRunRecord(
-                workspaceId = workspace.id,
-                conversationId = activeConversationId,
-                userInput = input,
-                response = currentTurnResponse,
-                error = errorText,
-                agentSessionId = activeAgentSessionId,
-                activityLog = timeline.collapsedEffectiveTools().filterIsInstance<TurnTimelineEntry.Tool>().map { it.toolCall.toolName },
-                contentBlocks = timeline.collapsedEffectiveTools().filter { it is TurnTimelineEntry.Tool || it is TurnTimelineEntry.Token },
-                inputTokens = usage?.inputTokens,
-                outputTokens = usage?.outputTokens,
-                totalTokens = usage?.totalTokens,
-                durationMs = usage?.durationMs,
-            )
-            withContext(Dispatchers.IO) { historyRepo.save(record) }
-            onRunCompleted()
-        }
-    }
-
     fun sendMessage() {
-        val agent = selectedAgent ?: return
+        val agent = viewModel.selectedAgent ?: return
         val text = inputText.text.trim()
-        if (text.isBlank() || !selectedAgentReady || isRunning) return
-
-        // First message in an empty transcript starts a new conversation;
-        // any message after that continues it via the agent's own resume mechanism.
-        val isNewConversation = messages.isEmpty()
+        if (text.isBlank() || !viewModel.selectedAgentReady || viewModel.isRunning) return
         inputText = TextFieldValue("")
-        executeAgentic(agent, text, isNewConversation = isNewConversation)
-    }
-
-    /** Resets the transcript so the next send starts a brand-new agent conversation. */
-    fun startNewConversation() {
-        inputText = TextFieldValue("")
-        messages = emptyList()
-        timeline = emptyList()
-        completedGroups = emptyMap()
-        currentTurnResponse = ""
-        activeAgentSessionId = null
-        activeConversationId = UUID.randomUUID().toString()
+        viewModel.sendMessage(agent, text)
     }
 
     // Report "has active conversation" up to the header whenever it changes, so the header's
     // "New chat" button can enable/disable itself without owning any transcript state.
-    LaunchedEffect(messages.isEmpty()) {
-        onConversationStateChanged(messages.isNotEmpty())
+    LaunchedEffect(viewModel.hasActiveConversation) {
+        onConversationStateChanged(viewModel.hasActiveConversation)
     }
 
     // Parent-driven reset — the header's "New chat" button bumps this key instead of calling
-    // into this composable directly, keeping this view the sole owner of `messages`/`timeline`.
+    // into this composable directly, keeping AgentRunViewModel the sole owner of the transcript.
     LaunchedEffect(newConversationRequestKey) {
-        if (newConversationRequestKey > 0) startNewConversation()
+        if (newConversationRequestKey > 0) {
+            inputText = TextFieldValue("")
+            viewModel.startNewConversation()
+        }
     }
 
     LaunchedEffect(preloadRecord) {
         if (preloadRecord != null) {
             inputText = TextFieldValue("")
-
-            val turns = withContext(Dispatchers.IO) {
-                historyRepo.findByConversationId(preloadRecord.conversationId)
-            }
-            messages = turns.flatMap { r ->
-                listOf(
-                    ChatMessageDTO(
-                        id = "${r.id}-user",
-                        content = r.userInput,
-                        isUser = true,
-                        timestamp = r.createdAt,
-                    ),
-                    ChatMessageDTO(
-                        id = "${r.id}-ai",
-                        content = r.response.ifBlank { r.error.orEmpty() },
-                        isUser = false,
-                        timestamp = r.createdAt,
-                        isFailed = r.error != null,
-                        inputTokens = r.inputTokens,
-                        outputTokens = r.outputTokens,
-                        totalTokens = r.totalTokens,
-                        durationMs = r.durationMs,
-                    ),
-                )
-            }
-            timeline = emptyList()
-            // Reconstruct each turn's ordered tool/text groups from its persisted
-            // `contentBlocks` — thinking/status were never persisted, so those groups simply
-            // won't reappear here (only for turns still live in this session).
-            completedGroups = turns.associate { r -> "${r.id}-ai" to r.contentBlocks.grouped() }.filterValues { it.isNotEmpty() }
-            currentTurnResponse = turns.lastOrNull()?.response.orEmpty()
-            activeConversationId = preloadRecord.conversationId
-            // Restore the agent's own session id so a follow-up on a re-opened history
-            // entry continues that same conversation rather than starting a new one.
-            activeAgentSessionId = turns.lastOrNull()?.agentSessionId
-            isRunning = false
-            isWaitingForFirstEvent = false
+            viewModel.preload(preloadRecord)
             onPreloadConsumed()
         }
     }
@@ -456,7 +148,7 @@ internal fun agenticRunArea(
     val transcriptScroll = rememberScrollState()
 
     // Auto-scroll to the bottom as new content streams in.
-    LaunchedEffect(messages.size, messages.lastOrNull()?.content, timeline.size) {
+    LaunchedEffect(viewModel.messages.size, viewModel.messages.lastOrNull()?.content, viewModel.timeline.size) {
         transcriptScroll.animateScrollTo(transcriptScroll.maxValue)
     }
 
@@ -476,6 +168,22 @@ internal fun agenticRunArea(
                         .padding(start = 24.dp, end = 12.dp, top = 8.dp, bottom = 16.dp),
                     verticalArrangement = Arrangement.spacedBy(Spacing.medium),
                 ) {
+                    // ── Conversation title — mirrors ChatView's session title header.
+                    // Shown the instant a conversation starts (deterministic fallback title),
+                    // then live-updated in place once the async AI-generated title arrives.
+                    viewModel.conversationTitle?.let { titleText ->
+                        themedTooltip(text = titleText) {
+                            Text(
+                                text = titleText,
+                                style = MaterialTheme.typography.titleLarge,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+
                     // ── Skills-as-context pill row ───────────────────────────────────────
                     if (skills.isNotEmpty()) {
                         var pillHeightPx by remember { mutableStateOf(0) }
@@ -667,7 +375,7 @@ internal fun agenticRunArea(
                     }
 
                     // ── Agent setup hint (needs auth) ────────────────────────────────────
-                    if (agentStateMap[selectedAgentRaw?.id] == AgentCardState.NEEDS_SETUP) {
+                    if (viewModel.agentStateMap[viewModel.selectedAgentRaw?.id] == AgentCardState.NEEDS_SETUP) {
                         Surface(
                             modifier = Modifier.fillMaxWidth(),
                             color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.4f),
@@ -675,7 +383,7 @@ internal fun agenticRunArea(
                         ) {
                             Column(modifier = Modifier.padding(Spacing.medium), verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
                                 Text(
-                                    text = selectedAgentRaw?.configurationHint ?: "",
+                                    text = viewModel.selectedAgentRaw?.configurationHint ?: "",
                                     style = AppTextStyles.caption,
                                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                                 )
@@ -684,20 +392,20 @@ internal fun agenticRunArea(
                     }
 
                     // ── Conversation transcript — same components as ChatView ────────────
-                    if (messages.isNotEmpty() || isRunning) {
+                    if (viewModel.messages.isNotEmpty() || viewModel.isRunning) {
                         messageList(
-                            messages = messages,
-                            isThinking = isWaitingForFirstEvent,
-                            thinkingElapsedSeconds = elapsedSeconds,
-                            completedGroupsByMessageId = completedGroups,
+                            messages = viewModel.messages,
+                            isThinking = viewModel.isWaitingForFirstEvent,
+                            thinkingElapsedSeconds = viewModel.elapsedSeconds,
+                            completedGroupsByMessageId = viewModel.completedGroups,
                         )
                         // Live, chronologically-ordered view of the *current* turn — tool
                         // calls, thinking, response text, and status, interleaved exactly as
                         // the agent's stream reported them, with consecutive same-kind items
                         // collapsed into one group. Replaced by the finalized bubble in
                         // `messages` once the run completes.
-                        if (isRunning && timeline.isNotEmpty()) {
-                            turnTimelineView(timeline.grouped())
+                        if (viewModel.isRunning && viewModel.timeline.isNotEmpty()) {
+                            turnTimelineView(viewModel.timeline.grouped())
                         }
                     } else {
                         // ── Empty-state hint — shown before the first message is sent ────
@@ -727,7 +435,7 @@ internal fun agenticRunArea(
                         value = inputText,
                         onValueChange = { inputText = it },
                         placeholder = { Text(stringResource("agents.agentic.goal.placeholder")) },
-                        enabled = !isRunning,
+                        enabled = !viewModel.isRunning,
                         modifier = Modifier.fillMaxWidth()
                             .onImeAwarePreviewKeyEvent(inputText.composition) { keyEvent ->
                                 when (KeyMapManager.handleKeyEvent(keyEvent)) {
@@ -739,7 +447,7 @@ internal fun agenticRunArea(
                                     }
 
                                     KeyMapManager.AppShortcut.SEND_MESSAGE -> {
-                                        if (inputText.text.isNotBlank() && selectedAgentReady && !isRunning) {
+                                        if (inputText.text.isNotBlank() && viewModel.selectedAgentReady && !viewModel.isRunning) {
                                             sendMessage()
                                         }
                                         true
@@ -764,7 +472,7 @@ internal fun agenticRunArea(
                             color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
                             border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.15f)),
                             modifier = Modifier
-                                .clickable(enabled = !isRunning, onClick = { modelDropdownExpanded = true })
+                                .clickable(enabled = !viewModel.isRunning, onClick = { modelDropdownExpanded = true })
                                 .pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             Row(
@@ -816,7 +524,7 @@ internal fun agenticRunArea(
                                 color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
                                 border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)),
                                 modifier = Modifier
-                                    .clickable(enabled = allAgents.isNotEmpty() && !isRunning, onClick = { agentDropdownExpanded = true })
+                                    .clickable(enabled = viewModel.allAgents.isNotEmpty() && !viewModel.isRunning, onClick = { agentDropdownExpanded = true })
                                     .pointerHoverIcon(PointerIcon.Hand),
                             ) {
                                 Row(
@@ -828,7 +536,7 @@ internal fun agenticRunArea(
                                         modifier = Modifier
                                             .size(6.dp)
                                             .background(
-                                                color = when (agentStateMap[selectedAgent?.id]) {
+                                                color = when (viewModel.agentStateMap[viewModel.selectedAgent?.id]) {
                                                     AgentCardState.READY -> MaterialTheme.colorScheme.tertiary.copy(alpha = 0.8f)
                                                     AgentCardState.NEEDS_SETUP -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.5f)
                                                     else -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
@@ -837,7 +545,7 @@ internal fun agenticRunArea(
                                             ),
                                     )
                                     Text(
-                                        text = selectedAgent?.name ?: stringResource("agents.view.no.agent"),
+                                        text = viewModel.selectedAgent?.name ?: stringResource("agents.view.no.agent"),
                                         style = AppTextStyles.hint,
                                     )
                                     Icon(
@@ -849,8 +557,8 @@ internal fun agenticRunArea(
                                 }
                             }
                             dropdownMenu(expanded = agentDropdownExpanded, onDismissRequest = { agentDropdownExpanded = false }) {
-                                allAgents.forEach { agent ->
-                                    val agentState = agentStateMap[agent.id] ?: AgentCardState.NOT_INSTALLED
+                                viewModel.allAgents.forEach { agent ->
+                                    val agentState = viewModel.agentStateMap[agent.id] ?: AgentCardState.NOT_INSTALLED
                                     val agentReady = agentState == AgentCardState.READY
                                     DropdownMenuItem(
                                         text = {
@@ -883,12 +591,8 @@ internal fun agenticRunArea(
                                             }
                                         },
                                         onClick = {
-                                            selectedAgentId = agent.id
-                                            ApplicationPreferences.setSelectedAgentId(agent.id)
+                                            viewModel.selectAgent(agent.id)
                                             agentDropdownExpanded = false
-                                            agentStateVersion++
-                                            // A resume/session id is only meaningful to the CLI that produced it.
-                                            activeAgentSessionId = null
                                         },
                                         modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                                     )
@@ -899,15 +603,15 @@ internal fun agenticRunArea(
                         // Send button
                         IconButton(
                             onClick = { sendMessage() },
-                            enabled = selectedAgentReady && inputText.text.isNotBlank() && !isRunning,
+                            enabled = viewModel.selectedAgentReady && inputText.text.isNotBlank() && !viewModel.isRunning,
                             colors = AppComponents.primaryIconButtonColors(),
                             modifier = Modifier
                                 .size(36.dp)
                                 .pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             Icon(
-                                imageVector = if (isRunning) Icons.Default.Refresh else Icons.Default.PlayArrow,
-                                contentDescription = if (isRunning) {
+                                imageVector = if (viewModel.isRunning) Icons.Default.Refresh else Icons.Default.PlayArrow,
+                                contentDescription = if (viewModel.isRunning) {
                                     stringResource("agents.view.running")
                                 } else {
                                     stringResource("agents.agentic.run")

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
@@ -43,11 +43,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -95,15 +95,17 @@ internal fun agenticRunArea(
     onConversationStateChanged: (Boolean) -> Unit = {},
     newConversationRequestKey: Int = 0,
 ) {
-    val scope = rememberCoroutineScope()
     val latestOnRunCompleted = rememberUpdatedState(onRunCompleted)
     val viewModel = remember(workspace.id) {
         AgentRunViewModel(
             workspace = workspace,
             skills = skills,
-            scope = scope,
             onRunCompleted = { latestOnRunCompleted.value() },
         )
+    }
+
+    DisposableEffect(viewModel) {
+        onDispose { viewModel.close() }
     }
 
     // ── Local, pure-UI state (not part of AgentRunViewModel) ────────────────

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
@@ -1,0 +1,450 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.ui.agent
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import io.askimo.core.agent.AgentUsage
+import io.askimo.core.agent.ExternalAgent
+import io.askimo.core.agent.ExternalAgentLoader
+import io.askimo.core.agent.domain.AgentRunRecord
+import io.askimo.core.agent.domain.SkillDefinition
+import io.askimo.core.agent.domain.Workspace
+import io.askimo.core.agent.repository.AgentRunHistoryRepository
+import io.askimo.core.chat.TitleGenerator
+import io.askimo.core.chat.dto.ChatMessageDTO
+import io.askimo.core.chat.dto.ToolCallInfo
+import io.askimo.core.chat.dto.ToolCallStatus
+import io.askimo.core.chat.dto.TurnTimelineEntry
+import io.askimo.core.chat.dto.TurnTimelineGroup
+import io.askimo.core.chat.dto.collapsedEffectiveTools
+import io.askimo.core.chat.dto.grouped
+import io.askimo.core.context.AppContext
+import io.askimo.core.db.DatabaseManager
+import io.askimo.core.event.EventBus
+import io.askimo.core.event.internal.AgentRunTitleUpdatedEvent
+import io.askimo.core.logging.currentFileLogger
+import io.askimo.ui.common.preferences.ApplicationPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.time.Instant
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
+
+internal enum class AgentCardState {
+    NOT_INSTALLED,
+    NEEDS_SETUP,
+    READY,
+}
+
+private val log = currentFileLogger()
+
+/** Ensures a (possibly empty) streaming AI placeholder message exists, so tool/thinking chips can render before the first token arrives. */
+private fun List<ChatMessageDTO>.ensureStreamingAiMessage(): List<ChatMessageDTO> {
+    if (any { !it.isUser && it.id == null }) return this
+    return this + ChatMessageDTO(id = null, content = "", isUser = false, timestamp = null)
+}
+
+/** Finalizes the trailing streaming AI message: assigns a stable id and marks failure/content/usage. */
+private fun List<ChatMessageDTO>.finalizeStreamingAiMessage(
+    finalContent: String,
+    isFailed: Boolean,
+    usage: AgentUsage? = null,
+    messageId: String = "ai-${System.nanoTime()}",
+): List<ChatMessageDTO> {
+    val idx = indexOfLast { !it.isUser && it.id == null }
+    if (idx < 0) return this
+    val updated = this[idx].copy(
+        id = messageId,
+        content = finalContent,
+        timestamp = Instant.now(),
+        isFailed = isFailed,
+        inputTokens = usage?.inputTokens,
+        outputTokens = usage?.outputTokens,
+        totalTokens = usage?.totalTokens,
+        durationMs = usage?.durationMs,
+    )
+    return toMutableList().also { it[idx] = updated }
+}
+
+/**
+ * ViewModel backing `agenticRunArea` — owns agent selection, the live conversation
+ * transcript/timeline, and conversation-title generation/persistence for a single
+ * agentic-run conversation. Mirrors [io.askimo.ui.chat.ChatViewModel]'s role for regular
+ * chat, so this business logic (turn execution, title generation, history preload) lives
+ * outside Compose and is independently testable.
+ *
+ * One instance is created per workspace (see `agenticRunArea`'s `remember(workspace.id)`).
+ */
+internal class AgentRunViewModel(
+    private val workspace: Workspace,
+    private val skills: List<SkillDefinition>,
+    private val scope: CoroutineScope,
+    private val historyRepo: AgentRunHistoryRepository = DatabaseManager.getInstance().getAgentRunHistoryRepository(),
+    private val onRunCompleted: () -> Unit = {},
+) {
+    val workDir: File = File(workspace.path)
+    val agenticSystemPrompt: String = buildAgenticSystemPrompt(skills)
+
+    // ── Agent selection ──────────────────────────────────────────────────────
+    val allAgents: List<ExternalAgent> = ExternalAgentLoader.all()
+
+    var agentStateMap by mutableStateOf(mapOf<String, AgentCardState>())
+        private set
+
+    var selectedAgentId by mutableStateOf(ApplicationPreferences.getSelectedAgentId())
+        private set
+
+    /** Resolved selected agent; falls back to the first ready one if the saved pref is unavailable. */
+    val selectedAgent: ExternalAgent?
+        get() = allAgents.firstOrNull { it.id == selectedAgentId && agentStateMap[it.id] == AgentCardState.READY }
+            ?: allAgents.firstOrNull { agentStateMap[it.id] == AgentCardState.READY }
+
+    /** The raw selected agent (or the first available one), regardless of readiness — used for setup hints. */
+    val selectedAgentRaw: ExternalAgent?
+        get() = allAgents.firstOrNull { it.id == selectedAgentId } ?: allAgents.firstOrNull()
+
+    val selectedAgentReady: Boolean
+        get() = agentStateMap[selectedAgent?.id] == AgentCardState.READY
+
+    /** Re-checks binary availability / auth for every known agent (off the UI thread). */
+    fun refreshAgentStates() {
+        scope.launch {
+            agentStateMap = withContext(Dispatchers.IO) {
+                allAgents.associate { agent ->
+                    agent.id to when {
+                        !agent.isBinaryAvailable() -> AgentCardState.NOT_INSTALLED
+                        !agent.isConfigured() -> AgentCardState.NEEDS_SETUP
+                        else -> AgentCardState.READY
+                    }
+                }
+            }
+        }
+    }
+
+    fun selectAgent(agentId: String) {
+        selectedAgentId = agentId
+        ApplicationPreferences.setSelectedAgentId(agentId)
+        // A resume/session id is only meaningful to the CLI that produced it.
+        activeAgentSessionId = null
+        refreshAgentStates()
+    }
+
+    // ── Conversation state ───────────────────────────────────────────────────
+    var messages by mutableStateOf(listOf<ChatMessageDTO>())
+        private set
+
+    var isRunning by mutableStateOf(false)
+        private set
+
+    /** Chronologically-ordered timeline for the *current* turn only — see [TurnTimelineEntry]. */
+    var timeline by mutableStateOf(listOf<TurnTimelineEntry>())
+        private set
+
+    /** Completed turns' groups, keyed by that turn's finalized AI message id. */
+    var completedGroups by mutableStateOf(mapOf<String, List<TurnTimelineGroup>>())
+        private set
+
+    /** True until the first token/tool-call/thinking chunk arrives — drives the "Thinking…" row. */
+    var isWaitingForFirstEvent by mutableStateOf(false)
+        private set
+
+    var elapsedSeconds by mutableStateOf(0)
+        private set
+
+    /** Native session id of the currently active conversation (e.g. Claude Code's `session_id`). */
+    var activeAgentSessionId by mutableStateOf<String?>(null)
+        private set
+
+    /** Askimo-side identifier grouping every turn of the current conversation in history. */
+    var activeConversationId by mutableStateOf(UUID.randomUUID().toString())
+        private set
+
+    /**
+     * Human-readable title for the current conversation — set synchronously to a deterministic
+     * truncation of the first turn's input the instant a new conversation starts (see
+     * [TitleGenerator.fallbackTitle]), then optionally replaced by a short AI-generated title
+     * once [generateAndPersistAgentTitle] completes. Null only when there is no active
+     * conversation yet.
+     */
+    var conversationTitle by mutableStateOf<String?>(null)
+        private set
+
+    val hasActiveConversation: Boolean
+        get() = messages.isNotEmpty()
+
+    // Accumulates this turn's raw response text — used only to build the AgentRunRecord
+    // saved to history; the displayed transcript is `messages`.
+    private var currentTurnResponse = ""
+    private var elapsedTimerJob: Job? = null
+
+    init {
+        refreshAgentStates()
+        observeTitleEvents()
+    }
+
+    /** Picks up AI-refined titles for the conversation currently active, wherever generated. */
+    private fun observeTitleEvents() {
+        scope.launch {
+            EventBus.internalEvents
+                .filterIsInstance<AgentRunTitleUpdatedEvent>()
+                .collect { event ->
+                    if (event.conversationId == activeConversationId) {
+                        conversationTitle = event.newTitle
+                    }
+                }
+        }
+    }
+
+    /**
+     * Sends [text] as the next turn of the current conversation (or starts a new one if
+     * the transcript is currently empty), using [agent].
+     */
+    fun sendMessage(agent: ExternalAgent, text: String) {
+        if (text.isBlank() || isRunning) return
+        val isNewConversation = messages.isEmpty()
+        executeAgentic(agent, text, isNewConversation)
+    }
+
+    /** Resets the transcript so the next [sendMessage] starts a brand-new agent conversation. */
+    fun startNewConversation() {
+        messages = emptyList()
+        timeline = emptyList()
+        completedGroups = emptyMap()
+        currentTurnResponse = ""
+        activeAgentSessionId = null
+        activeConversationId = UUID.randomUUID().toString()
+        conversationTitle = null
+    }
+
+    /** Reconstructs the full multi-turn conversation for a re-opened history entry. */
+    suspend fun preload(record: AgentRunRecord) {
+        val turns = withContext(Dispatchers.IO) { historyRepo.findByConversationId(record.conversationId) }
+        messages = turns.flatMap { r ->
+            listOf(
+                ChatMessageDTO(
+                    id = "${r.id}-user",
+                    content = r.userInput,
+                    isUser = true,
+                    timestamp = r.createdAt,
+                ),
+                ChatMessageDTO(
+                    id = "${r.id}-ai",
+                    content = r.response.ifBlank { r.error.orEmpty() },
+                    isUser = false,
+                    timestamp = r.createdAt,
+                    isFailed = r.error != null,
+                    inputTokens = r.inputTokens,
+                    outputTokens = r.outputTokens,
+                    totalTokens = r.totalTokens,
+                    durationMs = r.durationMs,
+                ),
+            )
+        }
+        timeline = emptyList()
+        // Reconstruct each turn's ordered tool/text groups from its persisted
+        // `contentBlocks` — thinking/status were never persisted, so those groups simply
+        // won't reappear here (only for turns still live in this session).
+        completedGroups = turns.associate { r -> "${r.id}-ai" to r.contentBlocks.grouped() }.filterValues { it.isNotEmpty() }
+        currentTurnResponse = turns.lastOrNull()?.response.orEmpty()
+        activeConversationId = record.conversationId
+        conversationTitle = turns.firstOrNull()?.title ?: record.title
+        // Restore the agent's own session id so a follow-up on a re-opened history
+        // entry continues that same conversation rather than starting a new one.
+        activeAgentSessionId = turns.lastOrNull()?.agentSessionId
+        isRunning = false
+        isWaitingForFirstEvent = false
+    }
+
+    /**
+     * Runs one turn of an agentic conversation.
+     *
+     * When [isNewConversation] is `true` this starts a brand-new conversation (fresh
+     * transcript, no resume id). Otherwise it continues the conversation identified by
+     * [activeAgentSessionId] via the agent's native resume mechanism — Askimo does not
+     * replay prior [messages] back to the agent as text; the agent's own CLI session
+     * owns that context.
+     */
+    private fun executeAgentic(agent: ExternalAgent, input: String, isNewConversation: Boolean) {
+        val resumeSessionId = if (isNewConversation) null else activeAgentSessionId
+        isRunning = true
+        isWaitingForFirstEvent = true
+        timeline = emptyList()
+        currentTurnResponse = ""
+        if (isNewConversation) {
+            messages = emptyList()
+            activeAgentSessionId = null
+            activeConversationId = UUID.randomUUID().toString()
+            // Instant, deterministic title — never blank. May be replaced by a short
+            // AI-generated title once generateAndPersistAgentTitle() completes below.
+            conversationTitle = TitleGenerator.fallbackTitle(input)
+        }
+
+        val userMessage = ChatMessageDTO(
+            id = "user-${System.nanoTime()}",
+            content = input,
+            isUser = true,
+            timestamp = Instant.now(),
+        )
+        messages = messages + userMessage
+
+        startElapsedTimer()
+
+        scope.launch {
+            val result = withContext(Dispatchers.IO) {
+                // Materialize every skill in the catalog into the agent's own native
+                // skill-discovery location (e.g. Claude Code's `.claude/skills/<name>/`) so its
+                // built-in Skill tool can find and invoke them — not just rely on the full skill
+                // text injected into agenticSystemPrompt below, which the agent can only read as
+                // background instructions, not "run" as a discrete skill.
+                val materialized = skills.map { skill -> agent.materializeSkill(skill, workDir) }
+                try {
+                    agent.runTracked(
+                        systemPrompt = agenticSystemPrompt,
+                        userInput = input,
+                        workDir = workDir,
+                        resumeSessionId = resumeSessionId,
+                        onToken = { token ->
+                            scope.launch {
+                                isWaitingForFirstEvent = false
+                                currentTurnResponse += token
+                                timeline = timeline + TurnTimelineEntry.Token(token)
+                            }
+                        },
+                        onToolCall = { toolName, detail ->
+                            scope.launch {
+                                isWaitingForFirstEvent = false
+                                timeline = timeline + TurnTimelineEntry.Tool(
+                                    ToolCallInfo.truncated(toolName = toolName, status = ToolCallStatus.DONE, arguments = detail),
+                                )
+                            }
+                        },
+                        onStatus = { status ->
+                            scope.launch {
+                                isWaitingForFirstEvent = false
+                                timeline = timeline + TurnTimelineEntry.Status(status)
+                            }
+                        },
+                        onThinking = { chunk ->
+                            scope.launch {
+                                isWaitingForFirstEvent = false
+                                timeline = timeline + TurnTimelineEntry.Thinking(chunk)
+                            }
+                        },
+                    )
+                } finally {
+                    materialized.forEach { it.close() }
+                }
+            }
+            // Update state on the same coroutine, right after the run completes, so the
+            // error (if any) is guaranteed to be captured before we build the history record
+            // below — no race with a separately-launched coroutine.
+            val errorText = result.exceptionOrNull()?.message
+            isRunning = false
+            isWaitingForFirstEvent = false
+
+            // Capture (or keep) the session id so the next follow-up turn can resume this
+            // exact conversation. Falls back to the id we resumed with in case this agent's
+            // CLI doesn't re-emit one on every turn.
+            activeAgentSessionId = agent.lastExecutionSessionId ?: resumeSessionId
+
+            // Best-effort token usage / duration reported by the agent's own stream for this
+            // turn (e.g. Claude's/Antigravity's "result" event). Null fields are hidden by
+            // MessageComponents' token-usage row — not every agent (e.g. Codex) exposes this.
+            val usage = agent.lastExecutionUsage
+
+            // Guarantee a bubble exists even if the run failed before any token/tool/thinking
+            // event arrived, then finalize it (stable id, failure flag) so it stops "streaming".
+            val finalizedMessageId = "ai-${System.nanoTime()}"
+            messages = messages
+                .ensureStreamingAiMessage()
+                .finalizeStreamingAiMessage(
+                    finalContent = currentTurnResponse.ifBlank { errorText.orEmpty() },
+                    isFailed = errorText != null,
+                    usage = usage,
+                    messageId = finalizedMessageId,
+                )
+            // Keep this turn's ordered tool/thinking/text trail visible for the rest of the
+            // session (all kinds, including thinking) — in memory only, never written to
+            // AgentRunRecord/the database.
+            if (timeline.isNotEmpty()) {
+                completedGroups = completedGroups + (finalizedMessageId to timeline.grouped())
+            }
+
+            val record = AgentRunRecord(
+                workspaceId = workspace.id,
+                conversationId = activeConversationId,
+                title = conversationTitle ?: TitleGenerator.fallbackTitle(input),
+                userInput = input,
+                response = currentTurnResponse,
+                error = errorText,
+                agentSessionId = activeAgentSessionId,
+                activityLog = timeline.collapsedEffectiveTools().filterIsInstance<TurnTimelineEntry.Tool>().map { it.toolCall.toolName },
+                contentBlocks = timeline.collapsedEffectiveTools().filter { it is TurnTimelineEntry.Tool || it is TurnTimelineEntry.Token },
+                inputTokens = usage?.inputTokens,
+                outputTokens = usage?.outputTokens,
+                totalTokens = usage?.totalTokens,
+                durationMs = usage?.durationMs,
+            )
+            withContext(Dispatchers.IO) { historyRepo.save(record) }
+            onRunCompleted()
+
+            // Best-effort AI title refinement — only for the first turn of a conversation,
+            // fired after the fallback title/record are already persisted so it never blocks
+            // (or risks corrupting) the visible run.
+            if (isNewConversation) {
+                scope.launch(Dispatchers.IO) {
+                    generateAndPersistAgentTitle(record.conversationId, input)
+                }
+            }
+        }
+    }
+
+    private fun startElapsedTimer() {
+        elapsedSeconds = 0
+        elapsedTimerJob?.cancel()
+        elapsedTimerJob = scope.launch {
+            while (isRunning) {
+                delay(1_000.milliseconds)
+                elapsedSeconds++
+            }
+        }
+    }
+
+    /**
+     * Best-effort async AI title generation for this conversation — mirrors
+     * `ChatSessionService.createSession`'s "AI title" block. On success, persists the new
+     * title across every turn of [conversationId] and broadcasts [AgentRunTitleUpdatedEvent]
+     * so any listening UI (this view model, the history panel) can pick it up without a full
+     * reload. Silently no-ops on any failure — the deterministic fallback title remains.
+     */
+    private suspend fun generateAndPersistAgentTitle(conversationId: String, firstMessage: String) {
+        try {
+            val prompt = """
+                Generate a short, concise title (150 words max, no quotes, no punctuation at end)
+                for a conversation that starts with this user message:
+                "$firstMessage"
+                Respond with only the title, nothing else.
+            """.trimIndent()
+            val utilityChatClient = AppContext.getInstance().createUtilityClient()
+            val aiTitle = utilityChatClient.sendMessage(prompt).trim()
+
+            if (aiTitle.isNotBlank()) {
+                withContext(Dispatchers.IO) { historyRepo.updateTitleForConversation(conversationId, aiTitle) }
+                EventBus.post(AgentRunTitleUpdatedEvent(conversationId = conversationId, newTitle = aiTitle))
+                log.debug("AI title generated for agent conversation {}: {}", conversationId, aiTitle)
+            }
+        } catch (e: Exception) {
+            log.debug("Failed to generate AI title for agent conversation {}: {}", conversationId, e.message)
+        }
+    }
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
@@ -15,6 +15,7 @@ import io.askimo.core.agent.domain.SkillDefinition
 import io.askimo.core.agent.domain.Workspace
 import io.askimo.core.agent.repository.AgentRunHistoryRepository
 import io.askimo.core.chat.TitleGenerator
+import io.askimo.core.chat.domain.SESSION_TITLE_MAX_LENGTH
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.dto.ToolCallStatus
@@ -31,6 +32,8 @@ import io.askimo.ui.common.preferences.ApplicationPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
@@ -83,15 +86,16 @@ private fun List<ChatMessageDTO>.finalizeStreamingAiMessage(
  * chat, so this business logic (turn execution, title generation, history preload) lives
  * outside Compose and is independently testable.
  *
- * One instance is created per workspace (see `agenticRunArea`'s `remember(workspace.id)`).
+ * One instance is created per workspace (see `agenticRunArea`'s `remember(workspace.id)`)
+ * and owns its own [CoroutineScope]; callers must invoke [close] when discarding an instance.
  */
 internal class AgentRunViewModel(
     private val workspace: Workspace,
     private val skills: List<SkillDefinition>,
-    private val scope: CoroutineScope,
     private val historyRepo: AgentRunHistoryRepository = DatabaseManager.getInstance().getAgentRunHistoryRepository(),
     private val onRunCompleted: () -> Unit = {},
 ) {
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val workDir: File = File(workspace.path)
     val agenticSystemPrompt: String = buildAgenticSystemPrompt(skills)
 
@@ -314,9 +318,9 @@ internal class AgentRunViewModel(
                         workDir = workDir,
                         resumeSessionId = resumeSessionId,
                         onToken = { token ->
+                            currentTurnResponse += token
                             scope.launch {
                                 isWaitingForFirstEvent = false
-                                currentTurnResponse += token
                                 timeline = timeline + TurnTimelineEntry.Token(token)
                             }
                         },
@@ -436,7 +440,11 @@ internal class AgentRunViewModel(
                 Respond with only the title, nothing else.
             """.trimIndent()
             val utilityChatClient = AppContext.getInstance().createUtilityClient()
-            val aiTitle = utilityChatClient.sendMessage(prompt).trim()
+
+            val aiTitle = utilityChatClient.sendMessage(prompt)
+                .trim()
+                .replace("\n", " ")
+                .take(SESSION_TITLE_MAX_LENGTH)
 
             if (aiTitle.isNotBlank()) {
                 withContext(Dispatchers.IO) { historyRepo.updateTitleForConversation(conversationId, aiTitle) }
@@ -446,5 +454,18 @@ internal class AgentRunViewModel(
         } catch (e: Exception) {
             log.debug("Failed to generate AI title for agent conversation {}: {}", conversationId, e.message)
         }
+    }
+
+    /**
+     * Cancels every coroutine owned by this instance (title-event collection, in-flight runs,
+     * the elapsed-timer ticker). This instance owns its own [CoroutineScope] rather than
+     * borrowing the composable's `rememberCoroutineScope()` — that scope outlives any single
+     * instance, so reusing it would leak this instance's coroutines whenever a workspace switch
+     * causes `agenticRunArea`'s `remember(workspace.id)` to replace it with a new one. Callers
+     * must invoke this (e.g. `DisposableEffect(viewModel) { onDispose { viewModel.close() } }`)
+     * once this instance is discarded.
+     */
+    fun close() {
+        scope.cancel()
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentView.kt
@@ -67,8 +67,6 @@ import io.askimo.core.agent.domain.AgentRunRecord
 import io.askimo.core.agent.domain.SkillDefinition
 import io.askimo.core.agent.domain.Workspace
 import io.askimo.core.agent.repository.SkillRepository
-import io.askimo.core.agent.service.WorkspaceService
-import io.askimo.core.db.DatabaseManager
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
 import io.askimo.ui.common.theme.AppComponents
@@ -76,82 +74,38 @@ import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.TooltipPlacement
 import io.askimo.ui.common.ui.themedTooltip
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import org.koin.core.context.GlobalContext
 import java.awt.Cursor
 import java.awt.Desktop
 import java.io.File
 import java.net.URI
 
-/**
- * Self-contained agentic skills sub-view — top-level entry point for the Skills feature.
- * Owns its own skills loading, layout, and workspace panel.
- * The agent autonomously selects skills from the full catalog.
- */
 @Composable
 fun agentsView(
     onNavigateToSkillsSettings: () -> Unit = {},
 ) {
     val skillRepository = remember { SkillRepository() }
-    val historyRepo = remember { DatabaseManager.getInstance().getAgentRunHistoryRepository() }
-    val workspaceService = remember { GlobalContext.get().get<WorkspaceService>() }
     val scope = rememberCoroutineScope()
+    val viewModel = remember { AgentsViewModel(scope) }
     val skills by remember { mutableStateOf(skillRepository.getSkillsOnly()) }
-    var allHistoryRefreshKey by remember { mutableStateOf(0) }
     var showOverlayPanel by remember { mutableStateOf(false) }
-
-    var runHistory by remember { mutableStateOf(listOf<AgentRunRecord>()) }
-    var pendingHistoryRecord by remember { mutableStateOf<AgentRunRecord?>(null) }
-
-    fun deleteHistoryRecord(record: AgentRunRecord) {
-        scope.launch {
-            withContext(Dispatchers.IO) { historyRepo.deleteByConversationId(record.conversationId) }
-            allHistoryRefreshKey++
-        }
-    }
-
-    // User-chosen workspace (persisted across sessions). Resolved off the UI thread since
-    // workspaceService.resolveCurrent() does several blocking DB transactions.
-    // Runs/history must never be saved before this resolves — the agent_run_history table
-    // enforces a NOT NULL foreign key on workspace_id, so a real, persisted Workspace row
-    // must exist first.
-    var workspace by remember { mutableStateOf<Workspace?>(null) }
-    LaunchedEffect(Unit) {
-        workspace = withContext(Dispatchers.IO) { workspaceService.resolveCurrent() }
-    }
-
-    LaunchedEffect(workspace?.id, allHistoryRefreshKey) {
-        workspace?.let { ws ->
-            val all = withContext(Dispatchers.IO) { historyRepo.findByWorkspaceId(ws.id) }
-            // One row per conversation — the latest turn represents the whole thread in the
-            // list; clicking it reconstructs the full multi-turn conversation (see
-            // agenticRunArea's preloadRecord handling).
-            runHistory = all
-                .groupBy { it.conversationId }
-                .map { (_, turns) -> turns.maxBy { it.createdAt } }
-                .sortedByDescending { it.createdAt }
-        }
-    }
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val isWide = maxWidth >= 1100.dp
         LaunchedEffect(isWide) { if (isWide) showOverlayPanel = false }
 
         val currentWorkspace =
-            workspace
+            viewModel.workspace
                 ?: return@BoxWithConstraints
         val workDir = remember(currentWorkspace.path) { File(currentWorkspace.path) }
 
         val panelContent: @Composable () -> Unit = {
             agenticWorkspacePanel(
                 workDir = workDir,
-                workDirRefreshKey = allHistoryRefreshKey,
-                runHistory = runHistory,
-                onWorkDirChanged = { workspace = workspaceService.select(it) },
-                onSelectRecord = { pendingHistoryRecord = it },
-                onDeleteRecord = ::deleteHistoryRecord,
+                workDirRefreshKey = viewModel.historyRefreshKey,
+                runHistory = viewModel.runHistory,
+                onWorkDirChanged = { viewModel.selectWorkspace(it) },
+                onSelectRecord = { viewModel.selectHistoryRecord(it) },
+                onDeleteRecord = { viewModel.deleteHistoryRecord(it) },
             )
         }
 
@@ -161,10 +115,10 @@ fun agentsView(
                     agenticContent(
                         skills = skills,
                         workspace = currentWorkspace,
-                        onRunCompleted = { allHistoryRefreshKey++ },
+                        onRunCompleted = { viewModel.onRunCompleted() },
                         onNavigateToSkillsSettings = onNavigateToSkillsSettings,
-                        preloadRecord = pendingHistoryRecord,
-                        onPreloadConsumed = { pendingHistoryRecord = null },
+                        preloadRecord = viewModel.pendingHistoryRecord,
+                        onPreloadConsumed = { viewModel.consumePendingHistoryRecord() },
                     )
                 }
                 panelContent()
@@ -174,13 +128,13 @@ fun agentsView(
                 agenticContent(
                     skills = skills,
                     workspace = currentWorkspace,
-                    onRunCompleted = { allHistoryRefreshKey++ },
+                    onRunCompleted = { viewModel.onRunCompleted() },
                     onNavigateToSkillsSettings = onNavigateToSkillsSettings,
                     showPanelToggle = true,
                     panelVisible = showOverlayPanel,
                     onTogglePanel = { showOverlayPanel = !showOverlayPanel },
-                    preloadRecord = pendingHistoryRecord,
-                    onPreloadConsumed = { pendingHistoryRecord = null },
+                    preloadRecord = viewModel.pendingHistoryRecord,
+                    onPreloadConsumed = { viewModel.consumePendingHistoryRecord() },
                 )
                 if (showOverlayPanel) {
                     Box(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentsViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentsViewModel.kt
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.ui.agent
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import io.askimo.core.agent.domain.AgentRunRecord
+import io.askimo.core.agent.domain.Workspace
+import io.askimo.core.agent.repository.AgentRunHistoryRepository
+import io.askimo.core.agent.service.WorkspaceService
+import io.askimo.core.db.DatabaseManager
+import io.askimo.core.event.EventBus
+import io.askimo.core.event.internal.AgentRunTitleUpdatedEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.core.context.GlobalContext
+import java.io.File
+
+/**
+ * ViewModel backing `agentsView` — owns the current [Workspace], the run-history list shown
+ * in the side panel, and the pending history record selected for preload. Mirrors
+ * [io.askimo.ui.chat.ChatViewModel]'s role for regular chat, keeping this business logic
+ * (workspace resolution, history refresh, title-event patching) out of the composable.
+ */
+internal class AgentsViewModel(
+    private val scope: CoroutineScope,
+    private val workspaceService: WorkspaceService = GlobalContext.get().get(),
+    private val historyRepo: AgentRunHistoryRepository = DatabaseManager.getInstance().getAgentRunHistoryRepository(),
+) {
+    // User-chosen workspace (persisted across sessions). Resolved off the UI thread since
+    // workspaceService.resolveCurrent() does several blocking DB transactions.
+    // Runs/history must never be saved before this resolves — the agent_run_history table
+    // enforces a NOT NULL foreign key on workspace_id, so a real, persisted Workspace row
+    // must exist first.
+    var workspace by mutableStateOf<Workspace?>(null)
+        private set
+
+    // One row per conversation — the latest turn represents the whole thread in the list;
+    // selecting it reconstructs the full multi-turn conversation (see AgentRunViewModel.preload).
+    var runHistory by mutableStateOf(listOf<AgentRunRecord>())
+        private set
+
+    var pendingHistoryRecord by mutableStateOf<AgentRunRecord?>(null)
+        private set
+
+    // Bumped every time a run completes — used by the workspace-files panel to know when
+    // to refresh its listing (files may have changed) and auto-switch/expand to that tab.
+    var historyRefreshKey by mutableStateOf(0)
+        private set
+
+    init {
+        resolveWorkspace()
+        observeTitleEvents()
+    }
+
+    private fun resolveWorkspace() {
+        scope.launch {
+            workspace = withContext(Dispatchers.IO) { workspaceService.resolveCurrent() }
+            refreshHistory()
+        }
+    }
+
+    /** Live-patches a conversation's title the moment the async AI-generated title lands. */
+    private fun observeTitleEvents() {
+        scope.launch {
+            EventBus.internalEvents
+                .filterIsInstance<AgentRunTitleUpdatedEvent>()
+                .collect { event ->
+                    runHistory = runHistory.map { record ->
+                        if (record.conversationId == event.conversationId) {
+                            record.copy(title = event.newTitle)
+                        } else {
+                            record
+                        }
+                    }
+                }
+        }
+    }
+
+    fun refreshHistory() {
+        val ws = workspace ?: return
+        scope.launch {
+            val all = withContext(Dispatchers.IO) { historyRepo.findByWorkspaceId(ws.id) }
+            runHistory = all
+                .groupBy { it.conversationId }
+                .map { (_, turns) -> turns.maxBy { it.createdAt } }
+                .sortedByDescending { it.createdAt }
+        }
+    }
+
+    fun selectWorkspace(dir: File) {
+        workspace = workspaceService.select(dir)
+        historyRefreshKey++
+        refreshHistory()
+    }
+
+    fun selectHistoryRecord(record: AgentRunRecord) {
+        pendingHistoryRecord = record
+    }
+
+    fun consumePendingHistoryRecord() {
+        pendingHistoryRecord = null
+    }
+
+    fun deleteHistoryRecord(record: AgentRunRecord) {
+        scope.launch {
+            withContext(Dispatchers.IO) { historyRepo.deleteByConversationId(record.conversationId) }
+            historyRefreshKey++
+            refreshHistory()
+        }
+    }
+
+    fun onRunCompleted() {
+        historyRefreshKey++
+        refreshHistory()
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/agent/domain/AgentRunRecord.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/domain/AgentRunRecord.kt
@@ -22,6 +22,13 @@ import java.util.UUID
  *                    (resumed via the agent's own session, see [agentSessionId]) reuses
  *                    the same id, so the full multi-turn thread can be reconstructed
  *                    from history instead of only the single turn that was clicked.
+ * @param title       Human-readable conversation title — never blank. Set to a deterministic
+ *                    truncation of the first turn's [userInput] (see
+ *                    `io.askimo.core.chat.TitleGenerator.fallbackTitle`) the instant a new
+ *                    conversation starts, then optionally replaced with a short AI-generated
+ *                    title (best-effort, async). Every turn of the same [conversationId]
+ *                    shares this same value — kept in sync via a bulk update rather than
+ *                    looked up from the first turn.
  * @param userInput   The context/prompt entered by the user before executing.
  * @param response    The full AI-generated response text; empty if the run failed.
  * @param error       Error message if the run failed; null on success.
@@ -45,6 +52,7 @@ data class AgentRunRecord(
 
     val workspaceId: String,
     val conversationId: String,
+    val title: String,
     val userInput: String,
     val response: String,
     val error: String?,
@@ -71,6 +79,7 @@ object AgentRunHistoryTable : Table("agent_run_history") {
     val id = varchar("id", 36)
     val workspaceId = varchar("workspace_id", 36).references(WorkspaceTable.id)
     val conversationId = varchar("conversation_id", 36)
+    val title = text("title").default("")
     val userInput = text("user_input").default("")
     val response = text("response").default("")
     val error = text("error").nullable()

--- a/shared/src/main/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepository.kt
@@ -20,6 +20,7 @@ import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 
 /**
  * Repository for persisting and querying [AgentRunRecord] entries.
@@ -43,6 +44,7 @@ class AgentRunHistoryRepository internal constructor(
                 it[id] = record.id
                 it[workspaceId] = record.workspaceId
                 it[conversationId] = record.conversationId
+                it[title] = record.title
                 it[userInput] = record.userInput
                 it[response] = record.response
                 it[error] = record.error
@@ -98,6 +100,21 @@ class AgentRunHistoryRepository internal constructor(
     }
 
     /**
+     * Updates the [AgentRunRecord.title] on every turn belonging to [conversationId] — call
+     * this once the async AI-generated title is ready, so the whole conversation (and the
+     * single row representing it in the history list) reflects the new title without any
+     * join/lookup needed at read time.
+     */
+    fun updateTitleForConversation(conversationId: String, newTitle: String) {
+        transaction(database) {
+            AgentRunHistoryTable.update({ AgentRunHistoryTable.conversationId eq conversationId }) {
+                it[title] = newTitle
+            }
+        }
+        log.debug("Updated title for conversation '{}'", conversationId)
+    }
+
+    /**
      * Deletes a single run record by [id].
      */
     fun deleteById(id: String) {
@@ -136,6 +153,7 @@ class AgentRunHistoryRepository internal constructor(
         id = row[AgentRunHistoryTable.id],
         workspaceId = row[AgentRunHistoryTable.workspaceId],
         conversationId = row[AgentRunHistoryTable.conversationId],
+        title = row[AgentRunHistoryTable.title],
         userInput = row[AgentRunHistoryTable.userInput],
         response = row[AgentRunHistoryTable.response],
         error = row[AgentRunHistoryTable.error],

--- a/shared/src/main/kotlin/io/askimo/core/chat/TitleGenerator.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/TitleGenerator.kt
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.chat
+
+import io.askimo.core.chat.domain.SESSION_TITLE_MAX_LENGTH
+
+/**
+ * Deterministic, non-AI title generation shared by chat sessions and agent-run
+ * conversations. Given the first user message, produces a short, non-empty title —
+ * preferring to cut at the end of a sentence rather than mid-word — so a title is
+ * always available instantly, before any (optional) AI-refined title arrives async.
+ */
+object TitleGenerator {
+    /**
+     * Truncates [firstMessage] into a title of at most [SESSION_TITLE_MAX_LENGTH] characters.
+     * Prefers cutting at the first sentence boundary (`. `, `? `, `! `) if that keeps the
+     * result within the limit; otherwise hard-truncates with an ellipsis.
+     */
+    fun fallbackTitle(firstMessage: String): String {
+        val cleaned = firstMessage.trim().replace("\n", " ")
+        return when {
+            cleaned.length <= SESSION_TITLE_MAX_LENGTH -> cleaned
+
+            cleaned.contains(". ") -> {
+                val candidate = cleaned.substringBefore(". ") + "."
+                if (candidate.length <= SESSION_TITLE_MAX_LENGTH) {
+                    candidate
+                } else {
+                    cleaned.take(SESSION_TITLE_MAX_LENGTH - 3) + "..."
+                }
+            }
+
+            cleaned.contains("? ") -> {
+                val candidate = cleaned.substringBefore("? ") + "?"
+                if (candidate.length <= SESSION_TITLE_MAX_LENGTH) {
+                    candidate
+                } else {
+                    cleaned.take(SESSION_TITLE_MAX_LENGTH - 3) + "..."
+                }
+            }
+
+            cleaned.contains("! ") -> {
+                val candidate = cleaned.substringBefore("! ") + "!"
+                if (candidate.length <= SESSION_TITLE_MAX_LENGTH) {
+                    candidate
+                } else {
+                    cleaned.take(SESSION_TITLE_MAX_LENGTH - 3) + "..."
+                }
+            }
+
+            else -> cleaned.take(SESSION_TITLE_MAX_LENGTH - 3) + "..."
+        }
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatSessionRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/repository/ChatSessionRepository.kt
@@ -4,6 +4,7 @@
  */
 package io.askimo.core.chat.repository
 
+import io.askimo.core.chat.TitleGenerator
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.chat.domain.ChatSessionsTable
 import io.askimo.core.chat.domain.ProjectsTable
@@ -197,41 +198,7 @@ class ChatSessionRepository internal constructor(
         } > 0
     }.also { if (it) EventBus.post(PushDataToServerEvent(reason = "session touched")) }
 
-    private fun generateTitle(firstMessage: String): String {
-        val cleaned = firstMessage.trim().replace("\n", " ")
-        return when {
-            cleaned.length <= SESSION_TITLE_MAX_LENGTH -> cleaned
-
-            cleaned.contains(". ") -> {
-                val candidate = cleaned.substringBefore(". ") + "."
-                if (candidate.length <= SESSION_TITLE_MAX_LENGTH) {
-                    candidate
-                } else {
-                    cleaned.take(SESSION_TITLE_MAX_LENGTH - 3) + "..."
-                }
-            }
-
-            cleaned.contains("? ") -> {
-                val candidate = cleaned.substringBefore("? ") + "?"
-                if (candidate.length <= SESSION_TITLE_MAX_LENGTH) {
-                    candidate
-                } else {
-                    cleaned.take(SESSION_TITLE_MAX_LENGTH - 3) + "..."
-                }
-            }
-
-            cleaned.contains("! ") -> {
-                val candidate = cleaned.substringBefore("! ") + "!"
-                if (candidate.length <= SESSION_TITLE_MAX_LENGTH) {
-                    candidate
-                } else {
-                    cleaned.take(SESSION_TITLE_MAX_LENGTH - 3) + "..."
-                }
-            }
-
-            else -> cleaned.take(SESSION_TITLE_MAX_LENGTH - 3) + "..."
-        }
-    }
+    private fun generateTitle(firstMessage: String): String = TitleGenerator.fallbackTitle(firstMessage)
 
     fun generateAndUpdateTitle(sessionId: String, firstMessage: String): String {
         val title = generateTitle(firstMessage)

--- a/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/service/ChatSessionService.kt
@@ -12,6 +12,7 @@ import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever
 import io.askimo.core.chat.domain.ChatMessage
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.chat.domain.Project
+import io.askimo.core.chat.domain.SESSION_TITLE_MAX_LENGTH
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.TurnTimelineEntry
 import io.askimo.core.chat.mapper.ChatMessageMapper.toDTO
@@ -417,7 +418,13 @@ class ChatSessionService(
                     """.trimIndent()
                     val utilityChatClient = appContext.createUtilityClient()
 
-                    val aiTitle = utilityChatClient.sendMessage(prompt).trim()
+                    // Normalize to a single line and cap the length before persisting/broadcasting —
+                    // mirrors TitleGenerator.fallbackTitle's contract, since the model isn't
+                    // guaranteed to honor the "short, no punctuation" instruction above.
+                    val aiTitle = utilityChatClient.sendMessage(prompt)
+                        .trim()
+                        .replace("\n", " ")
+                        .take(SESSION_TITLE_MAX_LENGTH)
 
                     if (aiTitle.isNotBlank()) {
                         sessionRepository.updateSessionTitle(createdSession.id, aiTitle)

--- a/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
@@ -724,6 +724,7 @@ class DatabaseManager private constructor(
                     id               TEXT PRIMARY KEY,
                     workspace_id     TEXT NOT NULL REFERENCES workspaces(id),
                     conversation_id  TEXT NOT NULL,
+                    title            TEXT NOT NULL DEFAULT '',
                     user_input       TEXT NOT NULL DEFAULT '',
                     response         TEXT NOT NULL DEFAULT '',
                     error            TEXT,

--- a/shared/src/main/kotlin/io/askimo/core/event/internal/AgentRunTitleUpdatedEvent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/event/internal/AgentRunTitleUpdatedEvent.kt
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.event.internal
+
+import io.askimo.core.event.Event
+import io.askimo.core.event.EventSource
+import io.askimo.core.event.EventType
+import java.time.Instant
+
+/**
+ * Emitted when an agent-run conversation's title is updated — either the initial
+ * deterministic fallback title or, later, a short AI-generated replacement.
+ * UI components (agentic run area, run-history panel) use this to refresh in place
+ * without waiting for a full history reload.
+ */
+data class AgentRunTitleUpdatedEvent(
+    val conversationId: String,
+    val newTitle: String,
+    override val timestamp: Instant = Instant.now(),
+    override val source: EventSource = EventSource.SYSTEM,
+) : Event {
+    override val type = EventType.INTERNAL
+
+    override fun getDetails() = "Agent run conversation $conversationId title updated to: $newTitle"
+}


### PR DESCRIPTION
- Agent run records now include a persistent, human-readable title.
- Title generation logic is centralized in `TitleGenerator`.
- UI components are updated to display the run title in history panels.
- Added event signaling for when a run title is updated.