### PR TITLE
refactor: replace AppComponents with AppColors for theming

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentHistoryPanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentHistoryPanel.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.askimo.core.agent.domain.AgentRunRecord
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.ui.TooltipPlacement
@@ -85,9 +85,9 @@ private fun skillRunHistoryPanelRow(
                 .hoverable(interactionSource)
                 .background(
                     color = if (isHovered) {
-                        AppComponents.surfaceRaised()
+                        AppColors.surfaceColor(AppColors.Elevation.RAISED)
                     } else {
-                        AppComponents.surfaceRecessed()
+                        AppColors.surfaceColor(AppColors.Elevation.RECESSED)
                     },
                     shape = RoundedCornerShape(8.dp),
                 )
@@ -111,7 +111,7 @@ private fun skillRunHistoryPanelRow(
                     Text(
                         record.title,
                         style = AppTextStyles.hint,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                        color = AppColors.secondaryIconColor(),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
@@ -127,7 +127,7 @@ private fun skillRunHistoryPanelRow(
                     Icon(
                         Icons.Default.Delete,
                         contentDescription = "Delete record",
-                        tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
+                        tint = AppColors.destructiveIconColor(),
                         modifier = Modifier.size(14.dp),
                     )
                 }
@@ -158,8 +158,8 @@ internal fun agentRunHistoryList(
             verticalArrangement = Arrangement.spacedBy(Spacing.small),
             modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
         ) {
-            Icon(Icons.Default.History, null, modifier = Modifier.size(36.dp), tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f))
-            Text(stringResource("agents.view.history.empty"), style = AppTextStyles.caption, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f))
+            Icon(Icons.Default.History, null, modifier = Modifier.size(36.dp), tint = AppColors.surfaceColor(AppColors.Elevation.RECESSED))
+            Text(stringResource("agents.view.history.empty"), style = AppTextStyles.caption, color = AppColors.tertiaryIconColor())
         }
     } else {
         var showAll by remember { mutableStateOf(false) }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -74,12 +75,20 @@ import io.askimo.ui.chat.turnTimelineView
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.onImeAwarePreviewKeyEvent
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.themedTooltip
+
+@Composable
+private fun agentReadinessDotColor(state: AgentReadiness?): Color = when (state) {
+    AgentReadiness.READY -> MaterialTheme.colorScheme.tertiary
+    AgentReadiness.NEEDS_SETUP -> MaterialTheme.colorScheme.secondary
+    AgentReadiness.NOT_INSTALLED, null -> AppColors.surfaceColor(AppColors.Elevation.RECESSED)
+}
 
 /**
  * Autonomous run area — user selects an agent and describes a goal;
@@ -220,7 +229,7 @@ internal fun agenticRunArea(
                         var pillHeightPx by remember { mutableStateOf(0) }
                         Box {
                             Surface(
-                                color = AppComponents.surfaceRaised(),
+                                color = AppColors.surfaceColor(AppColors.Elevation.RAISED),
                                 shape = MaterialTheme.shapes.small,
                                 modifier = Modifier
                                     .clickable(onClick = { skillsListExpanded = true })
@@ -248,7 +257,7 @@ internal fun agenticRunArea(
                                     val maxVisible = 4
                                     skills.take(maxVisible).forEach { skill ->
                                         Surface(
-                                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.07f),
+                                            color = AppColors.surfaceColor(AppColors.Elevation.RECESSED),
                                             shape = MaterialTheme.shapes.extraSmall,
                                         ) {
                                             Text(
@@ -282,14 +291,14 @@ internal fun agenticRunArea(
                                     onDismissRequest = { skillsListExpanded = false },
                                     properties = PopupProperties(focusable = true),
                                 ) {
-                                    MaterialTheme(colorScheme = AppComponents.popupColorScheme()) {
+                                    MaterialTheme(colorScheme = AppColors.popupColorScheme()) {
                                         Surface(
                                             modifier = Modifier.width(380.dp),
-                                            color = AppComponents.popupContainerColor(),
-                                            border = AppComponents.popupBorderStroke(),
+                                            color = AppColors.popupContainerColor(),
+                                            border = AppColors.popupBorderStroke(),
                                             shape = RoundedCornerShape(8.dp),
-                                            tonalElevation = AppComponents.popupSurfaceTonalElevation,
-                                            shadowElevation = AppComponents.popupElevation,
+                                            tonalElevation = AppColors.popupSurfaceTonalElevation,
+                                            shadowElevation = AppColors.popupElevation,
                                         ) {
                                             Column {
                                                 Box(modifier = Modifier.fillMaxWidth().heightIn(max = 320.dp)) {
@@ -346,7 +355,7 @@ internal fun agenticRunArea(
                                                 }
 
                                                 // ── Sticky footer — always visible, outside the scroll area ──
-                                                HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f))
+                                                HorizontalDivider(color = AppColors.codeBlockBorderColor())
                                                 Row(
                                                     modifier = Modifier
                                                         .fillMaxWidth()
@@ -374,7 +383,7 @@ internal fun agenticRunArea(
                         }
                     } else {
                         Surface(
-                            color = AppComponents.surfaceRaised(),
+                            color = AppColors.surfaceColor(AppColors.Elevation.RAISED),
                             shape = MaterialTheme.shapes.small,
                         ) {
                             Row(
@@ -388,7 +397,7 @@ internal fun agenticRunArea(
                                     Icons.Default.Extension,
                                     contentDescription = null,
                                     modifier = Modifier.size(14.dp),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                    tint = AppColors.tertiaryIconColor(),
                                 )
                                 Text(
                                     text = stringResource("agents.agentic.no.skills.hint"),
@@ -409,7 +418,7 @@ internal fun agenticRunArea(
                     if (viewModel.agentStateMap[viewModel.selectedAgentRaw?.id] == AgentReadiness.NEEDS_SETUP) {
                         Surface(
                             modifier = Modifier.fillMaxWidth(),
-                            color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.4f),
+                            color = AppColors.surfaceColor(AppColors.Elevation.RAISED),
                             shape = MaterialTheme.shapes.small,
                         ) {
                             Column(modifier = Modifier.padding(Spacing.medium), verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
@@ -502,7 +511,7 @@ internal fun agenticRunArea(
                             },
                         minLines = 4,
                         maxLines = 10,
-                        colors = AppComponents.outlinedTextFieldColors(),
+                        colors = AppColors.outlinedTextFieldColors(),
                     )
 
                     // ── Model selector — overlaid inside the field, bottom-left ────────
@@ -513,8 +522,8 @@ internal fun agenticRunArea(
                     ) {
                         Surface(
                             shape = MaterialTheme.shapes.small,
-                            color = AppComponents.surfaceEmphasis(),
-                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.15f)),
+                            color = AppColors.surfaceColor(AppColors.Elevation.EMPHASIS),
+                            border = BorderStroke(1.dp, AppColors.codeBlockBorderColor()),
                             modifier = Modifier
                                 .clickable(enabled = !viewModel.isRunning, onClick = { modelDropdownExpanded = true })
                                 .pointerHoverIcon(PointerIcon.Hand),
@@ -532,7 +541,7 @@ internal fun agenticRunArea(
                                     Icons.Default.ExpandMore,
                                     contentDescription = null,
                                     modifier = Modifier.size(12.dp),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                    tint = AppColors.secondaryIconColor(),
                                 )
                             }
                         }
@@ -572,8 +581,8 @@ internal fun agenticRunArea(
                             ) {
                                 Surface(
                                     shape = MaterialTheme.shapes.small,
-                                    color = AppComponents.surfaceEmphasis(),
-                                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.18f)),
+                                    color = AppColors.surfaceColor(AppColors.Elevation.EMPHASIS),
+                                    border = BorderStroke(1.dp, AppColors.codeBlockBorderColor()),
                                     modifier = Modifier
                                         .clickable(enabled = agentPickerEnabled, onClick = { agentDropdownExpanded = true })
                                         .pointerHoverIcon(if (agentPickerEnabled) PointerIcon.Hand else PointerIcon.Default),
@@ -587,11 +596,7 @@ internal fun agenticRunArea(
                                             modifier = Modifier
                                                 .size(6.dp)
                                                 .background(
-                                                    color = when (viewModel.agentStateMap[viewModel.selectedAgent?.id]) {
-                                                        AgentReadiness.READY -> MaterialTheme.colorScheme.tertiary.copy(alpha = 0.8f)
-                                                        AgentReadiness.NEEDS_SETUP -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.5f)
-                                                        else -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
-                                                    },
+                                                    color = agentReadinessDotColor(viewModel.agentStateMap[viewModel.selectedAgent?.id]),
                                                     shape = MaterialTheme.shapes.extraSmall,
                                                 ),
                                         )
@@ -603,7 +608,7 @@ internal fun agenticRunArea(
                                             Icons.Default.ExpandMore,
                                             contentDescription = null,
                                             modifier = Modifier.size(12.dp),
-                                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                            tint = AppColors.secondaryIconColor(),
                                         )
                                     }
                                 }
@@ -622,11 +627,7 @@ internal fun agenticRunArea(
                                                     modifier = Modifier
                                                         .size(7.dp)
                                                         .background(
-                                                            color = when (agentState) {
-                                                                AgentReadiness.READY -> MaterialTheme.colorScheme.tertiary
-                                                                AgentReadiness.NEEDS_SETUP -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.6f)
-                                                                AgentReadiness.NOT_INSTALLED -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
-                                                            },
+                                                            color = agentReadinessDotColor(agentState),
                                                             shape = MaterialTheme.shapes.extraSmall,
                                                         ),
                                                 )
@@ -658,7 +659,7 @@ internal fun agenticRunArea(
                         IconButton(
                             onClick = { sendMessage() },
                             enabled = viewModel.selectedAgentReady && inputText.text.isNotBlank() && !viewModel.isRunning,
-                            colors = AppComponents.primaryIconButtonColors(),
+                            colors = AppColors.primaryIconButtonColors(),
                             modifier = Modifier
                                 .size(36.dp)
                                 .pointerHoverIcon(PointerIcon.Hand),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentView.kt
@@ -66,7 +66,7 @@ import io.askimo.core.agent.domain.Workspace
 import io.askimo.core.agent.repository.SkillRepository
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.TooltipPlacement
@@ -140,7 +140,7 @@ fun agentsView(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.3f))
+                            .background(AppColors.scrimColor(alpha = 0.3f))
                             .clickable(
                                 indication = null,
                                 interactionSource = remember { MutableInteractionSource() },
@@ -199,7 +199,7 @@ internal fun agentsPageHeader(
                         tint = if (hasActiveConversation) {
                             MaterialTheme.colorScheme.primary
                         } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                            AppColors.tertiaryIconColor()
                         },
                     )
                 }
@@ -266,7 +266,7 @@ internal fun agentsPageHeader(
         runtimes.forEach { runtime ->
             Surface(
                 shape = MaterialTheme.shapes.small,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
+                color = AppColors.surfaceColor(AppColors.Elevation.RECESSED),
             ) {
                 Text(
                     text = runtime,
@@ -365,7 +365,7 @@ private fun agenticWorkspacePanel(
         modifier = Modifier.width(animatedWidth).fillMaxHeight(),
         shape = RectangleShape,
         colors = CardDefaults.cardColors(
-            containerColor = AppComponents.sidebarSurfaceColor(),
+            containerColor = AppColors.sidebarSurfaceColor(),
             contentColor = MaterialTheme.colorScheme.onSurface,
         ),
     ) {
@@ -430,7 +430,7 @@ private fun agenticWorkspacePanel(
                             }
                         }
                     }
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f))
+                    HorizontalDivider(color = AppColors.codeBlockBorderColor())
                     Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
                         workspaceFilesPanel(
                             workDir = workDir,
@@ -446,7 +446,7 @@ private fun agenticWorkspacePanel(
                         modifier = Modifier
                             .width(56.dp)
                             .fillMaxHeight()
-                            .background(AppComponents.surfaceRecessed())
+                            .background(AppColors.surfaceColor(AppColors.Elevation.RECESSED))
                             .clickable(
                                 indication = null,
                                 interactionSource = remember { MutableInteractionSource() },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/WorkspaceFilesPanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/WorkspaceFilesPanel.kt
@@ -84,6 +84,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.agent.domain.Workspace
 import io.askimo.core.db.DatabaseManager
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
@@ -263,7 +264,7 @@ internal fun workspaceFilesPanel(
                     value = renameWorkspaceText,
                     onValueChange = { renameWorkspaceText = it },
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                     modifier = Modifier.fillMaxWidth().focusRequester(focusRequester).onKeyEvent { event ->
                         if (event.key == Key.Enter && renameWorkspaceText.trim().isNotBlank()) {
                             val newName = renameWorkspaceText.trim()
@@ -345,7 +346,7 @@ internal fun workspaceFilesPanel(
                     onValueChange = { newItemName = it },
                     placeholder = { Text(stringResource("agents.view.workspace.name.placeholder")) },
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                     modifier = Modifier.fillMaxWidth().focusRequester(focusRequester).onKeyEvent { event ->
                         if (event.key == Key.Enter && newItemName.trim().isNotBlank()) {
                             createNewItem(parentDir, newItemName, isFolder)
@@ -442,7 +443,7 @@ internal fun workspaceFilesPanel(
                                         Text(
                                             stringResource("agents.view.workspace.switcher.empty"),
                                             style = AppTextStyles.caption,
-                                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                                            color = AppColors.tertiaryIconColor(),
                                         )
                                     },
                                     onClick = {},
@@ -526,7 +527,7 @@ internal fun workspaceFilesPanel(
                                                         Icons.Default.Delete,
                                                         contentDescription = stringResource("action.remove"),
                                                         modifier = Modifier.size(13.dp),
-                                                        tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
+                                                        tint = AppColors.destructiveIconColor(),
                                                     )
                                                 }
                                             }
@@ -631,14 +632,14 @@ internal fun workspaceFilesPanel(
                 }
             }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.12f))
+            HorizontalDivider(color = AppColors.codeBlockBorderColor())
 
             when {
                 isLoading -> Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Text(
                         "...",
                         style = AppTextStyles.caption,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                        color = AppColors.tertiaryIconColor(),
                     )
                 }
 
@@ -646,7 +647,7 @@ internal fun workspaceFilesPanel(
                     Text(
                         stringResource("agents.view.workspace.empty"),
                         style = AppTextStyles.caption,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                        color = AppColors.tertiaryIconColor(),
                         modifier = Modifier.padding(16.dp),
                     )
                 }
@@ -742,7 +743,7 @@ private fun workspaceNodeRow(
                     .fillMaxWidth()
                     .background(
                         if (isSelected) {
-                            AppComponents.surfaceSelected()
+                            AppColors.surfaceColor(AppColors.Elevation.SELECTED)
                         } else {
                             Color.Transparent
                         },
@@ -785,13 +786,13 @@ private fun workspaceNodeRow(
                         Icon(
                             if (isExpanded) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
                             contentDescription = null,
-                            tint = AppComponents.secondaryIconColor(),
+                            tint = AppColors.secondaryIconColor(),
                             modifier = Modifier.size(14.dp),
                         )
                         Icon(
                             if (isExpanded) Icons.Default.FolderOpen else Icons.Default.Folder,
                             contentDescription = null,
-                            tint = AppComponents.secondaryIconColor(),
+                            tint = AppColors.secondaryIconColor(),
                             modifier = Modifier.size(16.dp),
                         )
                     }
@@ -820,7 +821,7 @@ private fun workspaceNodeRow(
                         modifier = Modifier
                             .weight(1f)
                             .background(
-                                AppComponents.surfaceEmphasis(),
+                                AppColors.surfaceColor(AppColors.Elevation.EMPHASIS),
                                 RoundedCornerShape(3.dp),
                             )
                             .padding(horizontal = 4.dp, vertical = 2.dp)
@@ -878,7 +879,7 @@ private fun workspaceNodeRow(
                         Text(
                             text = node.file.length().toWorkspaceHumanSize(),
                             style = AppTextStyles.hint,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f),
+                            color = AppColors.tertiaryIconColor(),
                         )
                     }
                 }
@@ -1054,7 +1055,7 @@ private fun workspaceFileViewer(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(AppComponents.surfaceRecessed()),
+            .background(AppColors.surfaceColor(AppColors.Elevation.RECESSED)),
     ) {
         HorizontalDivider()
 
@@ -1074,7 +1075,7 @@ private fun workspaceFileViewer(
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.InsertDriveFile,
                     contentDescription = null,
-                    tint = AppComponents.secondaryIconColor(),
+                    tint = AppColors.secondaryIconColor(),
                     modifier = Modifier.size(15.dp),
                 )
                 Text(
@@ -1251,17 +1252,17 @@ private fun loadWorkspaceChildren(dir: File): List<WorkspaceNode> {
 
 @Composable
 private fun workspaceFileIconTint(name: String) = when {
-    name.endsWith(".sh") || name.endsWith(".bash") -> MaterialTheme.colorScheme.error.copy(alpha = 0.75f)
+    name.endsWith(".sh") || name.endsWith(".bash") -> AppColors.warningColor()
 
-    name.endsWith(".md") -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
+    name.endsWith(".md") -> AppColors.secondaryIconColor()
 
     name.endsWith(".kt") || name.endsWith(".java") || name.endsWith(".py") ||
-        name.endsWith(".js") || name.endsWith(".ts") -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f)
+        name.endsWith(".js") || name.endsWith(".ts") -> AppColors.secondaryIconColor()
 
     name.endsWith(".json") || name.endsWith(".xml") || name.endsWith(".yaml") || name.endsWith(".yml") ->
-        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+        AppColors.secondaryIconColor()
 
-    else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+    else -> AppColors.tertiaryIconColor()
 }
 
 private fun Long.toWorkspaceHumanSize(): String = when {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/bookmarks/BookmarksView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/bookmarks/BookmarksView.kt
@@ -5,6 +5,7 @@
 package io.askimo.ui.bookmarks
 
 import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -23,6 +24,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
@@ -38,6 +40,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.style.TextOverflow
@@ -45,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.chat.service.BookmarkGroup
 import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -152,7 +157,7 @@ fun bookmarksView(
                                     imageVector = Icons.Default.BookmarkBorder,
                                     contentDescription = null,
                                     modifier = Modifier.size(48.dp),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                    tint = AppColors.tertiaryIconColor(),
                                 )
                                 Text(
                                     text = stringResource("bookmarks.empty.title"),
@@ -216,7 +221,7 @@ private fun bookmarkGroupCard(
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = AppComponents.sidebarSurfaceColor(),
+        color = AppColors.sidebarSurfaceColor(),
         shape = MaterialTheme.shapes.medium,
     ) {
         Column {
@@ -244,7 +249,7 @@ private fun bookmarkGroupCard(
                 )
             }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+            HorizontalDivider(color = AppColors.codeBlockBorderColor())
 
             // ── Bookmarked messages ───────────────────────────────────────
             group.messages.forEach { message ->
@@ -257,7 +262,7 @@ private fun bookmarkGroupCard(
                 )
                 HorizontalDivider(
                     modifier = Modifier.padding(horizontal = Spacing.large),
-                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                    color = AppColors.codeBlockBorderColor(),
                 )
             }
         }
@@ -281,13 +286,16 @@ private fun bookmarkMessageRow(
         horizontalArrangement = Arrangement.spacedBy(Spacing.medium),
         verticalAlignment = Alignment.Top,
     ) {
-        // Bookmark icon — always visible; hover switches to BookmarkBorder; click removes
         val bookmarkHoverSource = remember { MutableInteractionSource() }
         val isBookmarkHovered by bookmarkHoverSource.collectIsHoveredAsState()
         Box(
             modifier = Modifier
                 .padding(top = 2.dp)
                 .size(20.dp)
+                .clip(CircleShape)
+                .background(
+                    if (isBookmarkHovered) AppColors.surfaceColor(AppColors.Elevation.RAISED) else Color.Transparent,
+                )
                 .hoverable(bookmarkHoverSource)
                 .pointerHoverIcon(PointerIcon.Hand)
                 .clickable(
@@ -301,7 +309,7 @@ private fun bookmarkMessageRow(
                 imageVector = if (isBookmarkHovered) Icons.Default.BookmarkBorder else Icons.Default.Bookmark,
                 contentDescription = stringResource("message.bookmark.remove"),
                 modifier = Modifier.size(16.dp),
-                tint = MaterialTheme.colorScheme.primary.copy(alpha = if (isBookmarkHovered) 1f else 0.7f),
+                tint = MaterialTheme.colorScheme.primary,
             )
         }
 
@@ -310,7 +318,7 @@ private fun bookmarkMessageRow(
             Text(
                 text = if (isUser) stringResource("bookmarks.role.user") else stringResource("bookmarks.role.ai"),
                 style = AppTextStyles.hint,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                color = AppColors.secondaryIconColor(),
             )
             Spacer(modifier = Modifier.height(2.dp))
             // Message preview — rendered as markdown
@@ -323,7 +331,7 @@ private fun bookmarkMessageRow(
                 Text(
                     text = TimeUtil.formatFullDateTime(ts, Locale.getDefault()),
                     style = AppTextStyles.hint,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                    color = AppColors.tertiaryIconColor(),
                 )
             }
         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatInputField.kt
@@ -135,6 +135,7 @@ import io.askimo.core.util.formatFileSize
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.onImeAwarePreviewKeyEvent
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
@@ -726,7 +727,7 @@ fun chatInputField(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = Spacing.small),
-                colors = AppComponents.bannerCardColors(),
+                colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
             ) {
                 Row(
                     modifier = Modifier
@@ -809,7 +810,7 @@ fun chatInputField(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(8.dp)
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                        .background(AppColors.surfaceColor(AppColors.Elevation.RECESSED))
                         .pointerHoverIcon(
                             PointerIcon(Cursor.getPredefinedCursor(Cursor.N_RESIZE_CURSOR)),
                         )
@@ -829,7 +830,7 @@ fun chatInputField(
                             .width(40.dp)
                             .height(4.dp)
                             .background(
-                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                AppColors.tertiaryIconColor(),
                                 RoundedCornerShape(2.dp),
                             ),
                     )
@@ -967,7 +968,7 @@ fun chatInputField(
                                     },
                                     enabled = !isLoading,
                                     colors = if (creationMode is CreationMode.Image) {
-                                        AppComponents.primaryIconButtonColors()
+                                        AppColors.primaryIconButtonColors()
                                     } else {
                                         IconButtonDefaults.iconButtonColors()
                                     },
@@ -1107,7 +1108,7 @@ fun chatInputField(
                                             Text(
                                                 text = stringResource("chat.reasoning.effort.label") + ":",
                                                 style = AppTextStyles.hint,
-                                                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                                                color = AppColors.secondaryIconColor(),
                                             )
                                             Text(
                                                 text = reasoningEffort.value.replaceFirstChar { it.uppercase() },
@@ -1155,7 +1156,7 @@ fun chatInputField(
                                                     showReasoningDropdown = false
                                                 },
                                                 modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                                colors = AppComponents.menuItemColors(),
+                                                colors = AppColors.menuItemColors(),
                                             )
                                         }
                                     }
@@ -1207,7 +1208,7 @@ fun chatInputField(
                                     color = if (recordingElapsedSeconds >= MAX_VOICE_RECORDING_SECONDS - 10) {
                                         MaterialTheme.colorScheme.error
                                     } else {
-                                        MaterialTheme.colorScheme.error.copy(alpha = 0.85f)
+                                        AppColors.warningColor()
                                     },
                                 )
                                 Spacer(modifier = Modifier.width(6.dp))
@@ -1254,7 +1255,7 @@ fun chatInputField(
                                             VoiceRecordingState.RECORDING -> MaterialTheme.colorScheme.error
 
                                             VoiceRecordingState.TRANSCRIBING ->
-                                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                                                AppColors.tertiaryIconColor()
 
                                             VoiceRecordingState.IDLE -> MaterialTheme.colorScheme.onSurface
                                         },
@@ -1468,7 +1469,7 @@ private fun toolsIndicatorButton(
             Surface(
                 shape = RoundedCornerShape(8.dp),
                 color = when {
-                    !modelSupportsTools -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                    !modelSupportsTools -> AppColors.surfaceColor(AppColors.Elevation.RECESSED)
                     !hasAnyEnabled -> Color.Transparent
                     else -> MaterialTheme.colorScheme.secondaryContainer
                 },
@@ -1493,8 +1494,8 @@ private fun toolsIndicatorButton(
                         Icons.Default.Build,
                         contentDescription = stringResource("chat.tools.button"),
                         tint = when {
-                            !modelSupportsTools -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-                            !hasAnyEnabled -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                            !modelSupportsTools -> AppColors.tertiaryIconColor()
+                            !hasAnyEnabled -> AppColors.tertiaryIconColor()
                             hasAnyEnabled -> MaterialTheme.colorScheme.onSecondaryContainer
                             else -> MaterialTheme.colorScheme.onSurface
                         },
@@ -1505,7 +1506,7 @@ private fun toolsIndicatorButton(
                             text = "$enabledServers/$totalServers",
                             style = AppTextStyles.hint,
                             color = if (hasDisabled) {
-                                MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f)
+                                AppColors.tertiaryIconColor()
                             } else {
                                 MaterialTheme.colorScheme.onSecondaryContainer
                             },
@@ -1690,7 +1691,7 @@ private fun mcpServerItem(
     Box {
         Card(
             modifier = Modifier.fillMaxWidth(),
-            colors = AppComponents.surfaceVariantCardColors(),
+            colors = AppColors.cardColors(AppColors.Elevation.RAISED),
         ) {
             Row(
                 modifier = Modifier
@@ -1738,20 +1739,13 @@ private fun mcpServerItem(
                             Text(
                                 text = server.name,
                                 style = AppTextStyles.body,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+                                color = if (isEnabled) MaterialTheme.colorScheme.onSurface else AppTextStyles.disabledContent,
                             )
                             if (server.tools.isNotEmpty()) {
+                                val badgeTone = if (server.isBuiltIn) AppColors.BadgeTone.BUILT_IN else AppColors.BadgeTone.CUSTOM
                                 Badge(
-                                    containerColor = if (server.isBuiltIn) {
-                                        MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f * contentAlpha)
-                                    } else {
-                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.2f * contentAlpha)
-                                    },
-                                    contentColor = if (server.isBuiltIn) {
-                                        MaterialTheme.colorScheme.tertiary.copy(alpha = contentAlpha)
-                                    } else {
-                                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha)
-                                    },
+                                    containerColor = AppColors.variantBadgeContainerColor(badgeTone, contentAlpha),
+                                    contentColor = AppColors.variantBadgeContentColor(badgeTone, contentAlpha, isEnabled),
                                 ) {
                                     Text(
                                         text = server.tools.size.toString(),
@@ -1769,7 +1763,7 @@ private fun mcpServerItem(
                                 stringResource("chat.tools.server.scope.project")
                             },
                             style = AppTextStyles.caption,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
+                            color = if (isEnabled) MaterialTheme.colorScheme.onSurfaceVariant else AppColors.tertiaryIconColor(),
                         )
                     }
 
@@ -1778,7 +1772,7 @@ private fun mcpServerItem(
                         Icon(
                             Icons.Default.ChevronRight,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
+                            tint = if (isEnabled) MaterialTheme.colorScheme.onSurfaceVariant else AppColors.tertiaryIconColor(),
                             modifier = Modifier.size(20.dp),
                         )
                     }
@@ -1828,7 +1822,7 @@ private fun mcpServerItem(
                         val rowBackground = if (index % 2 == 0) {
                             MaterialTheme.colorScheme.surface
                         } else {
-                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                            AppColors.surfaceColor(AppColors.Elevation.RAISED)
                         }
 
                         Box(modifier = Modifier.background(rowBackground)) {
@@ -1877,7 +1871,7 @@ private fun mcpServerItem(
                                     }
                                 },
                                 enabled = canToggleTool,
-                                colors = AppComponents.menuItemColors(),
+                                colors = AppColors.menuItemColors(),
                             )
                         }
                     }
@@ -1931,7 +1925,7 @@ private fun fileAttachmentItem(
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.surfaceVariantCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             // Header row
@@ -2010,7 +2004,7 @@ private fun fileAttachmentItem(
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(max = 240.dp)
-                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.5f))
+                        .background(AppColors.surfaceColor(AppColors.Elevation.RAISED))
                         .padding(horizontal = 12.dp, vertical = 8.dp),
                 ) {
                     when {
@@ -2086,7 +2080,7 @@ private fun directiveChip(
                                 style = AppTextStyles.caption,
                             )
                             HorizontalDivider(
-                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                color = AppColors.codeBlockBorderColor(),
                             )
                             Text(
                                 text = activeDirective.content,
@@ -2112,7 +2106,7 @@ private fun directiveChip(
                 color = if (selectedDirective != null) {
                     MaterialTheme.colorScheme.secondaryContainer
                 } else {
-                    MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
+                    AppColors.surfaceColor(AppColors.Elevation.EMPHASIS)
                 },
                 tonalElevation = 2.dp,
                 modifier = Modifier
@@ -2137,7 +2131,7 @@ private fun directiveChip(
                         tint = if (selectedDirective != null) {
                             MaterialTheme.colorScheme.onSecondaryContainer
                         } else {
-                            MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f)
+                            AppColors.tertiaryIconColor()
                         },
                         modifier = Modifier.size(16.dp),
                     )
@@ -2147,7 +2141,7 @@ private fun directiveChip(
                         color = if (selectedDirective != null) {
                             MaterialTheme.colorScheme.onSecondaryContainer
                         } else {
-                            MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f)
+                            AppColors.tertiaryIconColor()
                         },
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -2281,7 +2275,7 @@ private fun directiveChip(
                                         style = AppTextStyles.caption,
                                     )
                                     HorizontalDivider(
-                                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                        color = AppColors.codeBlockBorderColor(),
                                     )
                                     Text(
                                         text = directive.content,
@@ -2373,7 +2367,7 @@ private fun webSearchRagChip(
             color = if (active) {
                 MaterialTheme.colorScheme.secondaryContainer
             } else {
-                MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.4f)
+                AppColors.surfaceColor(AppColors.Elevation.RAISED)
             },
             tonalElevation = if (active) 2.dp else 0.dp,
             modifier = Modifier
@@ -2399,7 +2393,7 @@ private fun webSearchRagChip(
                     tint = if (active) {
                         MaterialTheme.colorScheme.onSecondaryContainer
                     } else {
-                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                        AppColors.tertiaryIconColor()
                     },
                 )
                 Text(
@@ -2408,7 +2402,7 @@ private fun webSearchRagChip(
                     color = if (active) {
                         MaterialTheme.colorScheme.onSecondaryContainer
                     } else {
-                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                        AppColors.tertiaryIconColor()
                     },
                 )
             }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -40,7 +40,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -105,6 +104,7 @@ import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.KeyMapManager.AppShortcut
 import io.askimo.ui.common.preferences.ApplicationPreferences
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.LocalBackgroundActive
@@ -513,7 +513,7 @@ fun chatView(
                             .fillMaxWidth()
                             .padding(horizontal = Spacing.large, vertical = Spacing.small),
                         colors = CardDefaults.cardColors(
-                            containerColor = AppComponents.sidebarSurfaceColor(),
+                            containerColor = AppColors.sidebarSurfaceColor(),
                             contentColor = MaterialTheme.colorScheme.onSurface,
                         ),
                     ) {
@@ -676,7 +676,7 @@ fun chatView(
                                         }
                                     }
 
-                                    DropdownMenu(
+                                    AppComponents.dropdownMenu(
                                         expanded = showBookmarksPopover,
                                         onDismissRequest = { showBookmarksPopover = false },
                                         modifier = Modifier.widthIn(min = 480.dp),
@@ -805,7 +805,7 @@ fun chatView(
                                                                         Text(
                                                                             text = formatDisplay(ts),
                                                                             style = AppTextStyles.hint,
-                                                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                                                            color = AppColors.secondaryIconColor(),
                                                                         )
                                                                     }
                                                                 }
@@ -858,7 +858,7 @@ fun chatView(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 8.dp),
-                        colors = AppComponents.bannerCardColors(),
+                        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                     ) {
                         Row(
                             modifier = Modifier
@@ -883,7 +883,7 @@ fun chatView(
                                     .focusRequester(searchFocusRequester),
                                 placeholder = { Text(stringResource("chat.search.placeholder")) },
                                 singleLine = true,
-                                colors = AppComponents.outlinedTextFieldColors(),
+                                colors = AppColors.outlinedTextFieldColors(),
                             )
 
                             // Result count
@@ -1172,7 +1172,7 @@ fun chatView(
                                 .widthIn(max = ThemePreferences.CONTENT_MAX_WIDTH)
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp, vertical = 4.dp),
-                            colors = AppComponents.bannerCardColors(),
+                            colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                         ) {
                             Row(
                                 modifier = Modifier
@@ -1315,7 +1315,7 @@ fun chatView(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f)),
+                    .background(AppColors.scrimColor(alpha = 0.32f)),
                 contentAlignment = Alignment.Center,
             ) {
                 Surface(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -106,6 +106,7 @@ import io.askimo.core.util.formatFileSize
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -322,7 +323,7 @@ fun messageList(
                 Text(
                     text = stringResource("message.loading.previous"),
                     style = AppTextStyles.bodySecondary,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    color = AppColors.secondaryIconColor(),
                 )
             }
         }
@@ -444,7 +445,7 @@ fun messageList(
                 Text(
                     text = "$spinnerFrame ${stringResource("message.thinking", thinkingElapsedSeconds)}",
                     style = AppTextStyles.bodySecondary,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    color = AppColors.secondaryIconColor(),
                 )
             }
         }
@@ -621,14 +622,14 @@ private fun userMessageBubble(
                         ),
                     colors = CardDefaults.cardColors(
                         containerColor = if (isOutdatedMessage) {
-                            AppComponents.userMessageBackground().copy(alpha = 0.5f)
+                            AppColors.outdatedUserMessageBackground()
                         } else {
-                            AppComponents.userMessageBackground()
+                            AppColors.userMessageBackground()
                         },
                         contentColor = if (isOutdatedMessage) {
-                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                            AppColors.secondaryIconColor()
                         } else {
-                            AppComponents.userMessageContentColor()
+                            AppColors.userMessageContentColor()
                         },
                     ),
                     elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -671,7 +672,7 @@ private fun userMessageBubble(
                             Text(
                                 text = stringResource("outdated.label"),
                                 style = AppTextStyles.hint,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                color = AppColors.tertiaryIconColor(),
                                 fontStyle = FontStyle.Italic,
                                 modifier = Modifier.padding(start = Spacing.medium, end = Spacing.medium, bottom = Spacing.small, top = Spacing.extraSmall),
                             )
@@ -685,7 +686,7 @@ private fun userMessageBubble(
                     modifier = Modifier
                         .size(32.dp)
                         .background(color = MaterialTheme.colorScheme.primary, shape = CircleShape)
-                        .border(width = 2.dp, color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f), shape = CircleShape),
+                        .border(width = 2.dp, color = AppColors.codeBlockBorderColor(), shape = CircleShape),
                     contentAlignment = Alignment.Center,
                 ) {
                     if (userAvatarPainter != null) {
@@ -794,7 +795,7 @@ private fun userMessageBubble(
                                         Text(
                                             text = LocalizationManager.formatMessageTime(ts),
                                             style = AppTextStyles.hint,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                            color = AppColors.tertiaryIconColor(),
                                         )
                                     }
                                 }
@@ -843,7 +844,7 @@ private fun aiMessageBubble(
     val isClickable = onMessageClick != null && message.id != null && message.timestamp != null
     val voiceErrorTitle = stringResource("chat.voice.error.title")
     val aiContentColor = if (isOutdatedMessage) {
-        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+        AppColors.secondaryIconColor()
     } else {
         MaterialTheme.colorScheme.onSurface
     }
@@ -885,7 +886,7 @@ private fun aiMessageBubble(
                     .padding(top = Spacing.medium)
                     .size(32.dp)
                     .background(color = MaterialTheme.colorScheme.primaryContainer, shape = CircleShape)
-                    .border(width = 2.dp, color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f), shape = CircleShape),
+                    .border(width = 2.dp, color = AppColors.codeBlockBorderColor(), shape = CircleShape),
                 contentAlignment = Alignment.Center,
             ) {
                 if (aiAvatarPainter != null) {
@@ -1006,7 +1007,7 @@ private fun aiMessageBubble(
                                     Text(
                                         text = stringResource("outdated.label"),
                                         style = AppTextStyles.hint,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                        color = AppColors.tertiaryIconColor(),
                                         fontStyle = FontStyle.Italic,
                                         modifier = Modifier.padding(start = Spacing.medium, end = Spacing.medium, bottom = Spacing.small, top = Spacing.extraSmall),
                                     )
@@ -1204,7 +1205,7 @@ private fun aiMessageBubble(
                                 contentDescription = stringResource("message.ai.export.pdf"),
                                 modifier = Modifier.size(16.dp),
                                 tint = if (isExporting) {
-                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                                    AppColors.tertiaryIconColor()
                                 } else {
                                     MaterialTheme.colorScheme.onSurfaceVariant
                                 },
@@ -1300,7 +1301,7 @@ private fun aiMessageBubble(
                             }
                         },
                         style = AppTextStyles.hint,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                        color = AppColors.tertiaryIconColor(),
                     )
                 }
             }
@@ -1313,7 +1314,7 @@ private fun aiMessageBubble(
                         Text(
                             text = "$timestampPrefix${LocalizationManager.formatMessageTime(ts)}",
                             style = AppTextStyles.hint,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                            color = AppColors.tertiaryIconColor(),
                         )
                     }
                 }
@@ -1389,7 +1390,7 @@ internal fun thinkingSection(
     isExpanded: Boolean,
     onToggle: () -> Unit,
 ) {
-    val headerColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+    val headerColor = AppColors.secondaryIconColor()
     val headerText = if (isStreaming) {
         stringResource("message.thinking.section.streaming")
     } else {
@@ -1465,7 +1466,7 @@ internal fun thinkingSection(
                         Text(
                             text = thinkingContent,
                             style = AppTextStyles.caption,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
+                            color = AppColors.secondaryIconColor(),
                             fontStyle = FontStyle.Italic,
                         )
                     }
@@ -1526,7 +1527,7 @@ internal fun turnTimelineView(
                         Text(
                             text = group.entries.last().text,
                             style = AppTextStyles.caption,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            color = AppColors.secondaryIconColor(),
                             maxLines = 1,
                             overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                             modifier = Modifier.fillMaxWidth(),
@@ -1609,7 +1610,7 @@ private fun aiProcessingIndicator() {
         Text(
             text = stringResource("message.processing", elapsedSeconds),
             style = AppTextStyles.hint,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            color = AppColors.secondaryIconColor(),
             fontStyle = FontStyle.Italic,
         )
     }
@@ -1716,7 +1717,7 @@ internal fun toolCallsSection(
     } else {
         stringResource("tool.call.header.done", toolCalls.size)
     }
-    val headerColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+    val headerColor = AppColors.secondaryIconColor()
 
     Column(
         modifier = Modifier
@@ -1779,16 +1780,20 @@ private fun toolCallRow(toolCall: ToolCallInfo) {
 
     var detailsExpanded by remember { mutableStateOf(false) }
 
-    val barColor = when {
-        hasFailed -> MaterialTheme.colorScheme.error.copy(alpha = 0.7f)
-        isDone -> MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
-        else -> MaterialTheme.colorScheme.outlineVariant
-    }
-    val statusIconColor = when {
-        hasFailed -> MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
-        isDone -> MaterialTheme.colorScheme.primary.copy(alpha = 0.8f)
-        else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-    }
+    val barColor = AppColors.statusAccentColor(
+        when {
+            hasFailed -> AppColors.StatusTone.FAILURE
+            isDone -> AppColors.StatusTone.SUCCESS
+            else -> AppColors.StatusTone.NEUTRAL
+        },
+    )
+    val statusIconColor = AppColors.statusIconColor(
+        when {
+            hasFailed -> AppColors.StatusTone.FAILURE
+            isDone -> AppColors.StatusTone.SUCCESS
+            else -> AppColors.StatusTone.NEUTRAL
+        },
+    )
 
     Row(
         modifier = Modifier
@@ -1865,7 +1870,7 @@ private fun toolCallRow(toolCall: ToolCallInfo) {
                         imageVector = if (detailsExpanded) Icons.Default.ExpandMore else Icons.Default.ChevronRight,
                         contentDescription = null,
                         modifier = Modifier.size(12.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                        tint = AppColors.tertiaryIconColor(),
                     )
                 }
             }
@@ -1888,7 +1893,7 @@ private fun toolCallRow(toolCall: ToolCallInfo) {
                         toolCallDetailSection(
                             label = stringResource("tool.call.detail.result"),
                             content = toolCall.result!!,
-                            labelColor = if (hasFailed) MaterialTheme.colorScheme.error.copy(alpha = 0.8f) else null,
+                            labelColor = if (hasFailed) AppColors.warningColor() else null,
                         )
                     }
                 }
@@ -1910,17 +1915,17 @@ private fun toolCallDetailSection(
         Text(
             text = label,
             style = AppTextStyles.hint,
-            color = labelColor ?: MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            color = labelColor ?: AppColors.secondaryIconColor(),
         )
         SelectionContainer {
             Text(
                 text = content,
                 style = AppTextStyles.codeSecondary,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
+                color = AppColors.secondaryIconColor(),
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(
-                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f),
+                        color = AppColors.codeBlockBackground(),
                         shape = RoundedCornerShape(4.dp),
                     )
                     .padding(horizontal = Spacing.extraSmall, vertical = 2.dp),
@@ -2033,7 +2038,7 @@ fun aiMessageEditDialog(
                             .fillMaxHeight()
                             .padding(end = 12.dp), // room for the scrollbar
                         textStyle = AppTextStyles.body,
-                        colors = AppComponents.outlinedTextFieldColors(),
+                        colors = AppColors.outlinedTextFieldColors(),
                         label = { Text(stringResource("message.ai.edit.content.label")) },
                         scrollState = textScrollState,
                     )
@@ -2087,16 +2092,16 @@ private fun messageDaySeparator(label: String) {
     ) {
         HorizontalDivider(
             modifier = Modifier.weight(1f),
-            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+            color = AppColors.codeBlockBorderColor(),
         )
         Text(
             text = label,
             style = AppTextStyles.hint,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            color = AppColors.secondaryIconColor(),
         )
         HorizontalDivider(
             modifier = Modifier.weight(1f),
-            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+            color = AppColors.codeBlockBorderColor(),
         )
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/OutdatedMessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/OutdatedMessageComponents.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 
 /**
@@ -104,7 +104,7 @@ fun outdatedBranchComponent(
                 .clickable { isExpanded = !isExpanded }
                 .pointerHoverIcon(PointerIcon.Hand),
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                containerColor = AppColors.surfaceColor(AppColors.Elevation.RAISED),
                 contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
             ),
         ) {
@@ -122,14 +122,14 @@ fun outdatedBranchComponent(
                     } else {
                         stringResource("outdated.expand")
                     },
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    tint = AppColors.secondaryIconColor(),
                     modifier = Modifier.size(20.dp),
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = stringResource("outdated.branch.header", messages.size),
                     style = AppTextStyles.caption,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    color = AppColors.secondaryIconColor(),
                     fontStyle = FontStyle.Italic,
                 )
             }
@@ -142,7 +142,7 @@ fun outdatedBranchComponent(
                     .fillMaxWidth()
                     .padding(start = 16.dp, top = 8.dp)
                     .background(
-                        AppComponents.surfaceRecessed(),
+                        AppColors.surfaceColor(AppColors.Elevation.RECESSED),
                         RoundedCornerShape(8.dp),
                     )
                     .padding(8.dp),
@@ -189,7 +189,7 @@ fun outdatedMessageItem(
         Box(
             modifier = Modifier
                 .matchParentSize()
-                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.4f)),
+                .background(AppColors.outdatedMessageOverlayColor()),
         )
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/ActionInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/ActionInputField.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.onImeAwarePreviewKeyEvent
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -111,7 +112,7 @@ internal fun actionInputField(
             if (isLoading) {
                 AppComponents.loadingSpinner(
                     size = 20.dp,
-                    trackColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f),
+                    trackColor = AppColors.onPrimaryTrackColor(),
                 )
             } else {
                 Icon(
@@ -135,7 +136,7 @@ internal fun actionInputField(
             if (isLoading) {
                 AppComponents.loadingSpinner(
                     size = 14.dp,
-                    trackColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f),
+                    trackColor = AppColors.onPrimaryTrackColor(),
                 )
             } else {
                 Icon(
@@ -235,7 +236,7 @@ internal fun actionInputField(
                 enabled = enabled,
                 isError = error != null,
                 supportingText = error?.let { { Text(it) } },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
             )
 
             sendButton()

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/Buttons.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/Buttons.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
+import io.askimo.ui.common.theme.AppColors
+import io.askimo.ui.common.theme.AppTextStyles
 
 /**
  * Primary action button with filled background.
@@ -96,9 +98,9 @@ fun secondaryButton(
         border = BorderStroke(
             width = 1.dp,
             color = if (enabled) {
-                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                AppColors.tertiaryIconColor()
             } else {
-                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+                AppColors.surfaceColor(AppColors.Elevation.RECESSED)
             },
         ),
         modifier = modifier.pointerHoverIcon(PointerIcon.Hand, overrideDescendants = true),
@@ -167,7 +169,7 @@ fun linkButton(
     val contentColor = if (enabled) {
         MaterialTheme.colorScheme.onSurface
     } else {
-        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+        AppTextStyles.disabledContent
     }
 
     CompositionLocalProvider(LocalContentColor provides contentColor) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/Icons.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/Icons.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.askimo.ui.common.theme.AppColors
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Status icons
@@ -71,7 +72,7 @@ fun notIndexedIcon(
     Icon(
         imageVector = Icons.Default.RadioButtonUnchecked,
         contentDescription = contentDescription,
-        tint = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
+        tint = AppColors.warningColor(),
         modifier = modifier.size(size),
     )
 }
@@ -91,7 +92,7 @@ fun warningIcon(
     Icon(
         imageVector = Icons.Default.Warning,
         contentDescription = contentDescription,
-        tint = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
+        tint = AppColors.warningColor(),
         modifier = modifier.size(size),
     )
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/TablePagination.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/components/TablePagination.kt
@@ -68,7 +68,7 @@ fun tablePagination(
                     tint = if (hasPrevious) {
                         MaterialTheme.colorScheme.onSurface
                     } else {
-                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        AppTextStyles.disabledContent
                     },
                 )
             }
@@ -88,7 +88,7 @@ fun tablePagination(
                     tint = if (hasNext) {
                         MaterialTheme.colorScheme.onSurface
                     } else {
-                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        AppTextStyles.disabledContent
                     },
                 )
             }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/UpdateDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/dialog/UpdateDialog.kt
@@ -33,6 +33,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -129,7 +130,7 @@ private fun newVersionDialog(
                         contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
                     )
 
-                    UpdateUrgency.LOW -> AppComponents.bannerCardColors()
+                    UpdateUrgency.LOW -> AppColors.cardColors(AppColors.Elevation.ACCENT)
                 }
                 val bannerIcon = if (urgency == UpdateUrgency.HIGH) Icons.Default.Warning else Icons.Default.Info
                 val bannerText = when (urgency) {
@@ -160,7 +161,7 @@ private fun newVersionDialog(
                 // Version info card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Row(
                         modifier = Modifier.fillMaxWidth().padding(Spacing.large),
@@ -210,7 +211,7 @@ private fun newVersionDialog(
                     )
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = AppComponents.bannerCardColors(),
+                        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                     ) {
                         Column(
                             modifier = Modifier
@@ -276,7 +277,7 @@ private fun upToDateDialog(
                 )
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),
@@ -321,7 +322,7 @@ private fun errorDialog(
         text = {
             Card(
                 modifier = Modifier.fillMaxWidth(),
-                colors = AppComponents.bannerCardColors(),
+                colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
             ) {
                 Text(
                     text = message,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppColors.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppColors.kt
@@ -1,0 +1,570 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.ui.common.theme
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.MenuItemColors
+import androidx.compose.material3.NavigationDrawerItemColors
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.NavigationRailItemColors
+import androidx.compose.material3.NavigationRailItemDefaults
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Every color token in Askimo — the single place to look when changing "what color is X".
+ *
+ * ## Component Catalog — "I'm building X, which function do I call?"
+ *
+ * Look up the UI element you're building here *first*, before reaching for a raw
+ * `MaterialTheme.colorScheme.*` or writing a new `.copy(alpha = ...)`. If your element
+ * genuinely isn't listed, that's a signal to add a new named token (with a doc comment
+ * explaining *why*) rather than hand-rolling a color at the call site.
+ *
+ * | UI element                                             | Function(s) |
+ * |----------------------------------------------------------|-------------|
+ * | Sidebar background                                        | [sidebarSurfaceColor] |
+ * | Sidebar header row (logo/title bar)                       | [sidebarHeaderColor] + [sidebarHeaderContentColor] |
+ * | Settings/search-result card, static pill, table header    | [cardColors] / [surfaceColor] with [Elevation.RAISED] |
+ * | Row hover highlight (non-selection)                       | [surfaceColor] with [Elevation.RAISED] |
+ * | Selected list/tree row                                    | [surfaceColor] with [Elevation.SELECTED] |
+ * | Inline rename field, dropdown pill on an input            | [surfaceColor] with [Elevation.EMPHASIS] |
+ * | Headline banner / deliberate call-to-action card          | [cardColors] with [Elevation.ACCENT] |
+ * | Recessed panel (viewer, collapsed rail)                   | [surfaceColor] with [Elevation.RECESSED] |
+ * | Dialog / dropdown / popup surface                         | [popupContainerColor], [popupBorderStroke], [popupColorScheme] |
+ * | Full-screen modal scrim                                   | [scrimColor] |
+ * | Badge distinguishing a category/variant (e.g. built-in vs custom) | [variantBadgeContainerColor] / [variantBadgeContentColor] with [BadgeTone] |
+ * | Small numeric count badge (e.g. bookmark count)           | [countBadgeAccentColor] |
+ * | Disabled text/icon                                        | [disabledContentColor] |
+ * | Delete/remove icon button                                 | [destructiveIconColor] |
+ * | Warning icon/accent (non-destructive)                     | [warningColor] |
+ * | Draggable resize handle/divider, hovered                  | [resizeHandleHoverColor] |
+ * | Tool-call/agent-step status dot or icon                   | [statusAccentColor] / [statusIconColor] with [StatusTone] |
+ * | Outlined text field                                       | [outlinedTextFieldColors] |
+ * | Dropdown/context menu item                                | [menuItemColors] |
+ * | Chat message bubble background                            | [userMessageBackground] / [outdatedUserMessageBackground] |
+ * | Outdated message full-bubble scrim                        | [outdatedMessageOverlayColor] |
+ * | Background-image / thumbnail picker tile scrim            | [imageThumbnailScrimColor] |
+ * | Code block background                                     | [codeBlockBackground] / [codeBlockContentColor] |
+ * | Secondary/tertiary icon or text (non-interactive)         | [secondaryIconColor] / [tertiaryIconColor] |
+ * | Inline bar-chart track / value label (pass the bar's own series color) | [chartBarTrackColor] / [chartValueLabelColor] |
+ * | Loading-skeleton placeholder box                          | [skeletonPlaceholderColor] |
+ * | Text/badge tint derived from a card's own contentColor (pass the card's `contentColor`) | [cardBadgeContainerColor] / [cardSecondaryContentColor] / [cardMonospaceDetailColor] |
+ */
+object AppColors {
+
+    // ── Elevation Scale ────────────────────────────────────────────────────────
+    // The single source of truth for every "surface sitting above its background"
+    // in the app: cards, pills, rows, hover/selection states.
+
+    enum class Elevation {
+        /** Recedes into the background — content viewers, expanded "raw output" panels,
+         *  a collapsed side rail. */
+        RECESSED,
+
+        /** The standard "card/pill/row at rest" background — settings option cards,
+         *  search-result cards, static info pills, table header rows. Also the right
+         *  choice for a plain (non-selection) hover highlight on a list row, since the
+         *  same subtle lift reads correctly in both cases. */
+        RAISED,
+
+        /** A stronger lift for elements that must stand out even against an already
+         *  [RAISED] container — an inline rename field sitting on a raised tree row, a
+         *  dropdown/selector pill sitting on an input field, a callout box. */
+        EMPHASIS,
+
+        /** True selection/active state — the one tier that shifts hue (toward
+         *  [MaterialTheme.colorScheme.primaryContainer]) rather than just opacity, so a
+         *  selected item is never confused with a merely-hovered or merely-raised one. */
+        SELECTED,
+
+        /** Full-strength accent container — a deliberate call-to-action or headline banner.
+         *  Rare; prefer [RAISED]/[EMPHASIS] unless the surface truly needs to read as
+         *  "primary." */
+        ACCENT,
+    }
+
+    /** Background [Color] for [tier] — the one place every elevation color is defined. */
+    @Composable
+    fun surfaceColor(tier: Elevation): Color = when (tier) {
+        Elevation.RECESSED -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f)
+        Elevation.RAISED -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+        Elevation.EMPHASIS -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+        Elevation.SELECTED -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+        Elevation.ACCENT -> MaterialTheme.colorScheme.primaryContainer
+    }
+
+    /** Matching content (text/icon) [Color] for [tier] — always paired with [surfaceColor]. */
+    @Composable
+    fun contentColorFor(tier: Elevation): Color = when (tier) {
+        Elevation.SELECTED, Elevation.ACCENT -> MaterialTheme.colorScheme.onPrimaryContainer
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+
+    /**
+     * Muted secondary-text variant of [contentColorFor] — preserves a primary/secondary text
+     * hierarchy even when sitting on a colored [Elevation.SELECTED]/[Elevation.ACCENT]
+     * container (e.g. the hex code shown under a selected accent-color preset's label).
+     */
+    @Composable
+    fun secondaryContentColorFor(tier: Elevation): Color = contentColorFor(tier).copy(alpha = 0.82f)
+
+    /** [CardColors] for [tier] — for any `Card` that isn't `AppComponents.clickableCard`. */
+    @Composable
+    fun cardColors(tier: Elevation): CardColors = CardDefaults.cardColors(
+        containerColor = surfaceColor(tier),
+        contentColor = contentColorFor(tier),
+    )
+
+    // ── Popup / Overlay Surface tokens ────────────────────────────────────────
+    // Single source of truth for every floating surface: dialogs, dropdowns,
+    // notification panels, popup cards.  Centralised here so the visual language
+    // of all overlays can be changed in one place.
+
+    /** Background color for all floating surfaces (dialogs, popups, dropdowns). */
+    @Composable
+    fun popupContainerColor(): Color = MaterialTheme.colorScheme.surface
+
+    /**
+     * Dimming overlay tint for scrims — full-screen modal backdrops (dialog-over-content),
+     * and small always-dark badges that need contrast against arbitrary photo content
+     * (e.g. an icon button overlaid on an image thumbnail).
+     *
+     * Built on [MaterialTheme.colorScheme.scrim], which — unlike `onSurface`/`onSurfaceVariant` —
+     * is specified to stay black-ish in both light and dark themes, so it's the only token-safe
+     * base for an overlay that must always read as "dark" regardless of the active theme.
+     *
+     * @param alpha Strength of the dim — heavier for full-screen backdrops (~0.3-0.35),
+     *   lighter or heavier for small icon badges depending on desired contrast (~0.4-0.5).
+     */
+    @Composable
+    fun scrimColor(alpha: Float): Color = MaterialTheme.colorScheme.scrim.copy(alpha = alpha)
+
+    /**
+     * Consistent 1 dp border for all floating surfaces.
+     * Provides subtle depth definition without relying on elevation alone, and
+     * ensures popups read clearly against any window background.
+     */
+    @Composable
+    fun popupBorderStroke(): BorderStroke = BorderStroke(
+        width = 1.dp,
+        color = MaterialTheme.colorScheme.outlineVariant,
+    )
+
+    /**
+     * Drop-shadow elevation for floating Card surfaces (e.g. notification popup).
+     * Controls visible shadow only — kept separate from [popupSurfaceTonalElevation]
+     * so shadow depth and tonal colour are independently adjustable.
+     */
+    val popupElevation: Dp = 8.dp
+
+    /**
+     * Tonal elevation for dialog/popup Surfaces — intentionally **0.dp**.
+     *
+     * M3 tonal elevation blends a primary-colour overlay into the Surface
+     * background, making a scaffold dialog / alert dialog appear slightly different
+     * from a dropdown menu (which forces all surfaceContainer tonal slots to plain
+     * surface via [popupColorScheme]). Keeping this at zero ensures every popup
+     * background resolves to the same pure [popupContainerColor] regardless of the
+     * active theme seed colour.
+     */
+    val popupSurfaceTonalElevation: Dp = 0.dp
+
+    /**
+     * Shared MaterialTheme colorScheme override for all popup surfaces.
+     *
+     * Forces every M3 surfaceContainer tonal slot to [popupContainerColor] so
+     * that Material3 components rendered inside (DropdownMenu, AlertDialog, etc.)
+     * pick up the canonical popup background rather than their own tonal slot.
+     * Combine with [popupSurfaceTonalElevation] = 0 for a fully consistent look.
+     */
+    @Composable
+    fun popupColorScheme() = MaterialTheme.colorScheme.let { cs ->
+        val bg = popupContainerColor()
+        cs.copy(
+            surfaceContainerLowest = bg,
+            surfaceContainerLow = bg,
+            surfaceContainer = bg,
+            surfaceContainerHigh = bg,
+            surfaceContainerHighest = bg,
+        )
+    }
+
+    // ── Navigation ───────────────────────────────────────────────────────────
+
+    @Composable
+    fun navigationDrawerItemColors(): NavigationDrawerItemColors = NavigationDrawerItemDefaults.colors(
+        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+        selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        selectedBadgeColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        unselectedContainerColor = Color.Transparent,
+        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        unselectedBadgeColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+
+    @Composable
+    fun navigationRailItemColors(): NavigationRailItemColors = NavigationRailItemDefaults.colors(
+        selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        indicatorColor = MaterialTheme.colorScheme.primaryContainer,
+    )
+
+    // ── Buttons & Icons ───────────────────────────────────────────────────────
+
+    /**
+     * Standard M3 disabled-content opacity (38%) applied to [MaterialTheme.colorScheme.onSurface] —
+     * the single source for every "disabled text/icon" tint in the app (icon buttons, menu items,
+     * etc), instead of each color-set repeating the same `.copy(alpha = 0.38f)` literal.
+     */
+    @Composable
+    fun disabledContentColor(): Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+
+    @Composable
+    fun primaryIconButtonColors(): IconButtonColors = IconButtonDefaults.iconButtonColors(
+        contentColor = MaterialTheme.colorScheme.primary,
+        disabledContentColor = disabledContentColor(),
+    )
+
+    @Composable
+    fun primaryTextButtonColors(): ButtonColors = ButtonDefaults.textButtonColors(
+        contentColor = MaterialTheme.colorScheme.primary,
+    )
+
+    /**
+     * Closed set of badge "variants" for MCP server tool-count badges — a built-in server
+     * reads as a distinct hue from a custom/user-added one. Kept as an enum (like
+     * [StatusTone]) rather than accepting an arbitrary [Color] parameter, so every badge in
+     * the app draws from the same fixed, curated palette instead of each call site inventing
+     * its own hue.
+     */
+    enum class BadgeTone {
+        /** Built-in / first-party integration. */
+        BUILT_IN,
+
+        /** Custom / user-added integration. */
+        CUSTOM,
+    }
+
+    /**
+     * Background tint for a small colored badge/chip that distinguishes a category or
+     * variant (e.g. built-in vs custom), scaled by [contentAlpha] so a disabled badge fades
+     * along with the rest of its row instead of fighting for attention. Named distinctly
+     * from [countBadgeAccentColor] — this one answers "which variant is this," not "how many."
+     */
+    @Composable
+    fun variantBadgeContainerColor(tone: BadgeTone, contentAlpha: Float = 1f): Color {
+        val hue = when (tone) {
+            BadgeTone.BUILT_IN -> MaterialTheme.colorScheme.tertiary
+            BadgeTone.CUSTOM -> MaterialTheme.colorScheme.primary
+        }
+        return hue.copy(alpha = 0.2f * contentAlpha)
+    }
+
+    /**
+     * Content tint paired with [variantBadgeContainerColor]. [isEnabled] additionally mutes a
+     * [BadgeTone.CUSTOM] badge to [tertiaryIconColor] when its row is disabled, matching the
+     * existing MCP-server-row disabled treatment.
+     */
+    @Composable
+    fun variantBadgeContentColor(tone: BadgeTone, contentAlpha: Float = 1f, isEnabled: Boolean = true): Color = when (tone) {
+        BadgeTone.BUILT_IN -> MaterialTheme.colorScheme.tertiary.copy(alpha = contentAlpha)
+        BadgeTone.CUSTOM -> if (isEnabled) MaterialTheme.colorScheme.onSurfaceVariant else tertiaryIconColor()
+    }
+
+    /**
+     * Accent tint for a small numeric count badge (e.g. the bookmark-count badge on a
+     * sidebar session row) — primary at reduced strength so it reads as a subtle inline
+     * indicator rather than a primary-colored call to action. Unlike [variantBadgeContentColor],
+     * this isn't a "which variant" choice — every count badge in the app uses this same tint.
+     */
+    @Composable
+    fun countBadgeAccentColor(): Color = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
+
+    /**
+     * Track color for [AppComponents.loadingSpinner] when it sits on top of a filled/primary
+     * button — needs to be a translucent [MaterialTheme.colorScheme.onPrimary] rather than the
+     * spinner's usual neutral track, since a neutral track wouldn't read against a primary fill.
+     */
+    @Composable
+    fun onPrimaryTrackColor(): Color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f)
+
+    /**
+     * Warning tint — [MaterialTheme.colorScheme.error] at reduced opacity. Used for
+     * non-destructive but important alerts/status (warning icons, "failed" accents) that
+     * should read as visually distinct without being as alarming as a full-strength error.
+     */
+    @Composable
+    fun warningColor(): Color = MaterialTheme.colorScheme.error.copy(alpha = 0.8f)
+
+    /**
+     * Muted destructive-action tint — [MaterialTheme.colorScheme.error] at 70% opacity. The
+     * standard tint for delete/remove icon buttons across the app (history rows, file panels,
+     * etc) — slightly softer than [warningColor] since it's an available action rather than
+     * a status/warning that must stay maximally legible.
+     */
+    @Composable
+    fun destructiveIconColor(): Color = MaterialTheme.colorScheme.error.copy(alpha = 0.7f)
+
+    /**
+     * Accent tint for a draggable resize handle/divider while hovered — signals "this is
+     * interactive" without a full-strength primary fill. Pair with [codeBlockBorderColor]
+     * (or [MaterialTheme.colorScheme.outlineVariant]) for the at-rest state.
+     */
+    @Composable
+    fun resizeHandleHoverColor(): Color = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+
+    // ── Status Tones ───────────────────────────────────────────────────────────
+    // Shared "running / succeeded / failed" outcome coloring for any inline status
+    // indicator — accent bars, dots, and icon tints (tool-call rows, agent run steps,
+    // background job chips, etc). Centralised so every "is this still going / did it
+    // work / did it fail" signal in the app uses the same three colors.
+
+    enum class StatusTone {
+        /** In progress, or no outcome yet — reads as inert/neutral, not colored. */
+        NEUTRAL,
+
+        /** Completed successfully. */
+        SUCCESS,
+
+        /** Failed / errored. */
+        FAILURE,
+    }
+
+    /** Color for a status accent bar / dot (e.g. the left accent bar on a tool-call row). */
+    @Composable
+    fun statusAccentColor(tone: StatusTone): Color = when (tone) {
+        StatusTone.NEUTRAL -> MaterialTheme.colorScheme.outlineVariant
+        StatusTone.SUCCESS -> MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+        StatusTone.FAILURE -> MaterialTheme.colorScheme.error.copy(alpha = 0.7f)
+    }
+
+    /** Color for a status icon/label — stronger than [statusAccentColor] since icons/text
+     *  need to read clearly rather than just hint at the outcome. */
+    @Composable
+    fun statusIconColor(tone: StatusTone): Color = when (tone) {
+        StatusTone.NEUTRAL -> secondaryIconColor()
+        StatusTone.SUCCESS -> MaterialTheme.colorScheme.primary.copy(alpha = 0.8f)
+        StatusTone.FAILURE -> warningColor()
+    }
+
+    // ── Inputs ────────────────────────────────────────────────────────────────
+
+    @Composable
+    fun outlinedTextFieldColors(
+        focusedBorderColor: Color = MaterialTheme.colorScheme.onSurface,
+        unfocusedBorderColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.42f),
+        focusedLabelColor: Color = MaterialTheme.colorScheme.onSurface,
+        unfocusedLabelColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+        focusedTextColor: Color = MaterialTheme.colorScheme.onSurface,
+        unfocusedTextColor: Color = MaterialTheme.colorScheme.onSurface,
+        cursorColor: Color = MaterialTheme.colorScheme.onSurface,
+        containerColor: Color = MaterialTheme.colorScheme.surface,
+    ): TextFieldColors = OutlinedTextFieldDefaults.colors(
+        focusedBorderColor = focusedBorderColor,
+        unfocusedBorderColor = unfocusedBorderColor,
+        focusedLabelColor = focusedLabelColor,
+        unfocusedLabelColor = unfocusedLabelColor,
+        focusedTextColor = focusedTextColor,
+        unfocusedTextColor = unfocusedTextColor,
+        cursorColor = cursorColor,
+        focusedContainerColor = containerColor,
+        unfocusedContainerColor = containerColor,
+        disabledContainerColor = containerColor,
+    )
+
+    @Composable
+    fun menuItemColors(): MenuItemColors = MenuDefaults.itemColors(
+        textColor = MaterialTheme.colorScheme.onSurface,
+        leadingIconColor = MaterialTheme.colorScheme.onSurface,
+        trailingIconColor = MaterialTheme.colorScheme.onSurface,
+        disabledTextColor = disabledContentColor(),
+        disabledLeadingIconColor = disabledContentColor(),
+        disabledTrailingIconColor = disabledContentColor(),
+    )
+
+    // ── Sidebar Colors ────────────────────────────────────────────────────────
+
+    @Composable
+    private fun sidebarTint(headerStrength: Boolean): Color {
+        val surfaceColor = MaterialTheme.colorScheme.surface
+        val primaryColor = MaterialTheme.colorScheme.primary
+        val isLight = surfaceColor.luminance() > 0.5
+        val tintAmount = when {
+            headerStrength && isLight -> 0.12f
+            headerStrength -> 0.16f
+            isLight -> 0.08f
+            else -> 0.12f
+        }
+        val base = Color(
+            red = surfaceColor.red + (primaryColor.red - surfaceColor.red) * tintAmount,
+            green = surfaceColor.green + (primaryColor.green - surfaceColor.green) * tintAmount,
+            blue = surfaceColor.blue + (primaryColor.blue - surfaceColor.blue) * tintAmount,
+            alpha = surfaceColor.alpha,
+        )
+        // When a background image is active, let it show through the sidebar
+        return if (LocalBackgroundActive.current) base.copy(alpha = 0.82f) else base
+    }
+
+    @Composable
+    fun sidebarSurfaceColor(): Color = sidebarTint(headerStrength = false)
+
+    @Composable
+    fun sidebarHeaderColor(): Color = sidebarTint(headerStrength = true)
+
+    /**
+     * Contrast-safe text/icon color for content painted directly on [sidebarHeaderColor] —
+     * e.g. the logo, app title, and collapse/expand icon in the sidebar header row.
+     */
+    @Composable
+    fun sidebarHeaderContentColor(): Color {
+        val backgroundLuminance = sidebarHeaderColor().luminance()
+        val onSurface = MaterialTheme.colorScheme.onSurface
+        val inverseOnSurface = MaterialTheme.colorScheme.inverseOnSurface
+        return if (backgroundLuminance > 0.5) {
+            if (onSurface.luminance() < inverseOnSurface.luminance()) onSurface else inverseOnSurface
+        } else {
+            if (onSurface.luminance() > inverseOnSurface.luminance()) onSurface else inverseOnSurface
+        }
+    }
+
+    // ── Chat / Content Shading ────────────────────────────────────────────────
+
+    /**
+     * Shifts [MaterialTheme.colorScheme.surface] toward black/white by [amount] — the one
+     * primitive behind every "surface, but slightly shaded" background in the app
+     * ([userMessageBackground], [codeBlockBackground]).
+     */
+    @Composable
+    private fun shadedSurface(amount: Float): Color {
+        val surface = MaterialTheme.colorScheme.surface
+        val isLight = surface.luminance() > 0.5
+        return if (isLight) {
+            Color(
+                red = (surface.red * (1f - amount)).coerceIn(0f, 1f),
+                green = (surface.green * (1f - amount)).coerceIn(0f, 1f),
+                blue = (surface.blue * (1f - amount)).coerceIn(0f, 1f),
+                alpha = surface.alpha,
+            )
+        } else {
+            Color(
+                red = (surface.red + amount).coerceIn(0f, 1f),
+                green = (surface.green + amount).coerceIn(0f, 1f),
+                blue = (surface.blue + amount).coerceIn(0f, 1f),
+                alpha = surface.alpha,
+            )
+        }
+    }
+
+    /** Subtle shade — message bubbles. */
+    @Composable
+    fun userMessageBackground(): Color = shadedSurface(if (MaterialTheme.colorScheme.surface.luminance() > 0.5) 0.08f else 0.10f)
+
+    /** Faded variant of [userMessageBackground] — outdated/superseded messages that are still
+     *  visible for context but shouldn't read as fully "current". */
+    @Composable
+    fun outdatedUserMessageBackground(): Color = userMessageBackground().copy(alpha = 0.5f)
+
+    /**
+     * Translucent scrim painted over a full outdated message bubble (any role) to mute it —
+     * pairs with [outdatedUserMessageBackground] but applies to the whole bubble (including
+     * AI messages) rather than just the user-bubble shade.
+     */
+    @Composable
+    fun outdatedMessageOverlayColor(): Color = MaterialTheme.colorScheme.surface.copy(alpha = 0.4f)
+
+    /**
+     * Dim scrim painted over a background/thumbnail image tile so overlaid label text stays
+     * readable regardless of the image's own colors (e.g. the background-image picker tiles
+     * in Appearance settings).
+     */
+    @Composable
+    fun imageThumbnailScrimColor(): Color = MaterialTheme.colorScheme.surface.copy(alpha = 0.45f)
+
+    @Composable
+    fun userMessageContentColor(): Color = MaterialTheme.colorScheme.onSurface
+
+    /** Stronger shade than [userMessageBackground] — code blocks need to read as clearly
+     *  distinct from surrounding prose. */
+    @Composable
+    fun codeBlockBackground(): Color = shadedSurface(if (MaterialTheme.colorScheme.surface.luminance() > 0.5) 0.15f else 0.25f)
+
+    @Composable
+    fun codeBlockContentColor(): Color = MaterialTheme.colorScheme.onSurface
+
+    @Composable
+    fun codeBlockBorderColor(): Color = MaterialTheme.colorScheme.outlineVariant
+
+    @Composable
+    fun isCodeBlockDark(): Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5
+
+    // ── Icon & Text Tints ─────────────────────────────────────────────────────
+    // Prefer AppTextStyles.primaryContent / secondaryContent over these helpers.
+    // These are kept for call sites that haven't been migrated yet.
+
+    /** @see AppTextStyles.secondaryContent */
+    @Composable
+    fun secondaryIconColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant
+
+    /** Subtle decorative icon tint — half-opacity secondary. */
+    @Composable
+    fun tertiaryIconColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+
+    // ── Charts ────────────────────────────────────────────────────────────────
+    // Shared tints for simple inline bar/line charts (e.g. the daily-activity chart in
+    // Usage settings) whose bars are colored per-series rather than always primary —
+    // centralised here so every chart derives its "track" and "value label" shades from
+    // the same two fixed opacities instead of each chart hand-rolling its own alpha.
+
+    /**
+     * Faint backdrop tint for a colored chart bar/segment — [hue] at low opacity, giving a
+     * "full range" track behind a bar without needing a separate neutral track color.
+     */
+    fun chartBarTrackColor(hue: Color): Color = hue.copy(alpha = 0.2f)
+
+    /**
+     * Value-label tint paired with a chart bar's [hue] — slightly dimmed from full strength
+     * so the numeric label reads as secondary to the bar itself.
+     */
+    fun chartValueLabelColor(hue: Color): Color = hue.copy(alpha = 0.85f)
+
+    /** Placeholder background for a loading skeleton row/box — same neutral tier used for
+     *  progress-bar tracks, so skeletons read as "not yet data" rather than a distinct color. */
+    @Composable
+    fun skeletonPlaceholderColor(): Color = surfaceColor(Elevation.RECESSED)
+
+    // ── Card Content Tints ────────────────────────────────────────────────────
+    // A notification/status card's `contentColor` varies by card type (e.g.
+    // onSecondaryContainer for an update card, onSurfaceVariant for a plain one) — these
+    // derive consistent "badge / secondary / monospace-detail" shades from *whatever*
+    // [contentColor] the card is using, so every card type gets the same visual hierarchy
+    // without each one hand-picking its own alpha.
+
+    /** Small pill/badge background derived from a card's own [contentColor] (e.g. the
+     *  version-bump badge on an update notification card). */
+    fun cardBadgeContainerColor(contentColor: Color): Color = contentColor.copy(alpha = 0.15f)
+
+    /** De-emphasized secondary text/caption tint on a colored card (e.g. a notification
+     *  card's timestamp) — dimmed from the card's own [contentColor]. */
+    fun cardSecondaryContentColor(contentColor: Color): Color = contentColor.copy(alpha = 0.7f)
+
+    /** Expandable monospace detail text (stack trace / error message) on a colored card —
+     *  dimmed less than [cardSecondaryContentColor] since code needs to stay legible. */
+    fun cardMonospaceDetailColor(contentColor: Color): Color = contentColor.copy(alpha = 0.85f)
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -113,7 +113,7 @@ object AppComponents {
      * Bakes in:
      * - `.clip(shape)` **before** `hoverable`/`clickable` so the ripple and hover
      *   highlight are always clipped to rounded corners (prevents the rectangle-border bug).
-     * - Default: [AppColors.Elevation.RAISED] + `outlineVariant.copy(alpha = 0.6f)` border.
+     * - Default: [AppColors.Elevation.RAISED] + [AppColors.codeBlockBorderColor] (`outlineVariant`) border.
      * - Hover:   [AppColors.Elevation.SELECTED] + `primary.copy(alpha = 0.4f)` border — the
      *   same tier used for an actually-selected item elsewhere, so hover and selection never
      *   read as two different colors.

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -47,8 +47,6 @@ import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AlertDialogDefaults
-import androidx.compose.material3.ButtonColors
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
@@ -58,22 +56,12 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonColors
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuDefaults
-import androidx.compose.material3.MenuItemColors
-import androidx.compose.material3.NavigationDrawerItemColors
-import androidx.compose.material3.NavigationDrawerItemDefaults
-import androidx.compose.material3.NavigationRailItemColors
-import androidx.compose.material3.NavigationRailItemDefaults
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -83,7 +71,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.TextStyle
@@ -100,6 +87,11 @@ import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import io.askimo.ui.common.i18n.stringResource
 
+/**
+ * Composable widgets and layout tokens shared across the app — dialogs, dropdown menus,
+ * form fields, cards, spinners, popups. For color tokens (backgrounds, borders, content
+ * colors), see [AppColors]; this object consumes those tokens but doesn't define new ones.
+ */
 object AppComponents {
 
     // Shared spacing/tokens for scaffold-style dialogs.
@@ -108,88 +100,10 @@ object AppComponents {
     val dialogActionBarMinHeight: Dp = 56.dp
     val dialogScrollbarPadding: Dp = 12.dp
 
-    // ── Popup / Overlay Surface tokens ────────────────────────────────────────
-    // Single source of truth for every floating surface: dialogs, dropdowns,
-    // notification panels, popup cards.  Centralised here so the visual language
-    // of all overlays can be changed in one place.
-
-    /** Background color for all floating surfaces (dialogs, popups, dropdowns). */
-    @Composable
-    fun popupContainerColor(): Color = MaterialTheme.colorScheme.surface
-
-    /**
-     * Consistent 1 dp border for all floating surfaces.
-     * Provides subtle depth definition without relying on elevation alone, and
-     * ensures popups read clearly against any window background.
-     */
-    @Composable
-    fun popupBorderStroke(): BorderStroke = BorderStroke(
-        width = 1.dp,
-        color = MaterialTheme.colorScheme.outlineVariant,
-    )
-
-    /**
-     * Drop-shadow elevation for floating Card surfaces (e.g. notification popup).
-     * Controls visible shadow only — kept separate from [popupSurfaceTonalElevation]
-     * so shadow depth and tonal colour are independently adjustable.
-     */
-    val popupElevation: Dp = 8.dp
-
-    /**
-     * Tonal elevation for dialog/popup [Surface]s — intentionally **0.dp**.
-     *
-     * M3 tonal elevation blends a primary-colour overlay into the Surface
-     * background, making [scaffoldDialog] and [alertDialog] appear slightly
-     * different from [dropdownMenu] (which forces all surfaceContainer tonal slots
-     * to plain [surface] via [popupColorScheme]).  Keeping this at zero ensures
-     * every popup background resolves to the same pure [popupContainerColor]
-     * regardless of the active theme seed colour.
-     */
-    val popupSurfaceTonalElevation: Dp = 0.dp
-
-    /**
-     * Shared MaterialTheme colorScheme override for all popup surfaces.
-     *
-     * Forces every M3 surfaceContainer tonal slot to [popupContainerColor] so
-     * that Material3 components rendered inside (DropdownMenu, AlertDialog, etc.)
-     * pick up the canonical popup background rather than their own tonal slot.
-     * Combine with [popupSurfaceTonalElevation] = 0 for a fully consistent look.
-     */
-    @Composable
-    fun popupColorScheme() = MaterialTheme.colorScheme.let { cs ->
-        val bg = popupContainerColor()
-        cs.copy(
-            surfaceContainerLowest = bg,
-            surfaceContainerLow = bg,
-            surfaceContainer = bg,
-            surfaceContainerHigh = bg,
-            surfaceContainerHighest = bg,
-        )
-    }
-
     // ── Navigation ───────────────────────────────────────────────────────────
 
     /** Corner radius for the selected-item background in all navigation components. */
     val navigationItemShape: Shape = RoundedCornerShape(8.dp)
-
-    @Composable
-    fun navigationDrawerItemColors(): NavigationDrawerItemColors = NavigationDrawerItemDefaults.colors(
-        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedBadgeColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        unselectedContainerColor = Color.Transparent,
-        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        unselectedBadgeColor = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-
-    @Composable
-    fun navigationRailItemColors(): NavigationRailItemColors = NavigationRailItemDefaults.colors(
-        selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        indicatorColor = MaterialTheme.colorScheme.primaryContainer,
-    )
 
     // ── Cards ─────────────────────────────────────────────────────────────────
 
@@ -199,8 +113,10 @@ object AppComponents {
      * Bakes in:
      * - `.clip(shape)` **before** `hoverable`/`clickable` so the ripple and hover
      *   highlight are always clipped to rounded corners (prevents the rectangle-border bug).
-     * - Default: `surfaceVariant.copy(alpha = 0.5f)` + `outlineVariant.copy(alpha = 0.6f)` border.
-     * - Hover:   `primaryContainer.copy(alpha = 0.25f)` + `primary.copy(alpha = 0.4f)` border.
+     * - Default: [AppColors.Elevation.RAISED] + `outlineVariant.copy(alpha = 0.6f)` border.
+     * - Hover:   [AppColors.Elevation.SELECTED] + `primary.copy(alpha = 0.4f)` border — the
+     *   same tier used for an actually-selected item elsewhere, so hover and selection never
+     *   read as two different colors.
      *
      * Use this instead of bare [Card] whenever the card is clickable.
      */
@@ -209,30 +125,20 @@ object AppComponents {
         onClick: (() -> Unit)?,
         modifier: Modifier = Modifier,
         shape: Shape = MaterialTheme.shapes.medium,
-        colors: CardColors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-            contentColor = MaterialTheme.colorScheme.onSurface,
-        ),
+        colors: CardColors = AppColors.cardColors(AppColors.Elevation.RAISED),
         content: @Composable ColumnScope.() -> Unit,
     ) {
         val interactionSource = remember { MutableInteractionSource() }
         val isHovered by interactionSource.collectIsHoveredAsState()
 
-        val resolvedColors = if (onClick != null && isHovered) {
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.25f),
-                contentColor = MaterialTheme.colorScheme.onSurface,
-            )
-        } else {
-            colors
-        }
+        val resolvedColors = if (onClick != null && isHovered) AppColors.cardColors(AppColors.Elevation.SELECTED) else colors
 
         val border = BorderStroke(
             1.dp,
             if (onClick != null && isHovered) {
                 MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)
             } else {
-                MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f)
+                AppColors.codeBlockBorderColor()
             },
         )
 
@@ -257,64 +163,10 @@ object AppComponents {
         )
     }
 
-    @Composable
-    fun primaryCardColors(): CardColors = CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.primaryContainer,
-        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-    )
-
-    @Composable
-    fun bannerCardColors(): CardColors = CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-    )
-
-    @Composable
-    fun surfaceVariantCardColors(): CardColors = CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-
-    // ── Buttons & Icons ───────────────────────────────────────────────────────
-
-    @Composable
-    fun primaryIconButtonColors(): IconButtonColors = IconButtonDefaults.iconButtonColors(
-        contentColor = MaterialTheme.colorScheme.primary,
-        disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-    )
-
-    @Composable
-    fun primaryTextButtonColors(): ButtonColors = ButtonDefaults.textButtonColors(
-        contentColor = MaterialTheme.colorScheme.primary,
-    )
-
     // ── Inputs ────────────────────────────────────────────────────────────────
 
-    @Composable
-    fun outlinedTextFieldColors(
-        focusedBorderColor: Color = MaterialTheme.colorScheme.onSurface,
-        unfocusedBorderColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.42f),
-        focusedLabelColor: Color = MaterialTheme.colorScheme.onSurface,
-        unfocusedLabelColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
-        focusedTextColor: Color = MaterialTheme.colorScheme.onSurface,
-        unfocusedTextColor: Color = MaterialTheme.colorScheme.onSurface,
-        cursorColor: Color = MaterialTheme.colorScheme.onSurface,
-        containerColor: Color = MaterialTheme.colorScheme.surface,
-    ): TextFieldColors = OutlinedTextFieldDefaults.colors(
-        focusedBorderColor = focusedBorderColor,
-        unfocusedBorderColor = unfocusedBorderColor,
-        focusedLabelColor = focusedLabelColor,
-        unfocusedLabelColor = unfocusedLabelColor,
-        focusedTextColor = focusedTextColor,
-        unfocusedTextColor = unfocusedTextColor,
-        cursorColor = cursorColor,
-        focusedContainerColor = containerColor,
-        unfocusedContainerColor = containerColor,
-        disabledContainerColor = containerColor,
-    )
-
     /**
-     * Themed [OutlinedTextField] with default colors from [outlinedTextFieldColors].
+     * Themed [OutlinedTextField] with default colors from [AppColors.outlinedTextFieldColors].
      */
     @Composable
     fun appOutlinedTextField(
@@ -350,7 +202,7 @@ object AppComponents {
             maxLines = maxLines,
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
-            colors = outlinedTextFieldColors(),
+            colors = AppColors.outlinedTextFieldColors(),
         )
     }
 
@@ -403,7 +255,7 @@ object AppComponents {
                     )
                 }
             },
-            colors = outlinedTextFieldColors(),
+            colors = AppColors.outlinedTextFieldColors(),
         )
     }
 
@@ -453,16 +305,6 @@ object AppComponents {
         }
     }
 
-    @Composable
-    fun menuItemColors(): MenuItemColors = MenuDefaults.itemColors(
-        textColor = MaterialTheme.colorScheme.onSurface,
-        leadingIconColor = MaterialTheme.colorScheme.onSurface,
-        trailingIconColor = MaterialTheme.colorScheme.onSurface,
-        disabledTextColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-        disabledLeadingIconColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-        disabledTrailingIconColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-    )
-
     /**
      * A themed [DropdownMenuItem] with consistent UX across the app:
      * - Always reserves leading-icon space for a [Check] mark, rendered transparently
@@ -496,151 +338,13 @@ object AppComponents {
                 )
             },
             trailingIcon = trailingIcon,
-            colors = menuItemColors(),
+            colors = AppColors.menuItemColors(),
             contentPadding = contentPadding,
         )
         if (showDivider) {
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+            HorizontalDivider(color = AppColors.codeBlockBorderColor())
         }
     }
-
-    // ── Surface Tiers ─────────────────────────────────────────────────────────
-
-    /**
-     * Quiet, non-interactive backdrop for content that should visually recede —
-     * file/content viewers, expanded "raw output" panels, a collapsed side rail.
-     */
-    @Composable
-    fun surfaceRecessed(): Color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f)
-
-    /**
-     * The standard "card/pill/row at rest" background — settings option cards,
-     * search-result cards, static info pills, table header rows. Also the right
-     * choice for a plain (non-selection) hover highlight on a list row, since the
-     * same subtle lift reads correctly in both cases.
-     */
-    @Composable
-    fun surfaceRaised(): Color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
-
-    /**
-     * A stronger lift for elements that must stand out even against an already
-     * [surfaceRaised] container — an inline rename field sitting on a raised tree
-     * row, a dropdown/selector pill sitting on an input field, a callout box.
-     */
-    @Composable
-    fun surfaceEmphasis(): Color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
-
-    /**
-     * True selection/active state — the one case that should shift hue (toward
-     * [MaterialTheme.colorScheme.primaryContainer]) rather than just opacity, so a
-     * selected item is never confused with a merely-hovered or merely-raised one.
-     */
-    @Composable
-    fun surfaceSelected(): Color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
-
-    // ── Surface Colors ────────────────────────────────────────────────────────
-
-    @Composable
-    private fun sidebarTint(headerStrength: Boolean): Color {
-        val surfaceColor = MaterialTheme.colorScheme.surface
-        val primaryColor = MaterialTheme.colorScheme.primary
-        val isLight = surfaceColor.luminance() > 0.5
-        val tintAmount = when {
-            headerStrength && isLight -> 0.12f
-            headerStrength -> 0.16f
-            isLight -> 0.08f
-            else -> 0.12f
-        }
-        val base = Color(
-            red = surfaceColor.red + (primaryColor.red - surfaceColor.red) * tintAmount,
-            green = surfaceColor.green + (primaryColor.green - surfaceColor.green) * tintAmount,
-            blue = surfaceColor.blue + (primaryColor.blue - surfaceColor.blue) * tintAmount,
-            alpha = surfaceColor.alpha,
-        )
-        // When a background image is active, let it show through the sidebar
-        return if (LocalBackgroundActive.current) base.copy(alpha = 0.82f) else base
-    }
-
-    @Composable
-    fun sidebarSurfaceColor(): Color = sidebarTint(headerStrength = false)
-
-    @Composable
-    fun sidebarHeaderColor(): Color = sidebarTint(headerStrength = true)
-
-    /**
-     * Contrast-safe text/icon color for content painted directly on [sidebarHeaderColor] —
-     * e.g. the logo, app title, and collapse/expand icon in the sidebar header row.
-     */
-    @Composable
-    fun sidebarHeaderContentColor(): Color {
-        val backgroundLuminance = sidebarHeaderColor().luminance()
-        val onSurface = MaterialTheme.colorScheme.onSurface
-        val inverseOnSurface = MaterialTheme.colorScheme.inverseOnSurface
-        return if (backgroundLuminance > 0.5) {
-            if (onSurface.luminance() < inverseOnSurface.luminance()) onSurface else inverseOnSurface
-        } else {
-            if (onSurface.luminance() > inverseOnSurface.luminance()) onSurface else inverseOnSurface
-        }
-    }
-
-    /**
-     * Shifts [MaterialTheme.colorScheme.surface] toward black/white by [amount] — the one
-     * primitive behind every "surface, but slightly shaded" background in the app
-     * ([userMessageBackground], [codeBlockBackground]).
-     */
-    @Composable
-    private fun shadedSurface(amount: Float): Color {
-        val surface = MaterialTheme.colorScheme.surface
-        val isLight = surface.luminance() > 0.5
-        return if (isLight) {
-            Color(
-                red = (surface.red * (1f - amount)).coerceIn(0f, 1f),
-                green = (surface.green * (1f - amount)).coerceIn(0f, 1f),
-                blue = (surface.blue * (1f - amount)).coerceIn(0f, 1f),
-                alpha = surface.alpha,
-            )
-        } else {
-            Color(
-                red = (surface.red + amount).coerceIn(0f, 1f),
-                green = (surface.green + amount).coerceIn(0f, 1f),
-                blue = (surface.blue + amount).coerceIn(0f, 1f),
-                alpha = surface.alpha,
-            )
-        }
-    }
-
-    /** Subtle shade — message bubbles. */
-    @Composable
-    fun userMessageBackground(): Color = shadedSurface(if (MaterialTheme.colorScheme.surface.luminance() > 0.5) 0.08f else 0.10f)
-
-    @Composable
-    fun userMessageContentColor(): Color = MaterialTheme.colorScheme.onSurface
-
-    /** Stronger shade than [userMessageBackground] — code blocks need to read as clearly
-     *  distinct from surrounding prose. */
-    @Composable
-    fun codeBlockBackground(): Color = shadedSurface(if (MaterialTheme.colorScheme.surface.luminance() > 0.5) 0.15f else 0.25f)
-
-    @Composable
-    fun codeBlockContentColor(): Color = MaterialTheme.colorScheme.onSurface
-
-    @Composable
-    fun codeBlockBorderColor(): Color = MaterialTheme.colorScheme.outlineVariant
-
-    @Composable
-    fun isCodeBlockDark(): Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5
-
-    // ── Icon & Text Tints ─────────────────────────────────────────────────────
-    // Prefer AppTextStyles.primaryContent / secondaryContent over these helpers.
-    // These are kept for call sites that haven't been migrated yet.
-
-    /** @see AppTextStyles.secondaryContent */
-    @Composable
-    fun secondaryIconColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant
-
-    /** Subtle decorative icon tint — half-opacity secondary. */
-    @Composable
-    fun tertiaryIconColor(): Color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
 
     @Composable
     fun dropdownMenu(
@@ -650,8 +354,8 @@ object AppComponents {
         offset: DpOffset = DpOffset.Zero,
         content: @Composable ColumnScope.() -> Unit,
     ) {
-        val border = popupBorderStroke()
-        MaterialTheme(colorScheme = popupColorScheme()) {
+        val border = AppColors.popupBorderStroke()
+        MaterialTheme(colorScheme = AppColors.popupColorScheme()) {
             DropdownMenu(
                 expanded = expanded,
                 onDismissRequest = onDismissRequest,
@@ -680,11 +384,11 @@ object AppComponents {
         iconContentColor: Color = AlertDialogDefaults.iconContentColor,
         titleContentColor: Color = AlertDialogDefaults.titleContentColor,
         textContentColor: Color = AlertDialogDefaults.textContentColor,
-        tonalElevation: Dp = popupSurfaceTonalElevation,
+        tonalElevation: Dp = AppColors.popupSurfaceTonalElevation,
         properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
-        val border = popupBorderStroke()
-        MaterialTheme(colorScheme = popupColorScheme()) {
+        val border = AppColors.popupBorderStroke()
+        MaterialTheme(colorScheme = AppColors.popupColorScheme()) {
             AlertDialog(
                 onDismissRequest = onDismissRequest,
                 confirmButton = confirmButton,
@@ -777,7 +481,7 @@ object AppComponents {
         properties: DialogProperties = DialogProperties(),
         shape: Shape = MaterialTheme.shapes.large,
         containerColor: Color = MaterialTheme.colorScheme.surface,
-        tonalElevation: Dp = popupSurfaceTonalElevation,
+        tonalElevation: Dp = AppColors.popupSurfaceTonalElevation,
         contentPadding: Dp = dialogContentPadding,
         sectionSpacing: Dp = dialogSectionSpacing,
         onCloseRequest: (() -> Unit)? = null,
@@ -792,9 +496,9 @@ object AppComponents {
             dismissOnClickOutside = properties.dismissOnClickOutside,
             usePlatformDefaultWidth = false,
         )
-        val border = popupBorderStroke()
+        val border = AppColors.popupBorderStroke()
         Dialog(onDismissRequest = onDismissRequest, properties = resolvedProperties) {
-            MaterialTheme(colorScheme = popupColorScheme()) {
+            MaterialTheme(colorScheme = AppColors.popupColorScheme()) {
                 BoxWithConstraints {
                     Surface(
                         modifier = modifier
@@ -884,7 +588,7 @@ object AppComponents {
         properties: DialogProperties = DialogProperties(),
         shape: Shape = MaterialTheme.shapes.large,
         containerColor: Color = MaterialTheme.colorScheme.surface,
-        tonalElevation: Dp = popupSurfaceTonalElevation,
+        tonalElevation: Dp = AppColors.popupSurfaceTonalElevation,
         contentPadding: Dp = dialogContentPadding,
         sectionSpacing: Dp = dialogSectionSpacing,
         onCloseRequest: (() -> Unit)? = null,
@@ -899,9 +603,9 @@ object AppComponents {
             dismissOnClickOutside = properties.dismissOnClickOutside,
             usePlatformDefaultWidth = false,
         )
-        val border = popupBorderStroke()
+        val border = AppColors.popupBorderStroke()
         Dialog(onDismissRequest = onDismissRequest, properties = resolvedProperties) {
-            MaterialTheme(colorScheme = popupColorScheme()) {
+            MaterialTheme(colorScheme = AppColors.popupColorScheme()) {
                 BoxWithConstraints {
                     Surface(
                         modifier = modifier
@@ -974,9 +678,9 @@ object AppComponents {
      * Standardised small loading spinner for all UI contexts.
      *
      * Color defaults to [LocalContentColor] so it automatically matches its container:
-     *   - inside a `primaryButton`         → onPrimary
-     *   - inside a `bannerCardColors` card → onSecondaryContainer
-     *   - on a plain surface               → onSurface
+     *   - inside a `primaryButton`                        → onPrimary
+     *   - inside a `AppColors.cardColors(Elevation.ACCENT)` card → onPrimaryContainer
+     *   - on a plain surface                               → onSurface
      *
      * Bakes in `strokeWidth = 2.dp` (lighter than M3 default of 4.dp) for inline use.
      *
@@ -1012,8 +716,8 @@ object AppComponents {
         thickness = 6.dp,
         shape = MaterialTheme.shapes.small,
         hoverDurationMillis = 300,
-        unhoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
-        hoverColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.50f),
+        unhoverColor = AppColors.surfaceColor(AppColors.Elevation.RECESSED),
+        hoverColor = AppColors.tertiaryIconColor(),
     )
 
     /**
@@ -1032,19 +736,19 @@ object AppComponents {
         properties: PopupProperties = PopupProperties(focusable = true),
         content: @Composable ColumnScope.() -> Unit,
     ) {
-        val border = popupBorderStroke()
+        val border = AppColors.popupBorderStroke()
         Popup(
             popupPositionProvider = positionProvider,
             onDismissRequest = onDismissRequest,
             properties = properties,
         ) {
-            MaterialTheme(colorScheme = popupColorScheme()) {
+            MaterialTheme(colorScheme = AppColors.popupColorScheme()) {
                 Surface(
                     modifier = modifier.border(border.width, border.brush, shape),
                     shape = shape,
-                    color = popupContainerColor(),
-                    tonalElevation = popupSurfaceTonalElevation,
-                    shadowElevation = popupElevation,
+                    color = AppColors.popupContainerColor(),
+                    tonalElevation = AppColors.popupSurfaceTonalElevation,
+                    shadowElevation = AppColors.popupElevation,
                 ) {
                     Column(content = content)
                 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/ThemePreferences.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/ThemePreferences.kt
@@ -121,12 +121,35 @@ object ThemePreferences {
         // AppConfig is the canonical store for the UI locale (shared, YAML-persisted)
         val savedTag = runCatching { AppConfig.currentLocale }.getOrNull()
         if (!savedTag.isNullOrBlank()) {
-            val locale = runCatching { Locale.forLanguageTag(savedTag) }.getOrDefault(Locale.ENGLISH)
+            val locale = normalizeLocale(
+                runCatching { Locale.forLanguageTag(savedTag) }.getOrDefault(Locale.ENGLISH),
+            )
+            val normalizedTag = locale.toLanguageTag()
+            if (normalizedTag != savedTag) {
+                // Self-heal legacy persisted tags like "vi-Latn-VN" -> "vi-VN"
+                AppConfig.updateField("currentLocale", normalizedTag)
+            }
             LocalizationManager.setLocale(locale)
             return locale
         }
         // No preference saved — default to English
         return Locale.ENGLISH
+    }
+
+    /**
+     * Strips any script/variant subtag (e.g. "Latn") from a [Locale] so persisted
+     * and in-memory tags stay consistent (e.g. "en", "vi-VN") instead of forms
+     * like "vi-Latn-VN" that the JVM's CLDR locale data can produce.
+     */
+    private fun normalizeLocale(locale: Locale): Locale {
+        val language = locale.language
+        val country = locale.country
+        if (language.isBlank()) return locale
+        return if (country.isNotEmpty()) {
+            Locale.Builder().setLanguage(language).setRegion(country).build()
+        } else {
+            Locale.Builder().setLanguage(language).build()
+        }
     }
 
     private fun loadLogLevel(): LogLevel {
@@ -173,10 +196,11 @@ object ThemePreferences {
     }
 
     fun setLocale(locale: Locale) {
-        _locale.value = locale
-        prefs.put(LOCALE_KEY, locale.toLanguageTag())
-        AppConfig.updateField("currentLocale", locale.toLanguageTag())
-        LocalizationManager.setLocale(locale)
+        val normalized = normalizeLocale(locale)
+        _locale.value = normalized
+        prefs.put(LOCALE_KEY, normalized.toLanguageTag())
+        AppConfig.updateField("currentLocale", normalized.toLanguageTag())
+        LocalizationManager.setLocale(normalized)
     }
 
     fun setLogLevel(level: LogLevel) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/CodeViewerBlock.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/CodeViewerBlock.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.LocalCodeFontFamily
 
@@ -60,7 +60,7 @@ fun codeViewerBlock(
     modifier: Modifier = Modifier,
 ) {
     val codeFontFamily = LocalCodeFontFamily.current
-    val isDark = AppComponents.isCodeBlockDark()
+    val isDark = AppColors.isCodeBlockDark()
     val theme = if (isDark) CodeHighlighter.darkTheme() else CodeHighlighter.lightTheme()
     val highlightedCode = CodeHighlighter.highlight(
         code = code,
@@ -69,8 +69,8 @@ fun codeViewerBlock(
         codeFontFamily = codeFontFamily,
     )
 
-    val backgroundColor = AppComponents.codeBlockBackground()
-    val contentColor = AppComponents.codeBlockContentColor()
+    val backgroundColor = AppColors.codeBlockBackground()
+    val contentColor = AppColors.codeBlockContentColor()
 
     val lines = code.lines()
     val lineCount = lines.size
@@ -165,8 +165,8 @@ fun codeViewerBlock(
                         thickness = 6.dp,
                         shape = MaterialTheme.shapes.small,
                         hoverDurationMillis = 150,
-                        unhoverColor = contentColor.copy(alpha = 0.20f),
-                        hoverColor = contentColor.copy(alpha = 0.50f),
+                        unhoverColor = AppColors.surfaceColor(AppColors.Elevation.RECESSED),
+                        hoverColor = AppColors.tertiaryIconColor(),
                     ),
                 )
             }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MarkdownText.kt
@@ -84,6 +84,7 @@ import io.askimo.core.logging.currentFileLogger
 import io.askimo.core.util.JsonUtils.json
 import io.askimo.tools.chart.MermaidChartData
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.LocalCodeFontFamily
@@ -394,11 +395,12 @@ private fun renderParagraph(
         return
     }
 
-    val inlineCodeBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+    val inlineCodeBg = AppColors.surfaceColor(AppColors.Elevation.EMPHASIS)
     val linkColor = MaterialTheme.colorScheme.tertiary
+    val mathBg = AppColors.surfaceColor(AppColors.Elevation.RECESSED)
 
     val annotatedText =
-        buildInlineContent(paragraph, inlineCodeBg, linkColor, codeFontFamily, onLinkClick)
+        buildInlineContent(paragraph, inlineCodeBg, linkColor, codeFontFamily, mathBg, onLinkClick)
     Text(
         text = annotatedText,
         style = AppTextStyles.body,
@@ -414,8 +416,9 @@ private fun renderHeading(
     codeFontFamily: FontFamily,
     onLinkClick: ((url: String) -> Unit)? = null,
 ) {
-    val inlineCodeBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+    val inlineCodeBg = AppColors.surfaceColor(AppColors.Elevation.EMPHASIS)
     val linkColor = MaterialTheme.colorScheme.tertiary
+    val mathBg = AppColors.surfaceColor(AppColors.Elevation.RECESSED)
 
     val style = when (heading.level) {
         1 -> MaterialTheme.typography.headlineMedium
@@ -427,7 +430,7 @@ private fun renderHeading(
     }
 
     Text(
-        text = buildInlineContent(heading, inlineCodeBg, linkColor, codeFontFamily, onLinkClick),
+        text = buildInlineContent(heading, inlineCodeBg, linkColor, codeFontFamily, mathBg, onLinkClick),
         style = style,
         modifier = Modifier
             .fillMaxWidth()
@@ -445,7 +448,7 @@ private fun renderBulletList(
     onRunRequest: ((String, String) -> Unit)? = null,
     messageId: String? = null,
 ) {
-    val inlineCodeBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+    val inlineCodeBg = AppColors.surfaceColor(AppColors.Elevation.EMPHASIS)
 
     Column(modifier = Modifier.padding(start = Spacing.large, top = Spacing.extraSmall, bottom = Spacing.extraSmall)) {
         var item = list.firstChild
@@ -468,7 +471,7 @@ private fun renderOrderedList(
     onRunRequest: ((String, String) -> Unit)? = null,
     messageId: String? = null,
 ) {
-    val inlineCodeBg = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+    val inlineCodeBg = AppColors.surfaceColor(AppColors.Elevation.EMPHASIS)
 
     Column(modifier = Modifier.padding(start = Spacing.large, top = Spacing.extraSmall, bottom = Spacing.extraSmall)) {
         var item = list.firstChild
@@ -497,6 +500,7 @@ private fun renderListItem(
     messageId: String? = null,
 ) {
     val linkColor = MaterialTheme.colorScheme.tertiary
+    val mathBg = AppColors.surfaceColor(AppColors.Elevation.RECESSED)
 
     Column(modifier = Modifier.padding(vertical = 2.dp)) {
         // Single pass over the item's children in document order. Consecutive inline nodes are
@@ -527,6 +531,7 @@ private fun renderListItem(
                                 inlineCodeBg,
                                 linkColor,
                                 codeFontFamily,
+                                mathBg,
                                 onLinkClick,
                             ),
                         )
@@ -585,11 +590,11 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
                 .padding(vertical = Spacing.extraSmall)
                 .border(
                     width = 1.dp,
-                    color = AppComponents.codeBlockBorderColor(),
+                    color = AppColors.codeBlockBorderColor(),
                     shape = MaterialTheme.shapes.small,
                 )
                 .clip(MaterialTheme.shapes.small)
-                .background(AppComponents.codeBlockBackground()),
+                .background(AppColors.codeBlockBackground()),
         ) {
             codeViewerBlock(
                 code = code,
@@ -606,7 +611,7 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
                 CircularProgressIndicator(
                     modifier = Modifier.size(10.dp),
                     strokeWidth = 1.5.dp,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f),
+                    color = AppColors.tertiaryIconColor(),
                 )
                 Spacer(modifier = Modifier.width(5.dp))
                 Text(
@@ -640,8 +645,8 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     AppComponents.loadingSpinner(
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
-                        trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f),
+                        color = AppColors.tertiaryIconColor(),
+                        trackColor = AppColors.surfaceColor(AppColors.Elevation.RECESSED),
                     )
                     Spacer(modifier = Modifier.height(Spacing.small))
                     Text(
@@ -678,7 +683,7 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
     }
 
     // Render as regular code block
-    val backgroundColor = AppComponents.codeBlockBackground()
+    val backgroundColor = AppColors.codeBlockBackground()
     val clipboardManager = LocalClipboardManager.current
     val density = LocalDensity.current
     var isHovered by remember { mutableStateOf(false) }
@@ -711,7 +716,7 @@ private fun renderCodeBlock(codeBlock: FencedCodeBlock, viewportTopY: Float? = n
             .padding(vertical = Spacing.extraSmall)
             .border(
                 width = 1.dp,
-                color = AppComponents.codeBlockBorderColor(),
+                color = AppColors.codeBlockBorderColor(),
                 shape = codeBlockShape,
             )
             .clip(codeBlockShape)
@@ -832,7 +837,7 @@ private fun renderBlockQuote(
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = Spacing.medium, top = Spacing.extraSmall, bottom = Spacing.extraSmall)
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+            .background(AppColors.surfaceColor(AppColors.Elevation.RECESSED))
             .padding(Spacing.small),
     ) {
         renderNode(blockQuote, viewportTopY, isStreaming, onRunRequest, messageId, onLinkClick)
@@ -855,7 +860,7 @@ private fun imageDownloadButton(
             modifier = modifier
                 .clip(MaterialTheme.shapes.small)
                 .background(
-                    color = Color.Black.copy(alpha = 0.45f),
+                    color = AppColors.scrimColor(alpha = 0.45f),
                     shape = MaterialTheme.shapes.small,
                 )
                 .pointerHoverIcon(PointerIcon.Hand)
@@ -1010,7 +1015,7 @@ private fun renderVideo(videoUrl: String) {
                     modifier = Modifier
                         .size(64.dp)
                         .background(
-                            Color.Black.copy(alpha = 0.5f),
+                            AppColors.scrimColor(alpha = 0.5f),
                             shape = CircleShape,
                         )
                         .padding(Spacing.large),
@@ -1036,7 +1041,7 @@ private fun renderVideo(videoUrl: String) {
 
 @Composable
 private fun renderTable(table: TableBlock) {
-    val borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+    val borderColor = AppColors.codeBlockBorderColor()
 
     Column(
         modifier = Modifier
@@ -1057,7 +1062,7 @@ private fun renderTable(table: TableBlock) {
                                     .fillMaxWidth()
                                     .height(IntrinsicSize.Min)
                                     .background(
-                                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                                        AppColors.surfaceColor(AppColors.Elevation.RAISED),
                                     ),
                             ) {
                                 var cell = headerRow.firstChild
@@ -1150,6 +1155,7 @@ private fun buildInlineContent(
     inlineCodeBg: Color,
     linkColor: Color,
     codeFontFamily: FontFamily,
+    mathBg: Color,
     onLinkClick: ((url: String) -> Unit)? = null,
 ): AnnotatedString = buildAnnotatedString {
     var child = node.firstChild
@@ -1280,7 +1286,7 @@ private fun buildInlineContent(
                             SpanStyle(
                                 fontFamily = FontFamily.Serif,
                                 fontStyle = FontStyle.Italic,
-                                background = inlineCodeBg.copy(alpha = 0.2f),
+                                background = mathBg,
                             ),
                         ) {
                             append(" ")
@@ -1300,13 +1306,13 @@ private fun buildInlineContent(
 
             is StrongEmphasis -> {
                 withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                    append(buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, onLinkClick))
+                    append(buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, mathBg, onLinkClick))
                 }
             }
 
             is Emphasis -> {
                 withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
-                    append(buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, onLinkClick))
+                    append(buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, mathBg, onLinkClick))
                 }
             }
 
@@ -1336,7 +1342,7 @@ private fun buildInlineContent(
             is Link -> {
                 // Add link annotation for clickable links using the new LinkAnnotation API
                 // Build styled content for link children (e.g., inline code with backticks)
-                val linkContent = buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, onLinkClick)
+                val linkContent = buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, mathBg, onLinkClick)
                 val displayContent = linkContent.ifEmpty {
                     AnnotatedString(child.destination)
                 }
@@ -1394,9 +1400,9 @@ private fun buildInlineContent(
 
             is HardLineBreak, is SoftLineBreak -> append("\n")
 
-            is Paragraph -> append(buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, onLinkClick))
+            is Paragraph -> append(buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, mathBg, onLinkClick))
 
-            else -> append(buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, onLinkClick))
+            else -> append(buildInlineContent(child, inlineCodeBg, linkColor, codeFontFamily, mathBg, onLinkClick))
         }
         child = child.next
     }
@@ -1410,9 +1416,10 @@ private fun buildInlineContentForNode(
     inlineCodeBg: Color,
     linkColor: Color,
     codeFontFamily: FontFamily,
+    mathBg: Color,
     onLinkClick: ((url: String) -> Unit)? = null,
 ): AnnotatedString = buildAnnotatedString {
-    append(buildInlineContent(node, inlineCodeBg, linkColor, codeFontFamily, onLinkClick))
+    append(buildInlineContent(node, inlineCodeBg, linkColor, codeFontFamily, mathBg, onLinkClick))
 }
 
 /**

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/ui/MermaidChartRenderer.kt
@@ -73,6 +73,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -428,7 +429,7 @@ fun mermaidChart(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.35f)),
+                            .background(AppColors.scrimColor(alpha = 0.35f)),
                     )
                     // Compact overlay card — always centered, never clipped
                     ElevatedCard(
@@ -615,7 +616,7 @@ private fun mermaidSetupInstructions(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.35f)),
+                .background(AppColors.scrimColor(alpha = 0.35f)),
         )
 
         ElevatedCard(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/discover/DiscoverView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/discover/DiscoverView.kt
@@ -80,6 +80,7 @@ import io.askimo.core.user.domain.UserProfile
 import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.components.clickableCard
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -704,7 +705,7 @@ private fun tokenUsageChartCard(
                     }
                 }
                 tokenUsageSummaryStrip(totalTokens = totalTokens, totalCalls = totalCalls, topModel = topModelName)
-                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+                HorizontalDivider(color = AppColors.codeBlockBorderColor())
 
                 topModels.forEachIndexed { index, stat ->
                     val provider = stat.instanceKey
@@ -725,7 +726,7 @@ private fun tokenUsageChartCard(
 
                     if (index < topModels.lastIndex) {
                         HorizontalDivider(
-                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                            color = AppColors.codeBlockBorderColor(),
                         )
                     }
                 }
@@ -892,7 +893,7 @@ private fun exploreCard(
     clickableCard(
         onClick = { runCatching { Desktop.getDesktop().browse(URI(url)) } },
         modifier = modifier,
-        colors = AppComponents.surfaceVariantCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().fillMaxHeight().padding(Spacing.large),
@@ -904,7 +905,7 @@ private fun exploreCard(
                 verticalAlignment = Alignment.Top,
             ) {
                 icon()
-                Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))
+                Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null, modifier = Modifier.size(14.dp), tint = AppColors.tertiaryIconColor())
             }
             Text(text = title, style = AppTextStyles.itemTitle)
             Text(text = description, style = AppTextStyles.caption)
@@ -937,7 +938,7 @@ private fun recentSessionsSection(
                     sessions.forEachIndexed { index, session ->
                         recentSessionRow(session = session, onResumeSession = onResumeSession)
                         if (index < sessions.lastIndex) {
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                            HorizontalDivider(color = AppColors.codeBlockBorderColor())
                         }
                     }
                 }
@@ -960,7 +961,7 @@ private fun recentSessionRow(
             .hoverable(interactionSource)
             .background(
                 if (isHovered) {
-                    AppComponents.surfaceRaised()
+                    AppColors.surfaceColor(AppColors.Elevation.RAISED)
                 } else {
                     Color.Transparent
                 },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/AddMcpInstanceDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/AddMcpInstanceDialog.kt
@@ -58,6 +58,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -393,7 +394,7 @@ fun addMcpInstanceDialog(
                 placeholder = { Text(stringResource("mcp.instance.name.placeholder")) },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
             )
 
             OutlinedTextField(
@@ -404,7 +405,7 @@ fun addMcpInstanceDialog(
                 modifier = Modifier.fillMaxWidth(),
                 minLines = 2,
                 maxLines = 3,
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
             )
         },
         actions = {
@@ -606,7 +607,7 @@ fun addMcpInstanceDialog(
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 colors = CardDefaults.cardColors(
-                    containerColor = AppComponents.surfaceRaised(),
+                    containerColor = AppColors.surfaceColor(AppColors.Elevation.RAISED),
                 ),
             ) {
                 Column(
@@ -719,7 +720,7 @@ private fun templateParameterFields(
                 } else {
                     null
                 },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
             )
         }
     }
@@ -801,7 +802,7 @@ private fun advancedTransportFields(
                     supportingText = { Text(stringResource("mcp.instance.field.command.hint")) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
                 OutlinedTextField(
                     value = args,
@@ -811,7 +812,7 @@ private fun advancedTransportFields(
                     supportingText = { Text(stringResource("mcp.instance.field.args.hint")) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
                 OutlinedTextField(
                     value = workingDir,
@@ -821,7 +822,7 @@ private fun advancedTransportFields(
                     supportingText = { Text(stringResource("mcp.instance.field.workingdir.hint")) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
                 OutlinedTextField(
                     value = envVars, onValueChange = onEnvVarsChange,
@@ -829,7 +830,7 @@ private fun advancedTransportFields(
                     placeholder = { Text(stringResource("mcp.instance.env.placeholder")) },
                     supportingText = { Text(stringResource("mcp.instance.env.hint")) },
                     modifier = Modifier.fillMaxWidth(), minLines = 3, maxLines = 5,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
             }
         }
@@ -844,7 +845,7 @@ private fun advancedTransportFields(
                     supportingText = { Text(stringResource("mcp.instance.http.url.hint")) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
                 OutlinedTextField(
                     value = headers, onValueChange = onHeadersChange,
@@ -852,7 +853,7 @@ private fun advancedTransportFields(
                     placeholder = { Text(stringResource("mcp.instance.http.headers.placeholder")) },
                     supportingText = { Text(stringResource("mcp.instance.http.headers.hint")) },
                     modifier = Modifier.fillMaxWidth(), minLines = 3, maxLines = 5,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
                 OutlinedTextField(
                     value = timeoutMs,
@@ -862,7 +863,7 @@ private fun advancedTransportFields(
                     supportingText = { Text(stringResource("mcp.instance.http.timeout.hint")) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
             }
         }
@@ -884,7 +885,7 @@ private fun advancedTransportFields(
                     )
                 },
                 modifier = Modifier.fillMaxWidth(),
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
             )
             // Transparent click interceptor — captures the click before the read-only TextField does
             Box(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpServerCatalogDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpServerCatalogDialog.kt
@@ -42,6 +42,7 @@ import io.askimo.core.mcp.McpServerTemplateRegistry
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -102,7 +103,7 @@ fun mcpServerCatalogDialog(
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null, modifier = Modifier.size(18.dp)) },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
             )
 
             FlowRow(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpToolsDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/mcp/McpToolsDialog.kt
@@ -68,6 +68,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -153,7 +154,7 @@ fun mcpToolsDialog(
                     placeholder = { Text(stringResource("mcp.tools.dialog.search.placeholder")) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
             }
         },
@@ -189,7 +190,7 @@ fun mcpToolsDialog(
         // ── Instance info card ─────────────────────────────────────────────
         Card(
             modifier = Modifier.fillMaxWidth(),
-            colors = AppComponents.bannerCardColors(),
+            colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
         ) {
             Column(
                 modifier = Modifier
@@ -203,7 +204,7 @@ fun mcpToolsDialog(
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
                 HorizontalDivider(
-                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f),
+                    color = AppColors.tertiaryIconColor(),
                 )
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -212,7 +213,7 @@ fun mcpToolsDialog(
                     Text(
                         text = stringResource("mcp.instance.field.serverId"),
                         style = AppTextStyles.caption,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                        color = AppColors.secondaryIconColor(),
                     )
                     SelectionContainer {
                         Text(
@@ -226,7 +227,7 @@ fun mcpToolsDialog(
                     Text(
                         text = stringResource("mcp.tools.dialog.parameters"),
                         style = AppTextStyles.caption,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                        color = AppColors.secondaryIconColor(),
                         modifier = Modifier.padding(top = Spacing.extraSmall),
                     )
                     instance.parameterValues.forEach { (key, value) ->
@@ -243,7 +244,7 @@ fun mcpToolsDialog(
                                 Text(
                                     text = key,
                                     style = AppTextStyles.caption,
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
+                                    color = AppColors.tertiaryIconColor(),
                                 )
                             }
                             Row(
@@ -287,7 +288,7 @@ fun mcpToolsDialog(
                                                 if (showSecret) "mcp.instance.password.hide" else "mcp.instance.password.show",
                                             ),
                                             modifier = Modifier.size(14.dp),
-                                            tint = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.6f),
+                                            tint = AppColors.tertiaryIconColor(),
                                         )
                                     }
                                 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/onboarding/OnboardingWizardDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/onboarding/OnboardingWizardDialog.kt
@@ -61,6 +61,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -288,7 +289,7 @@ private fun onboardingStepLanguage(
 
         Card(
             modifier = Modifier.fillMaxWidth(),
-            colors = AppComponents.bannerCardColors(),
+            colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
         ) {
             Column(
                 modifier = Modifier
@@ -442,7 +443,7 @@ private fun onboardingStepProfile(
                 placeholder = {
                     Text(
                         stringResource("onboarding.step.profile.name.placeholder"),
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                        color = AppColors.tertiaryIconColor(),
                     )
                 },
                 singleLine = true,
@@ -462,7 +463,7 @@ private fun onboardingStepProfile(
                 placeholder = {
                     Text(
                         stringResource("onboarding.step.profile.occupation.placeholder"),
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                        color = AppColors.tertiaryIconColor(),
                     )
                 },
                 singleLine = true,
@@ -601,9 +602,9 @@ private fun personaCard(
             ),
         colors = CardDefaults.cardColors(
             containerColor = if (highlighted) {
-                AppComponents.surfaceSelected()
+                AppColors.surfaceColor(AppColors.Elevation.SELECTED)
             } else {
-                AppComponents.surfaceRaised()
+                AppColors.surfaceColor(AppColors.Elevation.RAISED)
             },
         ),
     ) {
@@ -695,7 +696,7 @@ private fun onboardingStepAnalytics(
         Card(
             modifier = Modifier.fillMaxWidth(),
             colors = CardDefaults.cardColors(
-                containerColor = AppComponents.surfaceRaised(),
+                containerColor = AppColors.surfaceColor(AppColors.Elevation.RAISED),
             ),
         ) {
             Column(modifier = Modifier.fillMaxWidth().padding(Spacing.large)) {
@@ -742,9 +743,9 @@ private fun onboardingStepAnalytics(
             modifier = Modifier.fillMaxWidth(),
             colors = CardDefaults.cardColors(
                 containerColor = if (analyticsAccepted) {
-                    AppComponents.surfaceSelected()
+                    AppColors.surfaceColor(AppColors.Elevation.SELECTED)
                 } else {
-                    AppComponents.surfaceRaised()
+                    AppColors.surfaceColor(AppColors.Elevation.RAISED)
                 },
             ),
         ) {
@@ -833,7 +834,7 @@ private fun onboardingStepReady() {
 
         Card(
             modifier = Modifier.fillMaxWidth(),
-            colors = AppComponents.bannerCardColors(),
+            colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
         ) {
             Column(
                 modifier = Modifier
@@ -868,7 +869,7 @@ private fun onboardingStepReady() {
 private fun onboardingFeatureCard(title: String, description: String) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -894,7 +895,7 @@ private fun onboardingDocLink(label: String, url: String) {
     TextButton(
         onClick = { uriHandler.openUri(url) },
         modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-        colors = AppComponents.primaryTextButtonColors(),
+        colors = AppColors.primaryTextButtonColors(),
     ) {
         Text(
             text = label,
@@ -910,7 +911,7 @@ private fun onboardingLinkItem(title: String, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .pointerHoverIcon(PointerIcon.Hand),
-        colors = AppComponents.primaryTextButtonColors(),
+        colors = AppColors.primaryTextButtonColors(),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanDetailView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanDetailView.kt
@@ -79,6 +79,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -239,7 +240,7 @@ fun planDetailView(
                 }
             }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f))
+            HorizontalDivider(color = AppColors.codeBlockBorderColor())
 
             // ── Scrollable body ───────────────────────────────────────────────
             Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
@@ -264,7 +265,7 @@ fun planDetailView(
                         Spacer(modifier = Modifier.height(Spacing.small))
                         Surface(
                             modifier = Modifier.fillMaxWidth(),
-                            color = AppComponents.surfaceRaised(),
+                            color = AppColors.surfaceColor(AppColors.Elevation.RAISED),
                             shape = MaterialTheme.shapes.medium,
                         ) {
                             Column {
@@ -298,7 +299,7 @@ fun planDetailView(
                                     }
                                 }
                                 if (stepsExpanded) {
-                                    HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f))
+                                    HorizontalDivider(color = AppColors.codeBlockBorderColor())
                                     Column(
                                         modifier = Modifier.padding(Spacing.large),
                                         verticalArrangement = Arrangement.spacedBy(Spacing.medium),
@@ -340,7 +341,7 @@ fun planDetailView(
                                             }
                                             if (index < plan.steps.size - 1) {
                                                 HorizontalDivider(
-                                                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.1f),
+                                                    color = AppColors.codeBlockBorderColor(),
                                                 )
                                             }
                                         }
@@ -607,7 +608,7 @@ private fun agenticStepProgressPanel(
                 if (index > 0) {
                     HorizontalDivider(
                         modifier = Modifier.padding(vertical = Spacing.small),
-                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.12f),
+                        color = AppColors.codeBlockBorderColor(),
                     )
                 }
                 agenticStepRow(
@@ -771,7 +772,7 @@ private fun agenticStepRow(
                             Icon(
                                 imageVector = if (outputExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
                                 contentDescription = if (outputExpanded) "Collapse" else "Expand",
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                tint = AppColors.secondaryIconColor(),
                                 modifier = Modifier.size(14.dp),
                             )
                         }
@@ -925,7 +926,7 @@ private fun interactiveQuestionPanel(
 ) {
     Surface(
         modifier = modifier,
-        color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.6f),
+        color = MaterialTheme.colorScheme.tertiaryContainer,
         shape = MaterialTheme.shapes.medium,
     ) {
         Column(modifier = Modifier.padding(Spacing.large)) {
@@ -966,7 +967,7 @@ private fun interactiveQuestionPanel(
                 Text(
                     text = stringResource("plans.interactive.skip"),
                     style = AppTextStyles.hint,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
+                    color = AppColors.cardSecondaryContentColor(MaterialTheme.colorScheme.onTertiaryContainer),
                 )
             }
         }
@@ -986,7 +987,7 @@ private fun followUpPanel(
 
     Surface(
         modifier = modifier,
-        color = AppComponents.surfaceEmphasis(),
+        color = AppColors.surfaceColor(AppColors.Elevation.EMPHASIS),
         shape = MaterialTheme.shapes.medium,
     ) {
         Column(modifier = Modifier.padding(Spacing.large)) {
@@ -1069,7 +1070,7 @@ private fun resultPanel(
                     Icon(
                         if (isPinned) Icons.Default.PushPin else Icons.Default.CheckCircle,
                         contentDescription = null,
-                        tint = if (isPinned) MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f) else MaterialTheme.colorScheme.onSurface,
+                        tint = if (isPinned) AppColors.secondaryIconColor() else MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.size(18.dp),
                     )
                     Text(
@@ -1284,7 +1285,7 @@ private fun planInputField(
                     modifier = Modifier.fillMaxWidth(),
                     minLines = 3,
                     maxLines = 8,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
             }
 
@@ -1303,7 +1304,7 @@ private fun planInputField(
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
             }
 
@@ -1321,7 +1322,7 @@ private fun planInputField(
                     supportingText = error?.let { { Text(it) } },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
             }
         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanHistorySidePanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanHistorySidePanel.kt
@@ -61,6 +61,7 @@ import io.askimo.core.plan.domain.PlanExecutionStatus
 import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -95,7 +96,7 @@ fun planHistorySidePanel(
         modifier = modifier.width(animatedWidth).fillMaxHeight(),
         shape = RectangleShape,
         colors = CardDefaults.cardColors(
-            containerColor = AppComponents.sidebarSurfaceColor(),
+            containerColor = AppColors.sidebarSurfaceColor(),
             contentColor = MaterialTheme.colorScheme.onSurface,
         ),
     ) {
@@ -157,7 +158,7 @@ fun planHistorySidePanel(
                                 Box(
                                     modifier = Modifier
                                         .background(
-                                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f),
+                                            AppColors.surfaceColor(AppColors.Elevation.RECESSED),
                                             shape = MaterialTheme.shapes.extraSmall,
                                         )
                                         .padding(horizontal = 6.dp, vertical = 1.dp),
@@ -235,7 +236,7 @@ fun planHistorySidePanel(
                 modifier = Modifier
                     .width(56.dp)
                     .fillMaxHeight()
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                    .background(AppColors.surfaceColor(AppColors.Elevation.RECESSED))
                     .padding(vertical = Spacing.large, horizontal = Spacing.small),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(Spacing.large),
@@ -323,7 +324,7 @@ private fun planHistoryItem(
                         PlanExecutionStatus.COMPLETED -> Color(0xFF4CAF50)
                         PlanExecutionStatus.FAILED -> MaterialTheme.colorScheme.error
                         PlanExecutionStatus.RUNNING -> MaterialTheme.colorScheme.outline
-                        else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                        else -> AppColors.tertiaryIconColor()
                     }
                     Box(
                         modifier = Modifier
@@ -341,14 +342,14 @@ private fun planHistoryItem(
                             text = TimeUtil.formatDisplay(execution.createdAt),
                             style = AppTextStyles.hint,
 
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                            color = AppColors.secondaryIconColor(),
                         )
                         if (execution.runCount > 1) {
                             Text(
                                 text = "×${execution.runCount} runs",
                                 style = AppTextStyles.hint,
 
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                color = AppColors.secondaryIconColor(),
                             )
                         }
 
@@ -361,7 +362,7 @@ private fun planHistoryItem(
                                         text = "$key: $preview",
                                         style = AppTextStyles.hint,
 
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                                        color = AppColors.tertiaryIconColor(),
                                         maxLines = 1,
                                     )
                                 }
@@ -380,7 +381,7 @@ private fun planHistoryItem(
                                     Icon(
                                         Icons.Default.PushPin,
                                         contentDescription = stringResource(if (isPinned) "plans.result.unpin" else "plans.result.pin"),
-                                        tint = if (isPinned) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                        tint = if (isPinned) MaterialTheme.colorScheme.onSurface else AppColors.tertiaryIconColor(),
                                         modifier = Modifier.size(14.dp),
                                     )
                                 }
@@ -393,7 +394,7 @@ private fun planHistoryItem(
                             Icon(
                                 Icons.Default.Delete,
                                 contentDescription = stringResource("action.delete"),
-                                tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
+                                tint = AppColors.destructiveIconColor(),
                                 modifier = Modifier.size(16.dp),
                             )
                         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanInputField.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlanInputField.kt
@@ -40,7 +40,7 @@ import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ReasoningEffort
 import io.askimo.ui.common.components.actionInputField
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -187,7 +187,7 @@ fun planInputField(
                                     text = stringResource("chat.reasoning.effort.label") + ":",
                                     style = AppTextStyles.hint,
 
-                                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                                    color = AppColors.secondaryIconColor(),
                                 )
                                 Text(
                                     text = reasoningEffort.value.replaceFirstChar { it.uppercase() },
@@ -237,7 +237,7 @@ fun planInputField(
                                         showReasoningDropdown = false
                                     },
                                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                                    colors = AppComponents.menuItemColors(),
+                                    colors = AppColors.menuItemColors(),
                                 )
                             }
                         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansGalleryView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/plan/PlansGalleryView.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.AppConstants.DOMAIN
 import io.askimo.core.plan.domain.PlanDef
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.clickableCard
 import io.askimo.ui.common.theme.AppTextStyles
@@ -176,7 +177,7 @@ fun plansGalleryView(
                             modifier = Modifier.weight(1f),
                         )
                     }
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.2f))
+                    HorizontalDivider(color = AppColors.codeBlockBorderColor())
                 }
 
                 Spacer(modifier = Modifier.height(Spacing.large))
@@ -295,7 +296,7 @@ private fun planTab(
     val textColor = if (selected) {
         MaterialTheme.colorScheme.onBackground
     } else {
-        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+        AppColors.secondaryIconColor()
     }
     Column(
         modifier = modifier
@@ -422,7 +423,7 @@ private fun planCard(
                                         showMenu = false
                                         onDuplicate()
                                     },
-                                    colors = AppComponents.menuItemColors(),
+                                    colors = AppColors.menuItemColors(),
                                 )
                             }
                             if (onEdit != null) {
@@ -435,7 +436,7 @@ private fun planCard(
                                         showMenu = false
                                         onEdit()
                                     },
-                                    colors = AppComponents.menuItemColors(),
+                                    colors = AppColors.menuItemColors(),
                                 )
                             }
                             if (onDelete != null) {
@@ -448,7 +449,7 @@ private fun planCard(
                                         showMenu = false
                                         onDelete()
                                     },
-                                    colors = AppComponents.menuItemColors(),
+                                    colors = AppColors.menuItemColors(),
                                 )
                             }
                         }
@@ -489,7 +490,7 @@ private fun planCard(
                     tint = if (isHovered) {
                         MaterialTheme.colorScheme.onSurface
                     } else {
-                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                        AppColors.tertiaryIconColor()
                     },
                     modifier = Modifier.size(20.dp),
                 )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/EditDirectiveDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/EditDirectiveDialog.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.window.DialogProperties
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 
@@ -79,7 +79,7 @@ fun editDirectiveDialog(
                     singleLine = true,
                     isError = nameError != null,
                     supportingText = nameError?.let { { Text(it) } },
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 OutlinedTextField(
@@ -96,7 +96,7 @@ fun editDirectiveDialog(
                     maxLines = 8,
                     isError = contentError != null,
                     supportingText = contentError?.let { { Text(it) } },
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 Row(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ExportSessionDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ExportSessionDialog.kt
@@ -51,6 +51,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.export.ExportFormat
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -189,7 +190,7 @@ fun exportSessionDialog(
                 label = { Text(stringResource("session.export.file.path")) },
                 modifier = Modifier.weight(1f),
                 singleLine = true,
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
             )
             IconButton(
                 onClick = { showFileBrowser = true },
@@ -225,7 +226,7 @@ private fun formatCard(
     val borderColor = if (isSelected) {
         MaterialTheme.colorScheme.primary
     } else {
-        MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+        AppColors.codeBlockBorderColor()
     }
 
     TooltipBox(
@@ -291,7 +292,7 @@ private fun formatCard(
                     Text(
                         text = ".${format.extension}",
                         style = AppTextStyles.hint,
-                        color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f) else Color.Unspecified,
+                        color = if (isSelected) AppColors.contentColorFor(AppColors.Elevation.SELECTED) else Color.Unspecified,
                     )
                 }
 
@@ -299,7 +300,7 @@ private fun formatCard(
                 Text(
                     text = format.getDescription(),
                     style = AppTextStyles.caption,
-                    color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f) else Color.Unspecified,
+                    color = if (isSelected) AppColors.contentColorFor(AppColors.Elevation.SELECTED) else Color.Unspecified,
                 )
             }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/ManageDirectivesDialog.kt
@@ -55,6 +55,7 @@ import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -139,7 +140,7 @@ fun manageDirectivesDialog(
                     Card(
                         modifier = Modifier.fillMaxWidth(),
                         colors = CardDefaults.cardColors(
-                            containerColor = AppComponents.sidebarSurfaceColor(),
+                            containerColor = AppColors.sidebarSurfaceColor(),
                         ),
                     ) {
                         Column(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/NewDirectiveDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/NewDirectiveDialog.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.window.DialogProperties
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 
@@ -91,7 +91,7 @@ fun newDirectiveDialog(
                     singleLine = true,
                     isError = nameError != null,
                     supportingText = nameError?.let { { Text(it) } },
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 // Content field
@@ -109,7 +109,7 @@ fun newDirectiveDialog(
                     maxLines = 8,
                     isError = contentError != null,
                     supportingText = contentError?.let { { Text(it) } },
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 // Apply to current session checkbox

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/RenameSessionDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/RenameSessionDialog.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 
@@ -89,7 +90,7 @@ fun renameSessionDialog(
                 singleLine = true,
                 isError = error != null,
                 supportingText = error?.let { { Text(it, color = MaterialTheme.colorScheme.error) } },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(onDone = { performRename() }),
             )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionMemoryDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionMemoryDialog.kt
@@ -43,6 +43,7 @@ import io.askimo.core.util.JsonUtils
 import io.askimo.core.util.JsonUtils.prettyJson
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -92,7 +93,7 @@ fun sessionMemoryDialog(
             if (isLoading) {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.surfaceVariantCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Text(
                         text = stringResource("developer.session.memory.loading"),
@@ -103,7 +104,7 @@ fun sessionMemoryDialog(
             } else if (sessionMemory == null) {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.surfaceVariantCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Text(
                         text = stringResource("developer.session.memory.not.found"),
@@ -141,7 +142,7 @@ fun sessionMemoryDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .heightIn(max = 200.dp),
-                        colors = AppComponents.surfaceVariantCardColors(),
+                        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                     ) {
                         Box(
                             modifier = Modifier.fillMaxWidth(),
@@ -265,7 +266,7 @@ fun sessionMemoryDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(300.dp),
-                        colors = AppComponents.surfaceVariantCardColors(),
+                        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                     ) {
                         Box(
                             modifier = Modifier.fillMaxWidth(),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionTooltip.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionTooltip.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -19,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.chat.domain.ChatSession
 import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.ui.TooltipPlacement
@@ -70,7 +70,7 @@ private fun sessionTooltipContent(session: ChatSession) {
         )
 
         HorizontalDivider(
-            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+            color = AppColors.codeBlockBorderColor(),
         )
 
         // Started

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/session/SessionsView.kt
@@ -65,6 +65,7 @@ import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.components.tablePageSizeSelector
 import io.askimo.ui.common.components.tablePagination
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
@@ -155,7 +156,7 @@ fun sessionsView(
                     singleLine = true,
                     textStyle = AppTextStyles.body,
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 Spacer(modifier = Modifier.height(Spacing.large))
@@ -327,7 +328,7 @@ private fun sessionTable(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(AppComponents.surfaceRaised())
+                    .background(AppColors.surfaceColor(AppColors.Elevation.RAISED))
                     .padding(horizontal = 16.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -373,7 +374,7 @@ private fun sessionTable(
                     onStarSession = onStarSession,
                 )
                 if (index < sortedSessions.lastIndex) {
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    HorizontalDivider(color = AppColors.codeBlockBorderColor())
                 }
             }
         }
@@ -443,7 +444,7 @@ private fun sessionRow(
             .hoverable(interactionSource)
             .background(
                 if (isHovered) {
-                    AppComponents.surfaceRaised()
+                    AppColors.surfaceColor(AppColors.Elevation.RAISED)
                 } else {
                     MaterialTheme.colorScheme.surface
                 },
@@ -467,7 +468,7 @@ private fun sessionRow(
                 tint = if (session.isStarred) {
                     MaterialTheme.colorScheme.onSurface
                 } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                    AppColors.tertiaryIconColor()
                 },
                 modifier = Modifier.size(16.dp),
             )

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AgentsSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AgentsSettingsSection.kt
@@ -94,10 +94,12 @@ import io.askimo.core.agent.domain.SkillTreeNode
 import io.askimo.core.agent.repository.SkillRepository
 import io.askimo.core.util.AskimoHome
 import io.askimo.ui.common.components.dangerButton
+import io.askimo.ui.common.components.inlineErrorMessage
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.appOutlinedTextField
 import io.askimo.ui.common.theme.AppTextStyles
@@ -193,7 +195,7 @@ fun agentsSettingsSection() {
             modifier = Modifier.width(animatedPanelWidth).fillMaxHeight(),
             shape = RectangleShape,
             colors = CardDefaults.cardColors(
-                containerColor = AppComponents.sidebarSurfaceColor(),
+                containerColor = AppColors.sidebarSurfaceColor(),
                 contentColor = MaterialTheme.colorScheme.onSurface,
             ),
         ) {
@@ -268,7 +270,7 @@ fun agentsSettingsSection() {
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(AppComponents.surfaceRecessed())
+                        .background(AppColors.surfaceColor(AppColors.Elevation.RECESSED))
                         .padding(vertical = 12.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Top,
@@ -466,7 +468,7 @@ private fun skillsMainContent(
                             runtimes.forEach { runtime ->
                                 Surface(
                                     shape = MaterialTheme.shapes.small,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
+                                    color = AppColors.surfaceColor(AppColors.Elevation.RECESSED),
                                 ) {
                                     Text(
                                         text = runtime,
@@ -576,7 +578,7 @@ private fun skillsMainSelectPrompt() {
                 Icons.Default.Extension,
                 contentDescription = null,
                 modifier = Modifier.size(56.dp),
-                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
+                tint = AppColors.tertiaryIconColor(),
             )
             Text(
                 text = stringResource("settings.agents.select.prompt"),
@@ -602,7 +604,7 @@ private fun skillsMainEmptyState() {
                 Icons.Default.Extension,
                 contentDescription = null,
                 modifier = Modifier.size(56.dp),
-                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
+                tint = AppColors.tertiaryIconColor(),
             )
             Text(
                 text = stringResource("settings.agents.empty"),
@@ -710,7 +712,7 @@ private fun skillEditorContent(
                             onValueChange = { nameInput = it },
                             singleLine = true,
                             textStyle = AppTextStyles.sectionTitle,
-                            colors = AppComponents.outlinedTextFieldColors(),
+                            colors = AppColors.outlinedTextFieldColors(),
                             modifier = Modifier.weight(1f),
                         )
                         IconButton(
@@ -757,7 +759,7 @@ private fun skillEditorContent(
                             onValueChange = { descInput = it },
                             singleLine = true,
                             textStyle = AppTextStyles.caption,
-                            colors = AppComponents.outlinedTextFieldColors(),
+                            colors = AppColors.outlinedTextFieldColors(),
                             modifier = Modifier.weight(1f),
                         )
                         IconButton(
@@ -940,7 +942,7 @@ private fun fileEditorContent(
                         onValueChange = { renameInput = it },
                         singleLine = true,
                         textStyle = AppTextStyles.sectionTitle,
-                        colors = AppComponents.outlinedTextFieldColors(),
+                        colors = AppColors.outlinedTextFieldColors(),
                         modifier = Modifier.weight(1f),
                     )
                     // OK button — commit rename
@@ -1273,7 +1275,7 @@ private fun skillTreeNodeItem(
                         .fillMaxWidth()
                         .clip(MaterialTheme.shapes.small)
                         .background(
-                            if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f) else Color.Transparent,
+                            if (isSelected) AppColors.surfaceColor(AppColors.Elevation.SELECTED) else Color.Transparent,
                             shape = MaterialTheme.shapes.small,
                         )
                         .hoverable(interactionSource)
@@ -1412,7 +1414,7 @@ private fun skillTreeNodeItem(
                     .fillMaxWidth()
                     .padding(start = (depth * 12).dp)
                     .background(
-                        if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f) else Color.Transparent,
+                        if (isSelected) AppColors.surfaceColor(AppColors.Elevation.SELECTED) else Color.Transparent,
                         shape = MaterialTheme.shapes.small,
                     )
                     .hoverable(interactionSource)
@@ -1565,7 +1567,7 @@ private fun previewEditSegmentButton(
                 if (isActive) {
                     MaterialTheme.colorScheme.primaryContainer
                 } else {
-                    AppComponents.surfaceRaised()
+                    AppColors.surfaceColor(AppColors.Elevation.RAISED)
                 },
             )
             .then(
@@ -1603,22 +1605,6 @@ private fun openSkillsFolder(path: Path) {
 }
 
 // ── Dialogs ───────────────────────────────────────────────────────────────────
-
-@Composable
-private fun importErrorBanner(message: String) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.6f),
-        shape = MaterialTheme.shapes.small,
-    ) {
-        Text(
-            text = message,
-            style = AppTextStyles.caption,
-            color = MaterialTheme.colorScheme.onErrorContainer,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-        )
-    }
-}
 
 @Composable
 private fun newSkillInFolderDialog(
@@ -1693,9 +1679,7 @@ private fun importFromGitHubDialog(
                     enabled = !isImporting,
                 )
 
-                if (errorMessage != null) {
-                    importErrorBanner(errorMessage!!)
-                }
+                inlineErrorMessage(errorMessage)
             }
         },
         confirmButton = {
@@ -1782,9 +1766,7 @@ private fun importFromZipDialog(
                     )
                 }
 
-                if (errorMessage != null) {
-                    importErrorBanner(errorMessage!!)
-                }
+                inlineErrorMessage(errorMessage)
             }
         },
         confirmButton = {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AppearanceSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AppearanceSettingsSection.kt
@@ -83,6 +83,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.AccountPreferences
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.BackgroundImage
@@ -434,7 +435,7 @@ private fun accentColorSection() {
                             )
                         }
                     },
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 secondaryButton(
@@ -565,7 +566,7 @@ private fun accentPresetTile(
             .width(92.dp)
             .heightIn(min = 72.dp)
             .pointerHoverIcon(PointerIcon.Hand),
-        colors = if (selected) AppComponents.primaryCardColors() else AppComponents.surfaceVariantCardColors(),
+        colors = if (selected) AppColors.cardColors(AppColors.Elevation.ACCENT) else AppColors.cardColors(AppColors.Elevation.RAISED),
         shape = RoundedCornerShape(12.dp),
     ) {
         Column(
@@ -595,7 +596,7 @@ private fun accentPresetTile(
                 Text(
                     text = preset.hex,
                     style = AppTextStyles.hint,
-                    color = if (selected) selectedTextColor.copy(alpha = 0.82f) else AppTextStyles.secondaryContent,
+                    color = if (selected) AppColors.secondaryContentColorFor(AppColors.Elevation.ACCENT) else AppTextStyles.secondaryContent,
                 )
             }
         }
@@ -637,9 +638,9 @@ private fun themeOption(
             .fillMaxWidth()
             .clickableCard(onClick = onClick),
         colors = if (selected) {
-            AppComponents.primaryCardColors()
+            AppColors.cardColors(AppColors.Elevation.ACCENT)
         } else {
-            AppComponents.surfaceVariantCardColors()
+            AppColors.cardColors(AppColors.Elevation.RAISED)
         },
     ) {
         Row(
@@ -740,7 +741,7 @@ private fun avatarSetting(
     val scope = rememberCoroutineScope()
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.surfaceVariantCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Row(
             modifier = Modifier
@@ -874,7 +875,7 @@ private fun backgroundImageOption(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.45f)),
+                        .background(AppColors.imageThumbnailScrimColor()),
                 )
             } else {
                 // "None" — plain surface tile
@@ -983,7 +984,7 @@ private fun backgroundImageCustomOption(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.45f)),
+                        .background(AppColors.imageThumbnailScrimColor()),
                 )
             } else {
                 // No custom image yet — show a dashed/placeholder tile
@@ -1255,7 +1256,7 @@ private fun languageSelectionCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -1460,7 +1461,7 @@ private fun fontSettingsCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(Spacing.large),

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/ShortcutsSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/ShortcutsSettingsSection.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -148,7 +149,7 @@ fun shortcutsSettingsSection() {
                 filteredByCategory.forEach { (category, shortcuts) ->
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = AppComponents.bannerCardColors(),
+                        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                     ) {
                         Column(
                             modifier = Modifier
@@ -168,7 +169,7 @@ fun shortcutsSettingsSection() {
                                     modifier = Modifier.weight(1f),
                                 )
                                 Card(
-                                    colors = AppComponents.surfaceVariantCardColors(),
+                                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                                     shape = RoundedCornerShape(12.dp),
                                 ) {
                                     Text(
@@ -212,7 +213,7 @@ private fun shortcutRow(description: String, keyBinding: String) {
     val rowInteractionSource = remember { MutableInteractionSource() }
     val isHovered by rowInteractionSource.collectIsHoveredAsState()
     val rowBgColor by animateColorAsState(
-        targetValue = if (isHovered) MaterialTheme.colorScheme.onSurface.copy(alpha = 0.04f) else Color.Transparent,
+        targetValue = if (isHovered) AppColors.surfaceColor(AppColors.Elevation.RECESSED) else Color.Transparent,
         label = "shortcutRowHover",
     )
 
@@ -272,7 +273,7 @@ private fun shortcutRow(description: String, keyBinding: String) {
 @Composable
 private fun keyChip(key: String) {
     Card(
-        colors = AppComponents.surfaceVariantCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
         shape = RoundedCornerShape(4.dp),
     ) {
         Text(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/EventLogPanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/EventLogPanel.kt
@@ -28,7 +28,6 @@ import androidx.compose.material.icons.filled.HorizontalSplit
 import androidx.compose.material.icons.filled.VerticalSplit
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -55,6 +54,7 @@ import androidx.compose.ui.unit.dp
 import io.askimo.core.event.Event
 import io.askimo.core.util.TimeUtil
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -139,9 +139,9 @@ private fun resizeHandle(
             )
             .background(
                 if (isHovering) {
-                    MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+                    AppColors.resizeHandleHoverColor()
                 } else {
-                    MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+                    AppColors.codeBlockBorderColor()
                 },
             )
             .pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(cursor)))
@@ -315,7 +315,7 @@ private fun eventLogPanelContent(
                             },
                         )
                     }
-                    DropdownMenu(
+                    AppComponents.dropdownMenu(
                         expanded = showDockMenu,
                         onDismissRequest = { showDockMenu = false },
                     ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/GlobalSearchDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/GlobalSearchDialog.kt
@@ -59,6 +59,7 @@ import io.askimo.core.search.SortBy
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -188,7 +189,7 @@ fun globalSearchDialog(
                         }
                     },
                 singleLine = true,
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
             )
 
             // Filters Row
@@ -306,7 +307,7 @@ fun globalSearchDialog(
                     ) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             AppComponents.loadingSpinner(
-                                trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f),
+                                trackColor = AppColors.surfaceColor(AppColors.Elevation.RECESSED),
                             )
                             Spacer(modifier = Modifier.height(Spacing.large))
                             Text(
@@ -327,7 +328,7 @@ fun globalSearchDialog(
                                 imageVector = Icons.Default.Search,
                                 contentDescription = null,
                                 modifier = Modifier.size(48.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                tint = AppColors.tertiaryIconColor(),
                             )
                             Spacer(modifier = Modifier.height(Spacing.large))
                             Text(
@@ -373,7 +374,7 @@ fun globalSearchDialog(
                                 imageVector = Icons.Default.Search,
                                 contentDescription = null,
                                 modifier = Modifier.size(48.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                tint = AppColors.tertiaryIconColor(),
                             )
                             Spacer(modifier = Modifier.height(Spacing.large))
                             Text(
@@ -434,7 +435,7 @@ private fun searchResultItem(
             .fillMaxWidth()
             .pointerHoverIcon(PointerIcon.Hand),
         colors = CardDefaults.cardColors(
-            containerColor = AppComponents.surfaceRaised(),
+            containerColor = AppColors.surfaceColor(AppColors.Elevation.RAISED),
         ),
     ) {
         Column(

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/LogViewerDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/LogViewerDialog.kt
@@ -47,6 +47,7 @@ import io.askimo.core.logging.currentFileLogger
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import kotlinx.coroutines.Dispatchers
@@ -108,7 +109,7 @@ fun logViewerDialog(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f))
+                    .background(AppColors.scrimColor(alpha = 0.32f))
                     .pointerInput(Unit) {
                         detectTapGestures { onDismiss() }
                     },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
@@ -77,6 +77,7 @@ import io.askimo.core.event.internal.ProjectsRefreshEvent
 import io.askimo.core.event.internal.SessionsRefreshEvent
 import io.askimo.core.user.domain.UserProfile
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
@@ -275,18 +276,18 @@ private fun expandedNavigationSidebar(
         modifier = Modifier
             .width(animatedWidth)
             .fillMaxHeight()
-            .background(AppComponents.sidebarSurfaceColor()),
+            .background(AppColors.sidebarSurfaceColor()),
     ) {
         // Header with logo and collapse button
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(AppComponents.sidebarHeaderColor())
+                .background(AppColors.sidebarHeaderColor())
                 .padding(Spacing.large),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            sidebarLogoRow(fontScale = fontScale, contentColor = AppComponents.sidebarHeaderContentColor())
+            sidebarLogoRow(fontScale = fontScale, contentColor = AppColors.sidebarHeaderContentColor())
             themedTooltip(text = stringResource("sidebar.collapse")) {
                 IconButton(
                     onClick = onToggleExpand,
@@ -295,7 +296,7 @@ private fun expandedNavigationSidebar(
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.MenuOpen,
                         contentDescription = stringResource("sidebar.collapse"),
-                        tint = AppComponents.sidebarHeaderContentColor(),
+                        tint = AppColors.sidebarHeaderContentColor(),
                     )
                 }
             }
@@ -320,7 +321,7 @@ private fun expandedNavigationSidebar(
                         .padding(horizontal = Spacing.small)
                         .pointerHoverIcon(PointerIcon.Hand),
                     shape = AppComponents.navigationItemShape,
-                    colors = AppComponents.navigationDrawerItemColors(),
+                    colors = AppColors.navigationDrawerItemColors(),
                 )
             }
 
@@ -350,7 +351,7 @@ private fun expandedNavigationSidebar(
             // Visual separator between pinned and sessions zones
             HorizontalDivider(
                 modifier = Modifier.padding(horizontal = Spacing.small, vertical = Spacing.extraSmall),
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                color = AppColors.codeBlockBorderColor(),
             )
 
             // Sessions header (collapsible)
@@ -401,7 +402,7 @@ private fun expandedNavigationSidebar(
                     .padding(horizontal = Spacing.small, vertical = Spacing.extraSmall)
                     .pointerHoverIcon(PointerIcon.Hand),
                 shape = AppComponents.navigationItemShape,
-                colors = AppComponents.navigationDrawerItemColors(),
+                colors = AppColors.navigationDrawerItemColors(),
             )
 
             if (isSessionsExpanded) {
@@ -454,7 +455,7 @@ private fun collapsedNavigationSidebar(
         modifier = Modifier
             .width(animatedWidth)
             .fillMaxHeight()
-            .background(AppComponents.sidebarSurfaceColor()),
+            .background(AppColors.sidebarSurfaceColor()),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         val headerInteractionSource = remember { MutableInteractionSource() }
@@ -465,7 +466,7 @@ private fun collapsedNavigationSidebar(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(AppComponents.sidebarHeaderColor())
+                    .background(AppColors.sidebarHeaderColor())
                     .padding(vertical = Spacing.large)
                     .hoverable(headerInteractionSource)
                     .clickable(
@@ -480,7 +481,7 @@ private fun collapsedNavigationSidebar(
                     Icon(
                         imageVector = Icons.Filled.Menu,
                         contentDescription = stringResource("sidebar.expand"),
-                        tint = AppComponents.sidebarHeaderContentColor(),
+                        tint = AppColors.sidebarHeaderContentColor(),
                         modifier = Modifier.size((32 * fontScale).dp),
                     )
                 } else {
@@ -488,7 +489,7 @@ private fun collapsedNavigationSidebar(
                         painter = appLogo,
                         contentDescription = "Askimo",
                         modifier = Modifier.size((32 * fontScale).dp),
-                        tint = AppComponents.sidebarHeaderContentColor(),
+                        tint = AppColors.sidebarHeaderContentColor(),
                     )
                 }
             }
@@ -509,7 +510,7 @@ private fun collapsedNavigationSidebar(
                     selected = false,
                     onClick = onNewChat,
                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                    colors = AppComponents.navigationRailItemColors(),
+                    colors = AppColors.navigationRailItemColors(),
                 )
             }
 
@@ -521,7 +522,7 @@ private fun collapsedNavigationSidebar(
                         selected = item.isSelected,
                         onClick = item.onClick,
                         modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                        colors = AppComponents.navigationRailItemColors(),
+                        colors = AppColors.navigationRailItemColors(),
                     )
                 }
             }
@@ -533,7 +534,7 @@ private fun collapsedNavigationSidebar(
                     selected = isSessionsSelected,
                     onClick = onNavigateToSessions,
                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                    colors = AppComponents.navigationRailItemColors(),
+                    colors = AppColors.navigationRailItemColors(),
                 )
             }
         }
@@ -571,7 +572,7 @@ private fun sidebarNavItemRow(item: SidebarNavItem) {
             badge = item.badge?.let { badgeFn -> { badgeFn(isHovered) } },
             modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
             shape = AppComponents.navigationItemShape,
-            colors = AppComponents.navigationDrawerItemColors(),
+            colors = AppColors.navigationDrawerItemColors(),
         )
     }
 }
@@ -683,7 +684,7 @@ private fun pinnedSection(
                 .padding(vertical = Spacing.extraSmall)
                 .pointerHoverIcon(PointerIcon.Hand),
             shape = AppComponents.navigationItemShape,
-            colors = AppComponents.navigationDrawerItemColors(),
+            colors = AppColors.navigationDrawerItemColors(),
         )
 
         if (isExpanded) {
@@ -750,7 +751,7 @@ private fun pinnedProjectItem(
                     .padding(vertical = Spacing.extraSmall / 2f)
                     .pointerHoverIcon(PointerIcon.Hand),
                 shape = AppComponents.navigationItemShape,
-                colors = AppComponents.navigationDrawerItemColors(),
+                colors = AppColors.navigationDrawerItemColors(),
             )
         }
 
@@ -960,7 +961,7 @@ private fun sessionsList(
                         .padding(vertical = Spacing.extraSmall / 2f)
                         .pointerHoverIcon(PointerIcon.Hand),
                     shape = AppComponents.navigationItemShape,
-                    colors = AppComponents.navigationDrawerItemColors(),
+                    colors = AppColors.navigationDrawerItemColors(),
                 )
             }
         }
@@ -1095,7 +1096,7 @@ private fun sessionDrawerItemContent(
                 .fillMaxWidth()
                 .pointerHoverIcon(PointerIcon.Hand),
             shape = AppComponents.navigationItemShape,
-            colors = AppComponents.navigationDrawerItemColors(),
+            colors = AppColors.navigationDrawerItemColors(),
         )
     }
 }
@@ -1149,12 +1150,12 @@ private fun navigationItemLabelWithMenu(
                     imageVector = Icons.Default.Bookmark,
                     contentDescription = null,
                     modifier = Modifier.size((10 * fontScale).dp),
-                    tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f),
+                    tint = AppColors.countBadgeAccentColor(),
                 )
                 Text(
                     text = "$bookmarkCount",
                     style = AppTextStyles.hint,
-                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f),
+                    color = AppColors.countBadgeAccentColor(),
                 )
             }
         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NotificationComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NotificationComponents.kt
@@ -77,6 +77,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.AccountPreferences
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -279,10 +280,10 @@ fun notificationIcon(onShowUpdateDetails: () -> Unit) {
                 Card(
                     modifier = Modifier.padding(Spacing.small),
                     colors = CardDefaults.cardColors(
-                        containerColor = AppComponents.popupContainerColor(),
+                        containerColor = AppColors.popupContainerColor(),
                     ),
-                    border = AppComponents.popupBorderStroke(),
-                    elevation = CardDefaults.cardElevation(defaultElevation = AppComponents.popupElevation),
+                    border = AppColors.popupBorderStroke(),
+                    elevation = CardDefaults.cardElevation(defaultElevation = AppColors.popupElevation),
                 ) {
                     notificationPopup(
                         events = events,
@@ -514,7 +515,7 @@ fun notificationEventCard(
             contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
         )
 
-        else -> AppComponents.surfaceVariantCardColors()
+        else -> AppColors.cardColors(AppColors.Elevation.RAISED)
     }
 
     val contentColor = when {
@@ -630,7 +631,7 @@ fun notificationEventCard(
                     Box(
                         modifier = Modifier
                             .background(
-                                color = contentColor.copy(alpha = 0.15f),
+                                color = AppColors.cardBadgeContainerColor(contentColor),
                                 shape = RoundedCornerShape(4.dp),
                             )
                             .padding(horizontal = 6.dp, vertical = 2.dp),
@@ -668,7 +669,7 @@ fun notificationEventCard(
             Text(
                 text = formatInstantDisplay(event.timestamp),
                 style = AppTextStyles.caption,
-                color = contentColor.copy(alpha = 0.7f),
+                color = AppColors.cardSecondaryContentColor(contentColor),
             )
 
             // ── Details / file count ────────────────────────────────────────────────
@@ -696,7 +697,7 @@ fun notificationEventCard(
                             text = event.cause.stackTraceToString(),
                             style = AppTextStyles.hint,
                             fontFamily = FontFamily.Monospace,
-                            color = contentColor.copy(alpha = 0.85f),
+                            color = AppColors.cardMonospaceDetailColor(contentColor),
                         )
                     }
                 }
@@ -712,7 +713,7 @@ fun notificationEventCard(
                             text = event.errorMessage,
                             style = AppTextStyles.hint,
                             fontFamily = FontFamily.Monospace,
-                            color = contentColor.copy(alpha = 0.85f),
+                            color = AppColors.cardMonospaceDetailColor(contentColor),
                         )
                     }
                 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/StarPromptDialog.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/StarPromptDialog.kt
@@ -48,6 +48,7 @@ import io.askimo.core.analytics.Analytics
 import io.askimo.core.analytics.AnalyticsEvent
 import io.askimo.core.service.StatsService
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -648,9 +649,9 @@ private fun shareActionCard(
                     text = stringResource("star.prompt.share.description"),
                     style = AppTextStyles.caption,
                     color = if (isHovered) {
-                        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                        AppColors.contentColorFor(AppColors.Elevation.SELECTED)
                     } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                        AppColors.secondaryIconColor()
                     },
                 )
             }
@@ -668,7 +669,7 @@ private fun shareActionCard(
                         ShareUtils.share(target)
                         onShared()
                     },
-                    colors = AppComponents.menuItemColors(),
+                    colors = AppColors.menuItemColors(),
                     modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                 )
             }
@@ -718,9 +719,9 @@ private fun supportActionCard(
                 text = description,
                 style = AppTextStyles.caption,
                 color = if (isHovered) {
-                    MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                    AppColors.contentColorFor(AppColors.Elevation.SELECTED)
                 } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                    AppColors.secondaryIconColor()
                 },
             )
         }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/terminal/TerminalPanel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/terminal/TerminalPanel.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -65,6 +64,7 @@ import com.pty4j.WinSize
 import io.askimo.core.util.AskimoHome
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
+import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import kotlinx.coroutines.delay
@@ -270,7 +270,7 @@ fun terminalPanel(
                                         )
 
                                         // Context menu
-                                        DropdownMenu(
+                                        AppComponents.dropdownMenu(
                                             expanded = showContextMenu,
                                             onDismissRequest = { showContextMenu = false },
                                         ) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/voice/impl/OpenAiSpeechToTextService.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/voice/impl/OpenAiSpeechToTextService.kt
@@ -5,7 +5,9 @@
 package io.askimo.ui.voice.impl
 
 import dev.langchain4j.data.audio.Audio
+import dev.langchain4j.model.audio.AudioTranscriptionRequest
 import dev.langchain4j.model.openai.OpenAiAudioTranscriptionModel
+import io.askimo.core.config.AppConfig
 import io.askimo.core.config.VoiceConfig
 import io.askimo.core.config.VoiceProvider
 import io.askimo.core.logging.logger
@@ -40,13 +42,23 @@ class OpenAiSpeechToTextService(private val config: VoiceConfig) : SpeechToTextS
                 .apiKey(apiKey)
                 .modelName(config.sttModel.ifBlank { "whisper-1" })
                 .build()
-
-            model.transcribeToText(Audio.builder().base64Data(Base64.getEncoder().encodeToString(audio)).mimeType("audio/wav").build())
+            model.transcribe(
+                AudioTranscriptionRequest.builder().audio(
+                    Audio.builder().base64Data(Base64.getEncoder().encodeToString(audio)).mimeType("audio/wav").build(),
+                ).language(whisperLanguageCode()).build(),
+            ).text()
         } catch (e: Exception) {
             log.warn("OpenAI transcription request failed", e)
             throw VoiceServiceException("OpenAI transcription request failed: ${e.message}", e)
         }
     }
+
+    /**
+     * Whisper's `/v1/audio/transcriptions` API requires a plain ISO-639-1 language code
+     * (e.g. `"vi"`, `"en"`), not a full BCP-47 tag like `"vi-VN"`. Strip any region/script
+     * subtag from [AppConfig.currentLocale] before passing it along.
+     */
+    private fun whisperLanguageCode(): String = (AppConfig.currentLocale ?: "en").substringBefore('-').lowercase().ifBlank { "en" }
 }
 
 object OpenAiSpeechToTextFactory : SpeechToTextFactory {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/voice/impl/OpenAiSpeechToTextService.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/voice/impl/OpenAiSpeechToTextService.kt
@@ -19,6 +19,7 @@ import io.askimo.ui.voice.VoiceServiceException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.Base64
+import java.util.Locale
 
 /**
  * Speech-to-text via OpenAI's Whisper API (`/v1/audio/transcriptions`), using langchain4j's
@@ -55,10 +56,16 @@ class OpenAiSpeechToTextService(private val config: VoiceConfig) : SpeechToTextS
 
     /**
      * Whisper's `/v1/audio/transcriptions` API requires a plain ISO-639-1 language code
-     * (e.g. `"vi"`, `"en"`), not a full BCP-47 tag like `"vi-VN"`. Strip any region/script
-     * subtag from [AppConfig.currentLocale] before passing it along.
+     * (e.g. `"vi"`, `"en"`), not a full BCP-47 tag like `"vi-VN"` or a Java-style locale
+     * string like `"vi_VN"`. Strip any region/script subtag (both `-` and `_` separators)
+     * from [AppConfig.currentLocale] before passing it along, and lowercase using
+     * [Locale.ROOT] to avoid locale-sensitive casing quirks (e.g. Turkish "I").
      */
-    private fun whisperLanguageCode(): String = (AppConfig.currentLocale ?: "en").substringBefore('-').lowercase().ifBlank { "en" }
+    private fun whisperLanguageCode(): String {
+        val raw = AppConfig.currentLocale ?: "en"
+        val primary = raw.substringBefore('-').substringBefore('_')
+        return primary.lowercase(Locale.ROOT).ifBlank { "en" }
+    }
 }
 
 object OpenAiSpeechToTextFactory : SpeechToTextFactory {

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -116,6 +116,7 @@ import io.askimo.ui.common.keymap.KeyMapManager
 import io.askimo.ui.common.keymap.KeyMapManager.AppShortcut
 import io.askimo.ui.common.preferences.AccountPreferences
 import io.askimo.ui.common.preferences.ApplicationPreferences
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents.alertDialog
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.BackgroundImage
@@ -1177,7 +1178,7 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                                                         modifier = Modifier
                                                                             .size(2.dp)
                                                                             .background(
-                                                                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                                                                AppColors.tertiaryIconColor(),
                                                                                 shape = CircleShape,
                                                                             ),
                                                                     )

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/FileViewerPane.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/FileViewerPane.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.askimo.core.logging.currentFileLogger
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -113,7 +114,7 @@ fun fileViewerPane(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f)),
+            .background(AppColors.surfaceColor(AppColors.Elevation.RECESSED)),
     ) {
         HorizontalDivider()
 
@@ -134,7 +135,7 @@ fun fileViewerPane(
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.InsertDriveFile,
                     contentDescription = null,
-                    tint = AppComponents.secondaryIconColor(),
+                    tint = AppColors.secondaryIconColor(),
                     modifier = Modifier.size(15.dp),
                 )
                 Text(

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/ProjectSidePanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/ProjectSidePanel.kt
@@ -73,6 +73,7 @@ import io.askimo.desktop.project.mergeKnowledgeSourceConfigs
 import io.askimo.desktop.project.reIndexConfirmDialog
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.preferences.ApplicationPreferences
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -117,7 +118,7 @@ fun communityProjectSidePanel(
         modifier = modifier.width(animatedWidth).fillMaxHeight(),
         shape = RectangleShape,
         colors = CardDefaults.cardColors(
-            containerColor = AppComponents.sidebarSurfaceColor(),
+            containerColor = AppColors.sidebarSurfaceColor(),
             contentColor = MaterialTheme.colorScheme.onSurface,
         ),
     ) {
@@ -181,7 +182,7 @@ fun communityProjectSidePanel(
                                             tint = when (ragIndexingStatus) {
                                                 "completed" -> MaterialTheme.colorScheme.onSurface
                                                 "failed" -> MaterialTheme.colorScheme.error
-                                                else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                                                else -> AppColors.tertiaryIconColor()
                                             },
                                             modifier = Modifier.size(14.dp),
                                         )
@@ -276,7 +277,7 @@ fun communityProjectSidePanel(
             Column(
                 modifier = Modifier
                     .width(56.dp).fillMaxHeight()
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f))
+                    .background(AppColors.surfaceColor(AppColors.Elevation.RECESSED))
                     .padding(vertical = Spacing.large, horizontal = Spacing.small),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(Spacing.large),
@@ -326,7 +327,7 @@ private fun panelTabIcon(tab: PanelTab, isSelected: Boolean, onClick: () -> Unit
             contentAlignment = Alignment.Center,
             modifier = Modifier
                 .size(40.dp)
-                .background(if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f) else Color.Transparent)
+                .background(if (isSelected) AppColors.surfaceColor(AppColors.Elevation.SELECTED) else Color.Transparent)
                 .clickable(onClick = onClick, indication = null, interactionSource = remember { MutableInteractionSource() })
                 .pointerHoverIcon(PointerIcon.Hand),
         ) {
@@ -416,7 +417,7 @@ private fun ragSourcesTabContent(
             ) {
                 Row(horizontalArrangement = Arrangement.spacedBy(3.dp)) {
                     repeat(3) {
-                        Box(modifier = Modifier.size(3.dp).background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f), androidx.compose.foundation.shape.CircleShape))
+                        Box(modifier = Modifier.size(3.dp).background(AppColors.tertiaryIconColor(), androidx.compose.foundation.shape.CircleShape))
                     }
                 }
             }
@@ -435,11 +436,11 @@ private fun ragSourcesTabContent(
                     modifier = Modifier
                         .height(with(LocalDensity.current) { viewerHeightPx.toDp() })
                         .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f)),
+                        .background(AppColors.surfaceColor(AppColors.Elevation.RECESSED)),
                     contentAlignment = Alignment.Center,
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
-                        Icon(Icons.Default.FolderOpen, contentDescription = null, modifier = Modifier.size(28.dp), tint = AppComponents.tertiaryIconColor())
+                        Icon(Icons.Default.FolderOpen, contentDescription = null, modifier = Modifier.size(28.dp), tint = AppColors.tertiaryIconColor())
                         Text(text = stringResource("file.viewer.select.prompt"), style = AppTextStyles.caption, textAlign = TextAlign.Center, modifier = Modifier.padding(horizontal = Spacing.large))
                     }
                 }
@@ -452,7 +453,7 @@ private fun ragSourcesTabContent(
 private fun ragSourcesEmptyState(project: Project?, onAddMaterial: () -> Unit) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(Spacing.large)) {
-            Icon(Icons.Default.FolderOpen, contentDescription = null, modifier = Modifier.size(64.dp), tint = AppComponents.tertiaryIconColor())
+            Icon(Icons.Default.FolderOpen, contentDescription = null, modifier = Modifier.size(64.dp), tint = AppColors.tertiaryIconColor())
             Text(text = stringResource("rag.empty.title"), style = AppTextStyles.sectionTitle)
             Text(text = stringResource("rag.empty.description"), style = AppTextStyles.caption, textAlign = TextAlign.Center)
             Button(

--- a/desktop/src/main/kotlin/io/askimo/desktop/chat/RagSourcesTree.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/chat/RagSourcesTree.kt
@@ -38,7 +38,6 @@ import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -80,6 +79,7 @@ import io.askimo.core.rag.state.IndexStateManager
 import io.askimo.ui.common.components.indexedIcon
 import io.askimo.ui.common.components.notIndexedIcon
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -188,7 +188,7 @@ fun ragSourcesTree(
                 Text(
                     text = stringResource("rag.tree.search.placeholder"),
                     style = AppTextStyles.caption,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    color = AppColors.secondaryIconColor(),
                 )
             },
             leadingIcon = {
@@ -218,7 +218,7 @@ fun ragSourcesTree(
             textStyle = AppTextStyles.caption,
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
-                unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                unfocusedBorderColor = AppColors.codeBlockBorderColor(),
                 focusedContainerColor = Color.Transparent,
                 unfocusedContainerColor = Color.Transparent,
             ),
@@ -272,7 +272,7 @@ fun ragSourcesTree(
                                         stringResource("rag.tree.search.results.count", searchResults.size)
                                     },
                                     style = AppTextStyles.hint,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                                    color = AppColors.secondaryIconColor(),
                                     modifier = Modifier.padding(vertical = Spacing.extraSmall),
                                 )
                             }
@@ -332,7 +332,7 @@ fun ragSourcesTree(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.4f))
+                    .background(AppColors.surfaceColor(AppColors.Elevation.RAISED))
                     .padding(horizontal = Spacing.medium, vertical = Spacing.small),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
@@ -383,8 +383,8 @@ private fun searchResultItem(
     }
 
     val backgroundColor = when {
-        isInChatSelection -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.35f)
-        isSelected -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+        isInChatSelection -> AppColors.surfaceColor(AppColors.Elevation.RAISED)
+        isSelected -> AppColors.surfaceColor(AppColors.Elevation.SELECTED)
         else -> Color.Transparent
     }
     val isIndexed = IndexStateManager.normalizePathKey(path) in indexedPaths
@@ -407,7 +407,7 @@ private fun searchResultItem(
             Icon(
                 imageVector = if (isFile) Icons.AutoMirrored.Filled.InsertDriveFile else Icons.Default.Folder,
                 contentDescription = null,
-                tint = AppComponents.secondaryIconColor(),
+                tint = AppColors.secondaryIconColor(),
                 modifier = Modifier.size(16.dp),
             )
             Column(modifier = Modifier.weight(1f)) {
@@ -418,7 +418,7 @@ private fun searchResultItem(
                     BasicText(
                         text = buildAnnotatedString {
                             append(fileName.substring(0, matchStart))
-                            withStyle(SpanStyle(background = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f), fontWeight = FontWeight.SemiBold)) {
+                            withStyle(SpanStyle(background = AppColors.surfaceColor(AppColors.Elevation.RECESSED), fontWeight = FontWeight.SemiBold)) {
                                 append(fileName.substring(matchStart, matchStart + query.length))
                             }
                             append(fileName.substring(matchStart + query.length))
@@ -433,7 +433,7 @@ private fun searchResultItem(
                 Text(
                     text = file.parent ?: path,
                     style = AppTextStyles.hint,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    color = AppColors.secondaryIconColor(),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -461,7 +461,7 @@ private fun searchResultItem(
                     }
                 } else {
                     IconButton(onClick = onAddToSelection, modifier = Modifier.size(20.dp).pointerHoverIcon(PointerIcon.Hand)) {
-                        Icon(imageVector = Icons.Default.AddCircleOutline, contentDescription = stringResource("rag.tree.chat.select"), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f), modifier = Modifier.size(16.dp))
+                        Icon(imageVector = Icons.Default.AddCircleOutline, contentDescription = stringResource("rag.tree.chat.select"), tint = AppColors.secondaryIconColor(), modifier = Modifier.size(16.dp))
                     }
                 }
             }
@@ -570,7 +570,7 @@ private fun folderNodeItem(
     }
 
     val isSelected = selectedNode == node
-    val backgroundColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f) else Color.Transparent
+    val backgroundColor = if (isSelected) AppColors.surfaceColor(AppColors.Elevation.SELECTED) else Color.Transparent
 
     Column(modifier = modifier) {
         themedTooltip(text = node.fullPath) {
@@ -592,18 +592,18 @@ private fun folderNodeItem(
                     Icon(
                         imageVector = if (isExpanded) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
                         contentDescription = if (isExpanded) stringResource("rag.tree.collapse") else stringResource("rag.tree.expand"),
-                        tint = AppComponents.secondaryIconColor(),
+                        tint = AppColors.secondaryIconColor(),
                         modifier = Modifier.size(16.dp),
                     )
                     Icon(
                         imageVector = if (isExpanded) Icons.Default.FolderOpen else Icons.Default.Folder,
                         contentDescription = null,
-                        tint = AppComponents.secondaryIconColor(),
+                        tint = AppColors.secondaryIconColor(),
                         modifier = Modifier.size(18.dp),
                     )
                     Text(text = node.displayName, style = AppTextStyles.caption, color = MaterialTheme.colorScheme.onSurface, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
                 }
-                DropdownMenu(expanded = showContextMenu, onDismissRequest = { showContextMenu = false }, offset = DpOffset(x = 0.dp, y = 0.dp)) {
+                AppComponents.dropdownMenu(expanded = showContextMenu, onDismissRequest = { showContextMenu = false }, offset = DpOffset(x = 0.dp, y = 0.dp)) {
                     DropdownMenuItem(text = { Text(stringResource("rag.tree.folder.open")) }, onClick = {
                         openInFileBrowser(node.path)
                         showContextMenu = false
@@ -647,8 +647,8 @@ private fun fileNodeItem(
     val isInChatSelection = node.path in chatSelection
     val isIndexed = IndexStateManager.normalizePathKey(node.path) in indexedPaths
     val backgroundColor = when {
-        isInChatSelection -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.35f)
-        isSelected -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+        isInChatSelection -> AppColors.surfaceColor(AppColors.Elevation.RAISED)
+        isSelected -> AppColors.surfaceColor(AppColors.Elevation.SELECTED)
         else -> Color.Transparent
     }
 
@@ -665,7 +665,7 @@ private fun fileNodeItem(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(imageVector = Icons.AutoMirrored.Filled.InsertDriveFile, contentDescription = null, tint = AppComponents.secondaryIconColor(), modifier = Modifier.size(18.dp))
+                Icon(imageVector = Icons.AutoMirrored.Filled.InsertDriveFile, contentDescription = null, tint = AppColors.secondaryIconColor(), modifier = Modifier.size(18.dp))
                 Text(text = node.displayName, style = AppTextStyles.caption, color = MaterialTheme.colorScheme.onSurface, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
                 themedTooltip(
                     text = if (isIndexed) {
@@ -687,12 +687,12 @@ private fun fileNodeItem(
                         }
                     } else {
                         IconButton(onClick = { chatSelection.add(node.path) }, modifier = Modifier.size(20.dp).pointerHoverIcon(PointerIcon.Hand)) {
-                            Icon(imageVector = Icons.Default.AddCircleOutline, contentDescription = stringResource("rag.tree.chat.select"), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f), modifier = Modifier.size(16.dp))
+                            Icon(imageVector = Icons.Default.AddCircleOutline, contentDescription = stringResource("rag.tree.chat.select"), tint = AppColors.secondaryIconColor(), modifier = Modifier.size(16.dp))
                         }
                     }
                 }
             }
-            DropdownMenu(expanded = showContextMenu, onDismissRequest = { showContextMenu = false }, offset = DpOffset(x = 0.dp, y = 0.dp)) {
+            AppComponents.dropdownMenu(expanded = showContextMenu, onDismissRequest = { showContextMenu = false }, offset = DpOffset(x = 0.dp, y = 0.dp)) {
                 if (onAddToChat != null) {
                     if (isInChatSelection) {
                         DropdownMenuItem(text = { Text(stringResource("rag.tree.chat.deselect")) }, onClick = {
@@ -744,7 +744,7 @@ private fun urlNodeItem(
 ) {
     var showContextMenu by remember { mutableStateOf(false) }
     val isSelected = selectedNode == node
-    val backgroundColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f) else Color.Transparent
+    val backgroundColor = if (isSelected) AppColors.surfaceColor(AppColors.Elevation.SELECTED) else Color.Transparent
 
     themedTooltip(text = node.fullPath) {
         Box {
@@ -759,10 +759,10 @@ private fun urlNodeItem(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(imageVector = Icons.Default.Language, contentDescription = null, tint = AppComponents.secondaryIconColor(), modifier = Modifier.size(18.dp))
+                Icon(imageVector = Icons.Default.Language, contentDescription = null, tint = AppColors.secondaryIconColor(), modifier = Modifier.size(18.dp))
                 Text(text = node.displayName, style = AppTextStyles.caption, color = MaterialTheme.colorScheme.onSurface, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
             }
-            DropdownMenu(expanded = showContextMenu, onDismissRequest = { showContextMenu = false }, offset = DpOffset(x = 0.dp, y = 0.dp)) {
+            AppComponents.dropdownMenu(expanded = showContextMenu, onDismissRequest = { showContextMenu = false }, offset = DpOffset(x = 0.dp, y = 0.dp)) {
                 DropdownMenuItem(text = { Text(stringResource("rag.tree.url.open")) }, onClick = {
                     openInBrowser(node.url)
                     showContextMenu = false

--- a/desktop/src/main/kotlin/io/askimo/desktop/plan/PlanEditorView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/plan/PlanEditorView.kt
@@ -43,6 +43,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -241,11 +242,11 @@ fun planEditorView(
                             Text(
                                 text = if (isNewPlan) YAML_HINT else stringResource("plans.editor.placeholder"),
                                 style = AppTextStyles.codeBlockPlaceholder,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                color = AppColors.tertiaryIconColor(),
                             )
                         },
                         isError = viewModel.editorValidationError != null,
-                        colors = AppComponents.outlinedTextFieldColors(),
+                        colors = AppColors.outlinedTextFieldColors(),
                         shape = MaterialTheme.shapes.small,
                     )
                 }
@@ -322,7 +323,7 @@ private fun aiGenerationPanel(
 
     Surface(
         modifier = modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        color = AppColors.surfaceColor(AppColors.Elevation.RAISED),
         shape = MaterialTheme.shapes.medium,
     ) {
         Column(modifier = Modifier.padding(Spacing.large)) {
@@ -360,7 +361,7 @@ private fun aiGenerationPanel(
                 Text(
                     text = stringResource("plans.editor.ai.hint"),
                     style = AppTextStyles.hint,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    color = AppColors.secondaryIconColor(),
                     modifier = Modifier.padding(top = Spacing.extraSmall),
                 )
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/AddReferenceMaterialDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/AddReferenceMaterialDialog.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,6 +37,7 @@ import io.askimo.core.event.internal.ProjectRefreshEvent
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -136,7 +136,7 @@ fun addReferenceMaterialDialog(
                             )
                         }
                         if (index < KnowledgeSourceItem.availableTypes.lastIndex) {
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                            HorizontalDivider(color = AppColors.codeBlockBorderColor())
                         }
                     }
                 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/EditProjectDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/EditProjectDialog.kt
@@ -58,6 +58,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -297,7 +298,7 @@ private fun editProjectFormDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester),
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
             )
 
@@ -309,7 +310,7 @@ private fun editProjectFormDialog(
                 minLines = 3,
                 maxLines = 5,
                 modifier = Modifier.fillMaxWidth(),
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
             )
         },
@@ -369,7 +370,7 @@ private fun editProjectFormDialog(
                                 )
                             }
                             if (index < KnowledgeSourceItem.availableTypes.lastIndex) {
-                                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                                HorizontalDivider(color = AppColors.codeBlockBorderColor())
                             }
                         }
                     }
@@ -414,7 +415,7 @@ private fun editProjectFormDialog(
                             Text(stringResource("project.dialog.defaultDirective.none"), style = AppTextStyles.body)
                         }
                         availableDirectives.forEach { directive ->
-                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                            HorizontalDivider(color = AppColors.codeBlockBorderColor())
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/NewProjectDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/NewProjectDialog.kt
@@ -50,6 +50,7 @@ import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.rememberDialogState
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -270,7 +271,7 @@ fun newProjectDialog(
                     supportingText = nameError?.let { { Text(it, color = MaterialTheme.colorScheme.error) } },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                 )
 
@@ -282,7 +283,7 @@ fun newProjectDialog(
                     minLines = 3,
                     maxLines = 5,
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { handleCreate() }),
                 )
@@ -343,7 +344,7 @@ fun newProjectDialog(
                                 }
                                 if (index < KnowledgeSourceItem.availableTypes.lastIndex) {
                                     HorizontalDivider(
-                                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                        color = AppColors.codeBlockBorderColor(),
                                     )
                                 }
                             }
@@ -389,7 +390,7 @@ fun newProjectDialog(
                                 Text(stringResource("project.dialog.defaultDirective.none"), style = AppTextStyles.body)
                             }
                             availableDirectives.forEach { directive ->
-                                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                                HorizontalDivider(color = AppColors.codeBlockBorderColor())
                                 Row(
                                     modifier = Modifier
                                         .fillMaxWidth()

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
@@ -92,6 +92,7 @@ import io.askimo.ui.chat.chatInputField
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.successIcon
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
@@ -231,7 +232,7 @@ fun projectView(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(bottom = Spacing.large),
-                        colors = AppComponents.bannerCardColors(),
+                        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                         shape = MaterialTheme.shapes.large,
                     ) {
                         Row(
@@ -490,7 +491,7 @@ private fun sessionCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         border = BorderStroke(
             width = 1.dp,
-            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+            color = AppColors.codeBlockBorderColor(),
         ),
     ) {
         Row(
@@ -612,7 +613,7 @@ private fun knowledgeSourcesPanel(
 
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = AppComponents.surfaceVariantCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -690,7 +691,7 @@ private fun knowledgeSourcesPanel(
                             Icon(
                                 imageVector = Icons.Default.Info,
                                 contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                                tint = AppColors.secondaryIconColor(),
                                 modifier = Modifier
                                     .size(20.dp)
                                     .pointerHoverIcon(PointerIcon.Hand),
@@ -784,7 +785,7 @@ private fun knowledgeSourcesPanel(
                     ) {
                         HorizontalDivider(
                             modifier = Modifier.fillMaxWidth(),
-                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                            color = AppColors.codeBlockBorderColor(),
                         )
 
                         val groupedSources = currentProject.knowledgeSources.groupBy { source ->
@@ -827,12 +828,12 @@ private fun knowledgeSourcesPanel(
                 ) {
                     HorizontalDivider(
                         modifier = Modifier.fillMaxWidth(),
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                        color = AppColors.codeBlockBorderColor(),
                     )
                     Text(
                         text = stringResource("projects.sources.empty.description"),
                         style = AppTextStyles.caption,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
+                        color = AppColors.secondaryIconColor(),
                     )
                 }
             }
@@ -992,13 +993,13 @@ private fun indexProgressIndicator(
                         progress = { indexProgress.progressPercent / 100f },
                         modifier = Modifier.fillMaxWidth(),
                         color = MaterialTheme.colorScheme.onSurface,
-                        trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                        trackColor = AppColors.surfaceColor(AppColors.Elevation.RECESSED),
                     )
                 } else {
                     LinearProgressIndicator(
                         modifier = Modifier.fillMaxWidth(),
                         color = MaterialTheme.colorScheme.onSurface,
-                        trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                        trackColor = AppColors.surfaceColor(AppColors.Elevation.RECESSED),
                     )
                 }
                 indexProgress.currentFile?.let { file ->
@@ -1041,7 +1042,7 @@ private fun indexProgressIndicator(
                     Text(
                         text = "$file$elapsedText",
                         style = AppTextStyles.hint,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                        color = AppColors.secondaryIconColor(),
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -1143,7 +1144,7 @@ private fun skippedFilesWarning(skippedFileNames: List<String>) {
                     Text(
                         text = "• $name",
                         style = AppTextStyles.hint,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
+                        color = AppColors.secondaryIconColor(),
                     )
                 }
             }

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsView.kt
@@ -68,6 +68,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.tablePageSizeSelector
 import io.askimo.ui.common.components.tablePagination
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -175,7 +176,7 @@ fun projectsView(
                     singleLine = true,
                     textStyle = AppTextStyles.body,
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 Spacer(modifier = Modifier.height(Spacing.large))
@@ -307,7 +308,7 @@ internal fun embeddingModelNotConfiguredBanner(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Row(
             modifier = Modifier
@@ -394,7 +395,7 @@ private fun projectTable(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                    .background(AppColors.surfaceColor(AppColors.Elevation.RAISED))
                     .padding(horizontal = 16.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -441,7 +442,7 @@ private fun projectTable(
                     onStarProject = onStarProject,
                 )
                 if (index < sortedProjects.lastIndex) {
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
+                    HorizontalDivider(color = AppColors.codeBlockBorderColor())
                 }
             }
         }
@@ -512,7 +513,7 @@ private fun projectRow(
             .hoverable(interactionSource)
             .background(
                 if (isHovered) {
-                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+                    AppColors.surfaceColor(AppColors.Elevation.RAISED)
                 } else {
                     MaterialTheme.colorScheme.surface
                 },
@@ -536,7 +537,7 @@ private fun projectRow(
                 tint = if (project.isStarred) {
                     MaterialTheme.colorScheme.onSurface
                 } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                    AppColors.tertiaryIconColor()
                 },
                 modifier = Modifier.size(16.dp),
             )

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/UrlInputDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/UrlInputDialog.kt
@@ -28,6 +28,7 @@ import io.askimo.core.logging.logger
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import kotlinx.coroutines.Dispatchers
@@ -161,7 +162,7 @@ fun urlInputDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester),
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(onDone = { handleAdd() }),
             )

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
@@ -63,6 +63,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -103,7 +104,7 @@ fun aiProviderSettingsSection(viewModel: AIProviderViewModel) {
                 // Active provider card — Edit current instance or Add a new one
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Row(
                         modifier = Modifier
@@ -185,7 +186,7 @@ private fun providerModelConfigCard(instance: ProviderInstance, viewModel: AIPro
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -494,7 +495,7 @@ private fun providerModelTypePickerDialog(
         stickyHeader = if (modelsReady) {
             {
                 if (currentValue.isNotBlank()) {
-                    Card(modifier = Modifier.fillMaxWidth(), colors = AppComponents.bannerCardColors()) {
+                    Card(modifier = Modifier.fillMaxWidth(), colors = AppColors.cardColors(AppColors.Elevation.ACCENT)) {
                         Column(
                             modifier = Modifier.fillMaxWidth().padding(Spacing.large),
                             verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
@@ -506,7 +507,7 @@ private fun providerModelTypePickerDialog(
                 }
 
                 if (selectedModel != null && selectedModel != currentValue) {
-                    Card(modifier = Modifier.fillMaxWidth(), colors = AppComponents.primaryCardColors()) {
+                    Card(modifier = Modifier.fillMaxWidth(), colors = AppColors.cardColors(AppColors.Elevation.ACCENT)) {
                         Row(modifier = Modifier.fillMaxWidth().padding(Spacing.large), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(text = stringResource("settings.model.new"), style = AppTextStyles.fieldLabel, color = MaterialTheme.colorScheme.onPrimaryContainer)
@@ -524,7 +525,7 @@ private fun providerModelTypePickerDialog(
                     placeholder = { Text(stringResource("settings.model.search.placeholder")) },
                     label = { Text(stringResource("settings.model.search")) },
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 if (searchQuery.isNotBlank() && filteredModels.isNotEmpty()) {
@@ -567,7 +568,7 @@ private fun providerModelTypePickerDialog(
                 Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
                     Text(text = errorMessage ?: "", color = MaterialTheme.colorScheme.error, style = AppTextStyles.body)
                     errorHelp?.let { helpText ->
-                        Card(colors = AppComponents.surfaceVariantCardColors()) {
+                        Card(colors = AppColors.cardColors(AppColors.Elevation.RAISED)) {
                             Text(text = helpText, style = AppTextStyles.caption, modifier = Modifier.padding(Spacing.medium))
                         }
                     }
@@ -660,7 +661,7 @@ private fun providerConfigurableField(
                             )
                         }
                     },
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
             }
 
@@ -685,7 +686,7 @@ private fun providerConfigurableField(
                             )
                         }
                     },
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
             }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutDialog.kt
@@ -21,6 +21,7 @@ import io.askimo.core.VersionInfo
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -50,7 +51,7 @@ fun aboutDialog(
                 // Version Info
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),
@@ -89,7 +90,7 @@ fun aboutDialog(
                 // Description
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),
@@ -109,7 +110,7 @@ fun aboutDialog(
                 // License
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
@@ -40,6 +40,7 @@ import io.askimo.core.AppConstants.DOMAIN
 import io.askimo.core.VersionInfo
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -75,7 +76,7 @@ fun aboutSettingsSection() {
                 // Application Info Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Column(
                         modifier = Modifier
@@ -144,7 +145,7 @@ fun aboutSettingsSection() {
                 // Description Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Column(
                         modifier = Modifier
@@ -166,7 +167,7 @@ fun aboutSettingsSection() {
                 // License Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Column(
                         modifier = Modifier
@@ -194,7 +195,7 @@ fun aboutSettingsSection() {
                 // Runtime Information Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Column(
                         modifier = Modifier
@@ -226,7 +227,7 @@ fun aboutSettingsSection() {
                 // Links Section
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppComponents.bannerCardColors(),
+                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                 ) {
                     Column(
                         modifier = Modifier

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AdvancedSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AdvancedSettingsSection.kt
@@ -60,6 +60,7 @@ import io.askimo.core.util.NumberFormatUtil
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -154,7 +155,7 @@ private fun logLevelCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -249,7 +250,7 @@ private fun logViewerCard(
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -349,7 +350,7 @@ private fun analyticsSection() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -401,7 +402,7 @@ private fun developerModeSection() {
     // Developer Mode Card
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -441,7 +442,7 @@ private fun developerModeSection() {
 private fun ragConfigurationSection() {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -620,7 +621,7 @@ private fun ragConfigurationSection() {
 private fun modelsConfigurationSection() {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -657,7 +658,7 @@ private fun memoryConfigurationSection() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -855,7 +856,7 @@ private fun ragIntField(
                     )
                 }
             },
-            colors = AppComponents.outlinedTextFieldColors(),
+            colors = AppColors.outlinedTextFieldColors(),
         )
         Text(text = hint, style = AppTextStyles.caption)
     }
@@ -918,7 +919,7 @@ private fun ragDoubleField(
                     Icon(Icons.Default.Check, contentDescription = "Saved", tint = AppTextStyles.primaryContent, modifier = Modifier.size(20.dp))
                 }
             },
-            colors = AppComponents.outlinedTextFieldColors(),
+            colors = AppColors.outlinedTextFieldColors(),
         )
         Text(text = hint, style = AppTextStyles.caption)
     }
@@ -995,7 +996,7 @@ private fun ragOptionalIntField(
                     )
                 }
             },
-            colors = AppComponents.outlinedTextFieldColors(),
+            colors = AppColors.outlinedTextFieldColors(),
         )
         Text(
             text = hint,
@@ -1061,7 +1062,7 @@ private fun ragLongField(
                     Icon(Icons.Default.Check, contentDescription = "Saved", tint = AppTextStyles.primaryContent, modifier = Modifier.size(20.dp))
                 }
             },
-            colors = AppComponents.outlinedTextFieldColors(),
+            colors = AppColors.outlinedTextFieldColors(),
         )
         Text(text = hint, style = AppTextStyles.caption)
     }
@@ -1124,7 +1125,7 @@ private fun ragStringSetField(
                     )
                 }
             },
-            colors = AppComponents.outlinedTextFieldColors(),
+            colors = AppColors.outlinedTextFieldColors(),
         )
         Text(
             text = hint,

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/GroupedModelList.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/GroupedModelList.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.askimo.core.providers.ModelDTO
 import io.askimo.core.providers.ModelProvider
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.ui.clickableCard
 
@@ -63,9 +63,9 @@ fun groupedModelListAsCards(
                     .padding(bottom = 8.dp)
                     .clickableCard { onModelClick(dto.modelId) },
                 colors = if (isSelected) {
-                    AppComponents.primaryCardColors()
+                    AppColors.cardColors(AppColors.Elevation.ACCENT)
                 } else {
-                    AppComponents.surfaceVariantCardColors()
+                    AppColors.cardColors(AppColors.Elevation.RAISED)
                 },
             ) {
                 Row(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
@@ -54,6 +54,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -144,7 +145,7 @@ fun mcpServerTemplatesSection() {
 
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = AppComponents.bannerCardColors(),
+                        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
                     ) {
                         if (mcpInstances.isEmpty()) {
                             Box(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/NetworkSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/NetworkSettingsSection.kt
@@ -42,6 +42,7 @@ import io.askimo.core.config.AppConfig
 import io.askimo.core.config.ProxyType
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -117,7 +118,7 @@ private fun proxyConfigurationCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/ProviderSelectionDialog.kt
@@ -64,6 +64,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -133,7 +134,7 @@ fun providerWizardDialog(viewModel: ProviderWizardViewModel) {
                 )
 
                 viewModel.pendingModelForNewProvider?.let { selectedModel ->
-                    Card(modifier = Modifier.fillMaxWidth(), colors = AppComponents.surfaceVariantCardColors()) {
+                    Card(modifier = Modifier.fillMaxWidth(), colors = AppColors.cardColors(AppColors.Elevation.RAISED)) {
                         Row(
                             modifier = Modifier.fillMaxWidth().padding(Spacing.large),
                             horizontalArrangement = Arrangement.SpaceBetween,
@@ -154,7 +155,7 @@ fun providerWizardDialog(viewModel: ProviderWizardViewModel) {
                     placeholder = { Text(stringResource("settings.model.search.placeholder")) },
                     label = { Text(stringResource("settings.model.search")) },
                     singleLine = true,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 if (searchQuery.isNotBlank() && filteredModels.isNotEmpty()) {
@@ -308,7 +309,7 @@ private fun providerTypePickerScreen(viewModel: ProviderWizardViewModel) {
                 modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.small, vertical = Spacing.extraSmall),
                 placeholder = { Text(stringResource("provider.search.placeholder"), style = AppTextStyles.caption) },
                 singleLine = true,
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 textStyle = AppTextStyles.caption,
             )
             Box(modifier = Modifier.weight(1f)) {
@@ -536,7 +537,7 @@ private fun providerPickerDetail(
                 }
 
                 // Setup instructions specific to this template
-                Card(colors = AppComponents.surfaceVariantCardColors()) {
+                Card(colors = AppColors.cardColors(AppColors.Elevation.RAISED)) {
                     Row(
                         modifier = Modifier.fillMaxWidth().padding(Spacing.medium),
                         horizontalArrangement = Arrangement.spacedBy(Spacing.small),
@@ -590,7 +591,7 @@ private fun instanceConfigScreen(viewModel: ProviderWizardViewModel) {
                 supportingText = viewModel.displayNameError?.let { error ->
                     { Text(text = error, style = AppTextStyles.errorText) }
                 },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
             )
         }
         HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.small))
@@ -667,7 +668,7 @@ private fun instanceConfigScreen(viewModel: ProviderWizardViewModel) {
                                         modifier = Modifier.fillMaxWidth(),
                                         singleLine = true,
                                         placeholder = { Text(stringResource("settings.placeholder.baseurl")) },
-                                        colors = AppComponents.outlinedTextFieldColors(),
+                                        colors = AppColors.outlinedTextFieldColors(),
                                     )
                                 }
 
@@ -723,7 +724,7 @@ private fun instanceConfigScreen(viewModel: ProviderWizardViewModel) {
                             Text(text = viewModel.connectionError ?: "", style = AppTextStyles.body, color = MaterialTheme.colorScheme.onErrorContainer)
                             viewModel.connectionErrorHelp?.let {
                                 Spacer(Modifier.height(Spacing.extraSmall))
-                                Text(text = it, style = AppTextStyles.caption, color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f))
+                                Text(text = it, style = AppTextStyles.caption, color = AppColors.cardSecondaryContentColor(MaterialTheme.colorScheme.onErrorContainer))
                             }
                         }
                     }
@@ -757,7 +758,7 @@ private fun modelPickerScreen(
                 Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
                     Text(text = viewModel.modelError ?: "", color = MaterialTheme.colorScheme.error, style = AppTextStyles.body)
                     viewModel.modelErrorHelp?.let {
-                        Card(colors = AppComponents.surfaceVariantCardColors()) {
+                        Card(colors = AppColors.cardColors(AppColors.Elevation.RAISED)) {
                             Text(text = it, style = AppTextStyles.caption, modifier = Modifier.padding(Spacing.medium))
                         }
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsConfigDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsConfigDialog.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import io.askimo.core.providers.SettingField
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -72,7 +73,7 @@ fun settingsConfigDialog(
                                 } else {
                                     VisualTransformation.None
                                 },
-                                colors = AppComponents.outlinedTextFieldColors(),
+                                colors = AppColors.outlinedTextFieldColors(),
                             )
                         }
 
@@ -92,7 +93,7 @@ fun settingsConfigDialog(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
-                                    colors = AppComponents.outlinedTextFieldColors(),
+                                    colors = AppColors.outlinedTextFieldColors(),
                                 )
                                 ExposedDropdownMenu(
                                     expanded = expanded,
@@ -131,7 +132,7 @@ fun settingsConfigDialog(
                                 placeholder = { Text(field.description) },
                                 modifier = Modifier.fillMaxWidth(),
                                 singleLine = true,
-                                colors = AppComponents.outlinedTextFieldColors(),
+                                colors = AppColors.outlinedTextFieldColors(),
                             )
                         }
                     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/SettingsView.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.LocalBackgroundActive
 import io.askimo.ui.common.theme.Spacing
@@ -98,7 +98,7 @@ fun settingsViewWithSidebar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(AppComponents.sidebarHeaderColor())
+                .background(AppColors.sidebarHeaderColor())
                 .padding(Spacing.large),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
@@ -170,7 +170,7 @@ fun settingsViewWithSidebar(
                     modifier = Modifier
                         .width(calculatedWidth)
                         .fillMaxHeight()
-                        .background(AppComponents.sidebarSurfaceColor()),
+                        .background(AppColors.sidebarSurfaceColor()),
                 ) {
                     settingsSidebarItem(
                         title = stringResource("settings.appearance"),
@@ -267,7 +267,7 @@ fun settingsViewWithSidebar(
                                 modifier = Modifier
                                     .size(2.dp)
                                     .background(
-                                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                                        AppColors.tertiaryIconColor(),
                                         shape = CircleShape,
                                     ),
                             )

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/VoiceSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/VoiceSettingsSection.kt
@@ -49,6 +49,7 @@ import io.askimo.core.providers.ModelProvider
 import io.askimo.core.security.SecureKeyManager
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -93,7 +94,7 @@ fun voiceSettingsSection() {
                 Text(
                     text = stringResource("settings.voice.description"),
                     style = AppTextStyles.bodySecondary,
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                    color = AppTextStyles.secondaryContent,
                 )
 
                 voiceConfigCard()
@@ -175,7 +176,7 @@ private fun voiceConfigCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -463,7 +464,7 @@ private fun voiceProviderSelector(
                         .fillMaxWidth()
                         .clickableCard { onExpandedChange(true) },
                     colors = CardDefaults.cardColors(
-                        containerColor = AppComponents.surfaceRaised(),
+                        containerColor = AppColors.surfaceColor(AppColors.Elevation.RAISED),
                     ),
                 ) {
                     Row(
@@ -548,7 +549,7 @@ private fun voiceOptionSelector(
                     .fillMaxWidth()
                     .clickableCard { onExpandedChange(true) },
                 colors = CardDefaults.cardColors(
-                    containerColor = AppComponents.surfaceRaised(),
+                    containerColor = AppColors.surfaceColor(AppColors.Elevation.RAISED),
                 ),
             ) {
                 Row(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/WebSearchSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/WebSearchSettingsSection.kt
@@ -49,6 +49,7 @@ import io.askimo.tools.web.WebSearchDispatcher
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -90,7 +91,7 @@ fun webSearchSettingsSection() {
                 Text(
                     text = stringResource("settings.web_search.description"),
                     style = AppTextStyles.bodySecondary,
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                    color = AppTextStyles.secondaryContent,
                 )
 
                 webSearchConfigCard()
@@ -146,7 +147,7 @@ private fun webSearchConfigCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppComponents.bannerCardColors(),
+        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
     ) {
         Column(
             modifier = Modifier
@@ -193,7 +194,7 @@ private fun webSearchConfigCard() {
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f),
+                    containerColor = AppColors.surfaceColor(AppColors.Elevation.SELECTED),
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                 ),
             ) {

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/ComposeTopMenuBar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/ComposeTopMenuBar.kt
@@ -41,6 +41,7 @@ import io.askimo.core.config.AppConfig
 import io.askimo.core.config.FeatureFlags
 import io.askimo.core.util.AskimoHome
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -91,7 +92,7 @@ fun composeTopMenuBar(
 ) {
     var expandedMenu by remember { mutableStateOf<TopMenu?>(null) }
 
-    Column(modifier = Modifier.fillMaxWidth().background(AppComponents.sidebarSurfaceColor())) {
+    Column(modifier = Modifier.fillMaxWidth().background(AppColors.sidebarSurfaceColor())) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -320,7 +321,7 @@ private fun menuAnchor(
                 onDismissRequest = onDismiss,
                 properties = PopupProperties(focusable = true),
             ) {
-                val borderColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                val borderColor = AppColors.codeBlockBorderColor()
                 Surface(
                     shape = RoundedCornerShape(bottomStart = 4.dp, bottomEnd = 4.dp, topStart = 0.dp, topEnd = 4.dp),
                     color = MaterialTheme.colorScheme.surface,
@@ -343,7 +344,7 @@ private fun menuAction(key: String, onClick: () -> Unit) {
         onClick = onClick,
         modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
         contentPadding = PaddingValues(horizontal = 14.dp, vertical = 4.dp),
-        colors = AppComponents.menuItemColors(),
+        colors = AppColors.menuItemColors(),
     )
 }
 
@@ -359,5 +360,5 @@ private fun menuToggleAction(key: String, isSelected: Boolean, onClick: () -> Un
 
 @Composable
 private fun menuDivider() {
-    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+    HorizontalDivider(color = AppColors.codeBlockBorderColor())
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
@@ -50,7 +50,7 @@ import io.askimo.core.providers.ModelProvider
 import io.askimo.core.providers.ProviderInstanceService
 import io.askimo.core.providers.ProviderRegistry
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.ui.clickableCard
@@ -219,7 +219,7 @@ fun footerBar(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(AppComponents.sidebarSurfaceColor()),
+            .background(AppColors.sidebarSurfaceColor()),
     ) {
         HorizontalDivider()
 
@@ -232,7 +232,7 @@ fun footerBar(
                 Text(
                     text = "v${VersionInfo.version}",
                     style = AppTextStyles.caption,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                    color = AppColors.tertiaryIconColor(),
                     modifier = Modifier
                         .align(Alignment.CenterStart)
                         .pointerHoverIcon(PointerIcon.Hand)

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
@@ -45,6 +45,7 @@ import io.askimo.core.user.domain.UserProfile
 import io.askimo.desktop.View
 import io.askimo.desktop.project.ProjectsViewModel
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.LocalFontScale
@@ -234,7 +235,7 @@ private fun communityUserProfileSection(
                     imageVector = Icons.Default.Settings,
                     contentDescription = stringResource("user.menu.settings"),
                     modifier = Modifier.size((16 * fontScale).dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                    tint = AppColors.tertiaryIconColor(),
                 )
             }
             communityProfileMenu(
@@ -270,7 +271,7 @@ private fun communityUserProfileSection(
                     modifier = Modifier
                         .padding(vertical = (8 * fontScale).dp)
                         .pointerHoverIcon(PointerIcon.Hand),
-                    colors = AppComponents.navigationRailItemColors(),
+                    colors = AppColors.navigationRailItemColors(),
                 )
             }
             communityProfileMenu(

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/ProviderModelPanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/ProviderModelPanel.kt
@@ -74,6 +74,7 @@ import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppComponents.dropdownMenu
 import io.askimo.ui.common.theme.AppTextStyles
@@ -307,7 +308,7 @@ internal fun providerModelPanel(
                                         Text(
                                             text = stringResource("provider.model.panel.model.count", pendingModels.size),
                                             style = AppTextStyles.hint,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                            color = AppColors.secondaryIconColor(),
                                         )
                                     }
                                 }
@@ -374,7 +375,7 @@ private fun modelListColumn(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = null,
                             modifier = Modifier.size(20.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                            tint = AppColors.tertiaryIconColor(),
                         )
                         Text(
                             text = stringResource("provider.model.panel.select.hint"),
@@ -427,7 +428,7 @@ private fun modelListColumn(
                         Icon(Icons.Default.Search, contentDescription = null, modifier = Modifier.size(16.dp))
                     },
                     textStyle = AppTextStyles.caption,
-                    colors = AppComponents.outlinedTextFieldColors(),
+                    colors = AppColors.outlinedTextFieldColors(),
                 )
 
                 val modelListState = rememberLazyListState()
@@ -576,7 +577,7 @@ private fun modelListColumn(
                         Text(
                             text = stringResource("settings.model.chat.filter.label", filteredModels.size),
                             style = AppTextStyles.hint,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            color = AppColors.secondaryIconColor(),
                         )
                         linkButton(onClick = onShowAll) {
                             Text(
@@ -705,7 +706,7 @@ private fun instanceEditForm(
                                 singleLine = true,
                                 placeholder = { Text(stringResource("settings.placeholder.baseurl"), style = AppTextStyles.caption) },
                                 textStyle = AppTextStyles.caption,
-                                colors = AppComponents.outlinedTextFieldColors(),
+                                colors = AppColors.outlinedTextFieldColors(),
                             )
                         }
                     }
@@ -879,7 +880,7 @@ internal fun instanceRow(
                             Icon(
                                 Icons.Default.Delete,
                                 contentDescription = "Delete",
-                                tint = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
+                                tint = AppColors.warningColor(),
                                 modifier = Modifier.size(13.dp),
                             )
                         }

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/TelemetryPanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/TelemetryPanel.kt
@@ -50,6 +50,7 @@ import io.askimo.core.context.AppContext
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.core.telemetry.LlmInstanceStats
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -386,7 +387,7 @@ private fun telemetryMetricCard(
     Card(
         modifier = modifier,
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
+            containerColor = AppColors.surfaceColor(AppColors.Elevation.SELECTED),
         ),
     ) {
         Column(
@@ -416,7 +417,7 @@ private fun telemetryMetricCard(
                 text = subtitle,
                 style = AppTextStyles.caption,
                 fontSize = 10.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                color = AppColors.secondaryIconColor(),
             )
         }
     }

--- a/desktop/src/main/kotlin/io/askimo/desktop/user/UserProfileDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/user/UserProfileDialog.kt
@@ -42,6 +42,7 @@ import io.askimo.core.user.domain.UserProfile
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.components.secondaryButton
 import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppComponents
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
@@ -225,7 +226,7 @@ fun userProfileDialog(
                 value = name,
                 onValueChange = { name = it },
                 label = { Text(stringResource("user.profile.name")) },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
             )
@@ -234,7 +235,7 @@ fun userProfileDialog(
                 onValueChange = { email = it },
                 label = { Text(stringResource("user.profile.email")) },
                 placeholder = { Text(stringResource("user.profile.email.placeholder")) },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
             )
@@ -243,7 +244,7 @@ fun userProfileDialog(
                 onValueChange = { occupation = it },
                 label = { Text(stringResource("user.profile.occupation")) },
                 placeholder = { Text(stringResource("user.profile.occupation.placeholder")) },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
             )
@@ -252,7 +253,7 @@ fun userProfileDialog(
                 onValueChange = { location = it },
                 label = { Text(stringResource("user.profile.location")) },
                 placeholder = { Text(stringResource("user.profile.location.placeholder")) },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
             )
@@ -261,7 +262,7 @@ fun userProfileDialog(
                 onValueChange = { bio = it },
                 label = { Text(stringResource("user.profile.bio")) },
                 placeholder = { Text(stringResource("user.profile.bio.placeholder")) },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 modifier = Modifier.fillMaxWidth().height(100.dp),
                 maxLines = 4,
             )
@@ -302,7 +303,7 @@ fun userProfileDialog(
                 onValueChange = { customInterests = it },
                 label = { Text(stringResource("user.profile.interests.custom")) },
                 placeholder = { Text(stringResource("user.profile.interests.custom.placeholder")) },
-                colors = AppComponents.outlinedTextFieldColors(),
+                colors = AppColors.outlinedTextFieldColors(),
                 modifier = Modifier.fillMaxWidth(),
                 supportingText = {
                     Text(

--- a/desktop/src/main/kotlin/io/askimo/desktop/user/WelcomeProfileDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/user/WelcomeProfileDialog.kt
@@ -50,7 +50,7 @@ import io.askimo.core.user.domain.UserProfile
 import io.askimo.ui.common.components.linkButton
 import io.askimo.ui.common.components.primaryButton
 import io.askimo.ui.common.i18n.stringResource
-import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppColors
 import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.service.AvatarService
@@ -178,7 +178,7 @@ fun welcomeProfileDialog(
                         },
                         placeholder = { Text(stringResource("welcome.name.placeholder")) },
                         modifier = Modifier.fillMaxWidth(),
-                        colors = AppComponents.outlinedTextFieldColors(),
+                        colors = AppColors.outlinedTextFieldColors(),
                         singleLine = true,
                     )
 
@@ -189,7 +189,7 @@ fun welcomeProfileDialog(
                         label = { Text(stringResource("welcome.occupation")) },
                         placeholder = { Text(stringResource("welcome.occupation.placeholder")) },
                         modifier = Modifier.fillMaxWidth(),
-                        colors = AppComponents.outlinedTextFieldColors(),
+                        colors = AppColors.outlinedTextFieldColors(),
                         singleLine = true,
                     )
 

--- a/shared/src/main/kotlin/io/askimo/core/i18n/LocalizationManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/i18n/LocalizationManager.kt
@@ -61,9 +61,15 @@ object LocalizationManager {
 
                     try {
                         this::class.java.classLoader.getResourceAsStream(resourcePath)?.use {
-                            // File exists! Use this locale
-                            val displayName = buildDisplayName(locale)
-                            localesMap[locale] = displayName
+                            // File exists! Normalize to a plain language[-country] locale,
+                            // dropping any script/variant (e.g. avoid "vi-Latn-VN", keep "vi-VN").
+                            val normalizedLocale = if (country.isNotEmpty()) {
+                                Locale.Builder().setLanguage(language).setRegion(country).build()
+                            } else {
+                                Locale.Builder().setLanguage(language).build()
+                            }
+                            val displayName = buildDisplayName(normalizedLocale)
+                            localesMap[normalizedLocale] = displayName
                             seenLocales.add(localeKey)
                         }
                     } catch (_: Exception) {


### PR DESCRIPTION
- Introduce AppColors.kt providing a new color helper API
- Remove all AppComponents imports and replace color usage across the UI
- Update theme preferences to normalize locales when saving
- Replace colorScheme references with AppColors utilities in all UI files
- Update dropdown, cards, text fields, icons, and panels to use AppColors
- Update localization manager to normalize locale strings before storing