### PR TITLE
feat(agent): Implement graceful agent run cancellation

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
@@ -33,7 +33,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -54,6 +54,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -70,6 +71,7 @@ import io.askimo.core.agent.domain.AgentRunRecord
 import io.askimo.core.agent.domain.SkillDefinition
 import io.askimo.core.agent.domain.Workspace
 import io.askimo.core.chat.dto.grouped
+import io.askimo.core.user.repository.UserProfileRepository
 import io.askimo.ui.chat.messageList
 import io.askimo.ui.chat.turnTimelineView
 import io.askimo.ui.common.i18n.stringResource
@@ -82,6 +84,10 @@ import io.askimo.ui.common.theme.AppTextStyles
 import io.askimo.ui.common.theme.Spacing
 import io.askimo.ui.common.theme.ThemePreferences
 import io.askimo.ui.common.ui.themedTooltip
+import io.askimo.ui.service.AvatarService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.context.GlobalContext
 
 @Composable
 private fun agentReadinessDotColor(state: AgentReadiness?): Color = when (state) {
@@ -126,6 +132,19 @@ internal fun agenticRunArea(
     var inputText by remember { mutableStateOf(TextFieldValue("")) }
     var agentDropdownExpanded by remember { mutableStateOf(false) }
     var skillsListExpanded by remember { mutableStateOf(false) }
+
+    val avatarService = remember { GlobalContext.get().get<AvatarService>() }
+    val userProfileRepository = remember { GlobalContext.get().get<UserProfileRepository>() }
+    var aiAvatarPainter by remember { mutableStateOf<BitmapPainter?>(null) }
+    var userAvatarPainter by remember { mutableStateOf<BitmapPainter?>(null) }
+
+    LaunchedEffect(Unit) {
+        aiAvatarPainter = withContext(Dispatchers.IO) { avatarService.getAiAvatarPainter() }
+        userAvatarPainter = withContext(Dispatchers.IO) {
+            val avatarPath = runCatching { userProfileRepository.getProfile().preferences["avatarPath"] }.getOrNull()
+            avatarService.getUserAvatarPainter(avatarPath)
+        }
+    }
 
     fun sendMessage() {
         val agent = viewModel.selectedAgent ?: return
@@ -438,6 +457,8 @@ internal fun agenticRunArea(
                             isThinking = viewModel.isWaitingForFirstEvent,
                             thinkingElapsedSeconds = viewModel.elapsedSeconds,
                             completedGroupsByMessageId = viewModel.completedGroups,
+                            userAvatarPainter = userAvatarPainter,
+                            aiAvatarPainter = aiAvatarPainter,
                         )
                         // Live, chronologically-ordered view of the *current* turn — tool
                         // calls, thinking, response text, and status, interleaved exactly as
@@ -481,8 +502,6 @@ internal fun agenticRunArea(
                     .fillMaxWidth()
                     .padding(start = 24.dp, end = 36.dp, top = 8.dp, bottom = 16.dp),
             ) {
-                var modelDropdownExpanded by remember { mutableStateOf(false) }
-
                 Box(modifier = Modifier.fillMaxWidth()) {
                     OutlinedTextField(
                         value = inputText,
@@ -513,54 +532,6 @@ internal fun agenticRunArea(
                         maxLines = 10,
                         colors = AppColors.outlinedTextFieldColors(),
                     )
-
-                    // ── Model selector — overlaid inside the field, bottom-left ────────
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.BottomStart)
-                            .padding(bottom = 6.dp, start = 8.dp),
-                    ) {
-                        Surface(
-                            shape = MaterialTheme.shapes.small,
-                            color = AppColors.surfaceColor(AppColors.Elevation.EMPHASIS),
-                            border = BorderStroke(1.dp, AppColors.codeBlockBorderColor()),
-                            modifier = Modifier
-                                .clickable(enabled = !viewModel.isRunning, onClick = { modelDropdownExpanded = true })
-                                .pointerHoverIcon(PointerIcon.Hand),
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                            ) {
-                                Text(
-                                    text = stringResource("agents.agentic.model.default"),
-                                    style = AppTextStyles.hint,
-                                )
-                                Icon(
-                                    Icons.Default.ExpandMore,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(12.dp),
-                                    tint = AppColors.secondaryIconColor(),
-                                )
-                            }
-                        }
-                        dropdownMenu(
-                            expanded = modelDropdownExpanded,
-                            onDismissRequest = { modelDropdownExpanded = false },
-                        ) {
-                            DropdownMenuItem(
-                                text = {
-                                    Text(
-                                        text = stringResource("agents.agentic.model.default"),
-                                        style = AppTextStyles.body,
-                                    )
-                                },
-                                onClick = { modelDropdownExpanded = false },
-                                modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
-                            )
-                        }
-                    }
 
                     // ── Agent picker + Send — overlaid bottom-right ──
                     Row(
@@ -655,19 +626,28 @@ internal fun agenticRunArea(
                             }
                         }
 
-                        // Send button
+                        // Send / Stop button — while a turn is running this becomes an active
+                        // "Stop" control (previously just a disabled decorative Refresh icon)
+                        // so the user can interrupt a long-running/stuck agent process.
                         IconButton(
-                            onClick = { sendMessage() },
-                            enabled = viewModel.selectedAgentReady && inputText.text.isNotBlank() && !viewModel.isRunning,
+                            onClick = {
+                                if (viewModel.isRunning) {
+                                    viewModel.cancelRun()
+                                } else {
+                                    sendMessage()
+                                }
+                            },
+                            enabled = viewModel.isRunning ||
+                                (viewModel.selectedAgentReady && inputText.text.isNotBlank()),
                             colors = AppColors.primaryIconButtonColors(),
                             modifier = Modifier
                                 .size(36.dp)
                                 .pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             Icon(
-                                imageVector = if (viewModel.isRunning) Icons.Default.Refresh else Icons.Default.PlayArrow,
+                                imageVector = if (viewModel.isRunning) Icons.Default.Stop else Icons.Default.PlayArrow,
                                 contentDescription = if (viewModel.isRunning) {
-                                    stringResource("agents.view.running")
+                                    stringResource("agents.view.stop")
                                 } else {
                                     stringResource("agents.agentic.run")
                                 },

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
@@ -243,6 +243,38 @@ internal class AgentRunViewModel(
             if (isRunning) {
                 log.warn("Agent run did not finalize within 8s of cancel(); forcing job cancellation")
                 currentRunJob?.cancel()
+                val finalizedMessageId = "ai-${System.nanoTime()}"
+                messages = messages
+                    .ensureStreamingAiMessage()
+                    .finalizeStreamingAiMessage(
+                        finalContent = currentTurnResponse,
+                        isFailed = false,
+                        messageId = finalizedMessageId,
+                        isCancelled = true,
+                    )
+                if (timeline.isNotEmpty()) {
+                    completedGroups = completedGroups + (finalizedMessageId to timeline.grouped())
+                }
+                val forcedConversationId = activeConversationId
+                val forcedResponse = currentTurnResponse
+                scope.launch(Dispatchers.IO) {
+                    historyRepo.save(
+                        AgentRunRecord(
+                            workspaceId = workspace.id,
+                            conversationId = forcedConversationId,
+                            title = conversationTitle ?: TitleGenerator.fallbackTitle(forcedResponse),
+                            userInput = messages.lastOrNull { it.isUser }?.content.orEmpty(),
+                            response = forcedResponse,
+                            error = null,
+                            isCancelled = true,
+                            agentId = agent.id,
+                            agentSessionId = activeAgentSessionId,
+                            activityLog = timeline.collapsedEffectiveTools().filterIsInstance<TurnTimelineEntry.Tool>().map { it.toolCall.toolName },
+                            contentBlocks = timeline.collapsedEffectiveTools().filter { it is TurnTimelineEntry.Tool || it is TurnTimelineEntry.Token },
+                        ),
+                    )
+                    onRunCompleted()
+                }
                 isRunning = false
                 isWaitingForFirstEvent = false
                 runningAgent = null

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
@@ -239,7 +239,7 @@ internal class AgentRunViewModel(
         }
         cancelTimeoutJob?.cancel()
         cancelTimeoutJob = scope.launch {
-            delay(8_000)
+            delay(8_000.milliseconds)
             if (isRunning) {
                 log.warn("Agent run did not finalize within 8s of cancel(); forcing job cancellation")
                 currentRunJob?.cancel()
@@ -248,6 +248,10 @@ internal class AgentRunViewModel(
                 runningAgent = null
                 currentRunJob = null
             }
+            // Clear this job reference regardless of whether the branch above fired, so state
+            // stays consistent with the normal completion path (which also nulls it out) instead
+            // of leaving a reference to an already-completed job hanging around.
+            cancelTimeoutJob = null
         }
     }
 
@@ -550,19 +554,20 @@ internal class AgentRunViewModel(
     }
 
     /**
-     * Cancels every coroutine owned by this instance (title-event collection, in-flight runs,
-     * the elapsed-timer ticker). This instance owns its own [CoroutineScope] rather than
-     * borrowing the composable's `rememberCoroutineScope()` — that scope outlives any single
-     * instance, so reusing it would leak this instance's coroutines whenever a workspace switch
-     * causes `agenticRunArea`'s `remember(workspace.id)` to replace it with a new one. Callers
-     * must invoke this (e.g. `DisposableEffect(viewModel) { onDispose { viewModel.close() } }`)
-     * once this instance is discarded.
+     * Cancels every coroutine this instance owns (title events, in-flight runs, the elapsed
+     * timer). Owns its own [CoroutineScope] instead of the composable's `rememberCoroutineScope()`
+     * — that scope outlives a single instance, so reusing it would leak coroutines whenever a
+     * workspace switch replaces this instance (see `agenticRunArea`'s `remember(workspace.id)`).
+     * Callers must invoke this on disposal, e.g. `DisposableEffect(viewModel) { onDispose { viewModel.close() } }`.
      */
     fun close() {
-        // Cancelling the scope alone would abandon the coroutine but leave the underlying OS
-        // process (if any) running as an orphan — e.g. a workspace switch away from an active
-        // run. Kill it explicitly first, same as a user-initiated cancelRun().
-        runningAgent?.cancel()
+        // Kill any orphaned OS process, same as cancelRun(). Runs on a plain thread (not
+        // scope.launch, since scope.cancel() below would race with/abandon it) because this is
+        // invoked synchronously from onDispose on the UI thread, and cancel() can block a few
+        // seconds — fire-and-forget, we don't wait for it.
+        runningAgent?.let { agent ->
+            Thread({ agent.cancel() }, "agent-run-close-cancel").apply { isDaemon = true }.start()
+        }
         scope.cancel()
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
@@ -7,6 +7,7 @@ package io.askimo.ui.agent
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import io.askimo.core.agent.AgentCancelledException
 import io.askimo.core.agent.AgentReadiness
 import io.askimo.core.agent.AgentUsage
 import io.askimo.core.agent.ExternalAgent
@@ -58,6 +59,7 @@ private fun List<ChatMessageDTO>.finalizeStreamingAiMessage(
     isFailed: Boolean,
     usage: AgentUsage? = null,
     messageId: String = "ai-${System.nanoTime()}",
+    isCancelled: Boolean = false,
 ): List<ChatMessageDTO> {
     val idx = indexOfLast { !it.isUser && it.id == null }
     if (idx < 0) return this
@@ -65,7 +67,10 @@ private fun List<ChatMessageDTO>.finalizeStreamingAiMessage(
         id = messageId,
         content = finalContent,
         timestamp = Instant.now(),
-        isFailed = isFailed,
+        // A cancelled turn is never also "failed" — it's a deliberate user action, not an
+        // error, and should render with a neutral "Cancelled" label instead of the retry icon.
+        isFailed = isFailed && !isCancelled,
+        isCancelled = isCancelled,
         inputTokens = usage?.inputTokens,
         outputTokens = usage?.outputTokens,
         totalTokens = usage?.totalTokens,
@@ -200,6 +205,52 @@ internal class AgentRunViewModel(
     private var currentTurnResponse = ""
     private var elapsedTimerJob: Job? = null
 
+    // The agent instance actually running the current turn, and the coroutine `Job` executing
+    // it — both needed by `cancelRun()`. `runningAgent` may differ transiently from
+    // `selectedAgent` only in theory (selection is locked once a turn starts, see
+    // `isAgentSelectionLocked`), but kept separate so cancellation never depends on selection
+    // state still matching what's actually in flight.
+    private var runningAgent: ExternalAgent? = null
+    private var currentRunJob: Job? = null
+
+    // Safety-net timer started by cancelRun() — forces UI state back to "not running" if
+    // executeAgentic's coroutine somehow never observes the cancellation and finalizes on its
+    // own (e.g. the OS process refuses to die). Cancelled once the run finishes normally.
+    private var cancelTimeoutJob: Job? = null
+
+    /**
+     * Best-effort request to stop the turn currently in flight. Delegates to
+     * [ExternalAgent.cancel] (kills the OS process) off the calling thread, since that can
+     * block for a few seconds. No-op if nothing is running.
+     *
+     * Does **not** cancel [currentRunJob] directly — that would abort [executeAgentic]'s
+     * coroutine before it can set [isRunning] to `false` and finalize/persist the turn,
+     * leaving the UI stuck as "running" forever. Instead, killing the process makes `run()`
+     * return a failure wrapping [AgentCancelledException], which [executeAgentic] handles via
+     * its normal completion path (tagged `isCancelled = true`). The timeout below is only a
+     * last-resort fallback in case that path is somehow never reached.
+     */
+    fun cancelRun() {
+        if (!isRunning) return
+        val agent = runningAgent ?: return
+        log.debug("Cancel requested for active agent run (agent={})", agent.id)
+        scope.launch(Dispatchers.IO) {
+            agent.cancel()
+        }
+        cancelTimeoutJob?.cancel()
+        cancelTimeoutJob = scope.launch {
+            delay(8_000)
+            if (isRunning) {
+                log.warn("Agent run did not finalize within 8s of cancel(); forcing job cancellation")
+                currentRunJob?.cancel()
+                isRunning = false
+                isWaitingForFirstEvent = false
+                runningAgent = null
+                currentRunJob = null
+            }
+        }
+    }
+
     init {
         refreshAgentStates()
         observeTitleEvents()
@@ -257,6 +308,7 @@ internal class AgentRunViewModel(
                     isUser = false,
                     timestamp = r.createdAt,
                     isFailed = r.error != null,
+                    isCancelled = r.isCancelled,
                     inputTokens = r.inputTokens,
                     outputTokens = r.outputTokens,
                     totalTokens = r.totalTokens,
@@ -325,7 +377,8 @@ internal class AgentRunViewModel(
 
         startElapsedTimer()
 
-        scope.launch {
+        runningAgent = agent
+        currentRunJob = scope.launch {
             val result = withContext(Dispatchers.IO) {
                 // Materialize every skill in the catalog into the agent's own native
                 // skill-discovery location (e.g. Claude Code's `.claude/skills/<name>/`) so its
@@ -368,19 +421,33 @@ internal class AgentRunViewModel(
                         },
                     )
                 } finally {
+                    // Cleanup runs regardless of whether the turn completed, failed, or was
+                    // cancelled — it's independent of the agent process's outcome.
                     materialized.forEach { it.close() }
                 }
             }
             // Update state on the same coroutine, right after the run completes, so the
             // error (if any) is guaranteed to be captured before we build the history record
             // below — no race with a separately-launched coroutine.
-            val errorText = result.exceptionOrNull()?.message
+            val exception = result.exceptionOrNull()
+            val isCancelled = exception is AgentCancelledException
+            // A cancellation is a deliberate user action, not a failure — never surface it via
+            // the same error path a genuine failure would take.
+            val errorText = exception?.message?.takeIf { !isCancelled }
             isRunning = false
             isWaitingForFirstEvent = false
+            runningAgent = null
+            currentRunJob = null
+            // Normal completion path reached — the cancelRun() safety net (if one was started)
+            // is no longer needed.
+            cancelTimeoutJob?.cancel()
+            cancelTimeoutJob = null
 
             // Capture (or keep) the session id so the next follow-up turn can resume this
-            // exact conversation. Falls back to the id we resumed with in case this agent's
-            // CLI doesn't re-emit one on every turn.
+            // exact conversation — including after a cancellation, since the underlying CLI
+            // session may already have been established before the process was killed. Falls
+            // back to the id we resumed with in case this agent's CLI doesn't re-emit one on
+            // every turn.
             activeAgentSessionId = agent.lastExecutionSessionId ?: resumeSessionId
 
             // Best-effort token usage / duration reported by the agent's own stream for this
@@ -389,7 +456,8 @@ internal class AgentRunViewModel(
             val usage = agent.lastExecutionUsage
 
             // Guarantee a bubble exists even if the run failed before any token/tool/thinking
-            // event arrived, then finalize it (stable id, failure flag) so it stops "streaming".
+            // event arrived, then finalize it (stable id, failure/cancelled flag) so it stops
+            // "streaming".
             val finalizedMessageId = "ai-${System.nanoTime()}"
             messages = messages
                 .ensureStreamingAiMessage()
@@ -398,6 +466,7 @@ internal class AgentRunViewModel(
                     isFailed = errorText != null,
                     usage = usage,
                     messageId = finalizedMessageId,
+                    isCancelled = isCancelled,
                 )
             // Keep this turn's ordered tool/thinking/text trail visible for the rest of the
             // session (all kinds, including thinking) — in memory only, never written to
@@ -413,6 +482,7 @@ internal class AgentRunViewModel(
                 userInput = input,
                 response = currentTurnResponse,
                 error = errorText,
+                isCancelled = isCancelled,
                 agentId = agent.id,
                 agentSessionId = activeAgentSessionId,
                 activityLog = timeline.collapsedEffectiveTools().filterIsInstance<TurnTimelineEntry.Tool>().map { it.toolCall.toolName },
@@ -489,6 +559,10 @@ internal class AgentRunViewModel(
      * once this instance is discarded.
      */
     fun close() {
+        // Cancelling the scope alone would abandon the coroutine but leave the underlying OS
+        // process (if any) running as an orphan — e.g. a workspace switch away from an active
+        // run. Kill it explicitly first, same as a user-initiated cancelRun().
+        runningAgent?.cancel()
         scope.cancel()
     }
 }

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -1012,6 +1012,19 @@ private fun aiMessageBubble(
                                         modifier = Modifier.padding(start = Spacing.medium, end = Spacing.medium, bottom = Spacing.small, top = Spacing.extraSmall),
                                     )
                                 }
+
+                                // Neutral marker for an agentic turn the user stopped mid-flight
+                                // (ExternalAgent.cancel) — deliberately distinct from the failed
+                                // retry-icon state below: no retry action, no error color.
+                                if (message.isCancelled) {
+                                    Text(
+                                        text = stringResource("agents.agentic.cancelled"),
+                                        style = AppTextStyles.hint,
+                                        color = AppColors.secondaryIconColor(),
+                                        fontStyle = FontStyle.Italic,
+                                        modifier = Modifier.padding(start = Spacing.medium, end = Spacing.medium, bottom = Spacing.small, top = Spacing.extraSmall),
+                                    )
+                                }
                             }
                         }
                     }

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1612,6 +1612,7 @@ agents.view.description=Run an AI agent ({0}) directly on your machine. The agen
 agents.view.empty.search=No skills match your search
 agents.view.manage=Manage Skills
 agents.view.running=Running…
+agents.view.stop=Stop
 agents.view.no.agent=No agent installed
 agents.view.agent.not.installed=Not installed
 agents.view.agent.locked=Agent is locked for this conversation — start a new chat to switch agents

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=Back to history
 
 # Agentic run mode
 agents.agentic.run=Run
+agents.agentic.cancelled=Cancelled
 agents.agentic.goal.placeholder=Describe your goal — the agent will select the right skills automatically…
 agents.agentic.skills.available={0} skills available as agent context
 agents.agentic.no.skills.hint=No custom skills — the agent uses its own built-in capabilities. Add skills in Settings → Agents & Skills to extend it with your own.
-agents.agentic.model.default=Default model
 
 # Onboarding Wizard
 onboarding.title=Welcome to Askimo

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1612,6 +1612,7 @@ agents.view.description=Führe einen KI-Agenten ({0}) direkt auf deinem Computer
 agents.view.empty.search=Keine Skills gefunden
 agents.view.manage=Skills verwalten
 agents.view.running=Läuft…
+agents.view.stop=Stopp
 agents.view.no.agent=Kein Agent installiert
 agents.view.agent.not.installed=Nicht installiert
 agents.view.agent.locked=Der Agent ist für diese Unterhaltung gesperrt — starten Sie einen neuen Chat, um den Agenten zu wechseln

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=Zurück zum Verlauf
 
 # Agentic run mode
 agents.agentic.run=Ausführen
+agents.agentic.cancelled=Abgebrochen
 agents.agentic.goal.placeholder=Beschreibe dein Ziel — der Agent wählt automatisch die passenden Skills aus…
 agents.agentic.skills.available={0} Skills als Agentenkontext verfügbar
 agents.agentic.no.skills.hint=Keine eigenen Skills — der Agent nutzt seine eingebauten Fähigkeiten. Füge unter Einstellungen → Agenten & Skills eigene Skills hinzu.
-agents.agentic.model.default=Standardmodell
 
 # Onboarding Wizard
 onboarding.title=Willkommen bei Askimo

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1612,6 +1612,7 @@ agents.view.description=Ejecuta un agente de IA ({0}) directamente en tu máquin
 agents.view.empty.search=Ningún skill coincide con tu búsqueda
 agents.view.manage=Gestionar skills
 agents.view.running=Ejecutando…
+agents.view.stop=Detener
 agents.view.no.agent=No hay agente instalado
 agents.view.agent.not.installed=No instalado
 agents.view.agent.locked=El agente está bloqueado para esta conversación — inicia un nuevo chat para cambiar de agente

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=Volver al historial
 
 # Agentic run mode
 agents.agentic.run=Ejecutar
+agents.agentic.cancelled=Cancelado
 agents.agentic.goal.placeholder=Describe tu objetivo — el agente seleccionará automáticamente los skills adecuados…
 agents.agentic.skills.available={0} skills disponibles como contexto del agente
 agents.agentic.no.skills.hint=Sin skills personalizados — el agente usa sus capacidades integradas. Añade skills en Ajustes → Agentes & Skills para ampliarlo.
-agents.agentic.model.default=Modelo predeterminado
 
 # Onboarding Wizard
 onboarding.title=Bienvenido a Askimo

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1612,6 +1612,7 @@ agents.view.description=Exécutez un agent IA ({0}) directement sur votre machin
 agents.view.empty.search=Aucun skill ne correspond à votre recherche
 agents.view.manage=Gérer les skills
 agents.view.running=En cours…
+agents.view.stop=Arrêter
 agents.view.no.agent=Aucun agent installé
 agents.view.agent.not.installed=Non installé
 agents.view.agent.locked=L'agent est verrouillé pour cette conversation — démarrez une nouvelle discussion pour changer d'agent

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=Retour à l'historique
 
 # Agentic run mode
 agents.agentic.run=Exécuter
+agents.agentic.cancelled=Annulé
 agents.agentic.goal.placeholder=Décrivez votre objectif — l'agent sélectionnera automatiquement les skills appropriés…
 agents.agentic.skills.available={0} skills disponibles comme contexte pour l'agent
 agents.agentic.no.skills.hint=Aucun skill personnalisé — l'agent utilise ses capacités intégrées. Ajoutez des skills dans Paramètres → Agents & Skills pour l'enrichir.
-agents.agentic.model.default=Modèle par défaut
 
 # Onboarding Wizard
 onboarding.title=Bienvenue sur Askimo

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1612,6 +1612,7 @@ agents.view.description=AI エージェント（{0}）をマシン上で直接�
 agents.view.empty.search=検索に一致するスキルがありません
 agents.view.manage=スキルを管理
 agents.view.running=実行中…
+agents.view.stop=停止
 agents.view.no.agent=エージェントがインストールされていません
 agents.view.agent.not.installed=未インストール
 agents.view.agent.locked=この会話ではエージェントがロックされています — エージェントを切り替えるには新しいチャットを開始してください

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=履歴に戻る
 
 # Agentic run mode
 agents.agentic.run=実行
+agents.agentic.cancelled=キャンセル済み
 agents.agentic.goal.placeholder=目標を説明してください — エージェントが適切なスキルを自動的に選択します…
 agents.agentic.skills.available={0} 個のスキルがエージェントのコンテキストとして利用可能
 agents.agentic.no.skills.hint=カスタムスキルなし — エージェントは組み込みの機能を使用します。設定 → エージェント & スキル でカスタムスキルを追加して拡張できます。
-agents.agentic.model.default=デフォルトモデル
 
 # Onboarding Wizard
 onboarding.title=Askimoへようこそ

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=기록으로 돌아가기
 
 # Agentic run mode
 agents.agentic.run=실행
+agents.agentic.cancelled=취소됨
 agents.agentic.goal.placeholder=목표를 설명하세요 — 에이전트가 적합한 스킬을 자동으로 선택합니다…
 agents.agentic.skills.available={0}개의 스킬이 에이전트 컨텍스트로 제공됩니다
 agents.agentic.no.skills.hint=커스텀 스킬 없음 — 에이전트는 자체 내장 기능을 사용합니다. 설정 → 에이전트 & 스킬에서 커스텀 스킬을 추가하여 확장할 수 있습니다.
-agents.agentic.model.default=기본 모델
 
 # Onboarding Wizard
 onboarding.title=Askimo에 오신 것을 환영합니다

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1612,6 +1612,7 @@ agents.view.description=AI 에이전트({0})를 내 컴퓨터에서 직접 실�
 agents.view.empty.search=검색과 일치하는 스킬이 없습니다
 agents.view.manage=스킬 관리
 agents.view.running=실행 중…
+agents.view.stop=중지
 agents.view.no.agent=설치된 에이전트가 없습니다
 agents.view.agent.not.installed=설치되지 않음
 agents.view.agent.locked=이 대화에서는 에이전트가 잠겨 있습니다 — 에이전트를 변경하려면 새 채팅을 시작하세요

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=Voltar ao histórico
 
 # Agentic run mode
 agents.agentic.run=Executar
+agents.agentic.cancelled=Cancelado
 agents.agentic.goal.placeholder=Descreva seu objetivo — o agente selecionará automaticamente os skills adequados…
 agents.agentic.skills.available={0} skills disponíveis como contexto do agente
 agents.agentic.no.skills.hint=Sem skills personalizados — o agente usa suas capacidades integradas. Adicione skills em Configurações → Agentes & Skills para estendê-lo.
-agents.agentic.model.default=Modelo padrão
 
 # Onboarding Wizard
 onboarding.title=Bem-vindo ao Askimo

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1612,6 +1612,7 @@ agents.view.description=Execute um agente de IA ({0}) diretamente na sua máquin
 agents.view.empty.search=Nenhum skill corresponde à sua pesquisa
 agents.view.manage=Gerenciar skills
 agents.view.running=Executando…
+agents.view.stop=Parar
 agents.view.no.agent=Nenhum agente instalado
 agents.view.agent.not.installed=Não instalado
 agents.view.agent.locked=O agente está bloqueado para esta conversa — inicie um novo chat para trocar de agente

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=Quay lại lịch sử
 
 # Agentic run mode
 agents.agentic.run=Chạy
+agents.agentic.cancelled=Đã hủy
 agents.agentic.goal.placeholder=Mô tả mục tiêu của bạn — trợ lý sẽ tự động chọn kỹ năng phù hợp…
 agents.agentic.skills.available={0} kỹ năng khả dụng làm ngữ cảnh cho trợ lý
 agents.agentic.no.skills.hint=Không có kỹ năng tùy chỉnh — trợ lý sử dụng các khả năng tích hợp sẵn. Thêm kỹ năng trong Cài đặt → Trợ lý & Kỹ năng để mở rộng.
-agents.agentic.model.default=Mô hình mặc định
 
 # Onboarding Wizard
 onboarding.title=Chào mừng đến với Askimo

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1612,6 +1612,7 @@ agents.view.description=Chạy trợ lý AI ({0}) trực tiếp trên máy của
 agents.view.empty.search=Không có kỹ năng nào khớp với tìm kiếm của bạn
 agents.view.manage=Quản lý kỹ năng
 agents.view.running=Đang chạy…
+agents.view.stop=Dừng
 agents.view.no.agent=Chưa cài đặt trợ lý nào
 agents.view.agent.not.installed=Chưa cài đặt
 agents.view.agent.locked=Trợ lý đã bị khóa cho cuộc trò chuyện này — hãy bắt đầu cuộc trò chuyện mới để đổi trợ lý

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1612,6 +1612,7 @@ agents.view.description=直接在您的机器上运行 AI 智能体（{0}）。�
 agents.view.empty.search=没有与搜索匹配的技能
 agents.view.manage=管理技能
 agents.view.running=运行中…
+agents.view.stop=停止
 agents.view.no.agent=未安装智能体
 agents.view.agent.not.installed=未安装
 agents.view.agent.locked=此对话已锁定智能体 — 请开始新对话以切换智能体

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=返回历史记录
 
 # Agentic run mode
 agents.agentic.run=运行
+agents.agentic.cancelled=已取消
 agents.agentic.goal.placeholder=描述您的目标——智能体将自动选择合适的技能…
 agents.agentic.skills.available={0} 个技能可用作智能体上下文
 agents.agentic.no.skills.hint=暂无自定义技能——智能体将使用其内置能力。您可在设置 → 智能体与技能中添加自定义技能来扩展它。
-agents.agentic.model.default=默认模型
 
 # Onboarding Wizard
 onboarding.title=欢迎使用 Askimo

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1612,6 +1612,7 @@ agents.view.description=直接在您的機器上執行 AI 智能體（{0}）。�
 agents.view.empty.search=沒有符合搜尋的技能
 agents.view.manage=管理技能
 agents.view.running=執行中…
+agents.view.stop=停止
 agents.view.no.agent=未安裝智能體
 agents.view.agent.not.installed=未安裝
 agents.view.agent.locked=此對話已鎖定智能體 — 請開始新對話以切換智能體

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1649,10 +1649,10 @@ agents.view.back.to.history=返回歷史記錄
 
 # Agentic run mode
 agents.agentic.run=執行
+agents.agentic.cancelled=已取消
 agents.agentic.goal.placeholder=描述您的目標——智能體將自動選擇合適的技能…
 agents.agentic.skills.available={0} 個技能可用作智能體上下文
 agents.agentic.no.skills.hint=尚無自訂技能——智能體將使用其內建能力。您可在設定 → 智能體與技能中新增自訂技能來擴充它。
-agents.agentic.model.default=預設模型
 
 # Onboarding Wizard
 onboarding.title=歡迎使用 Askimo

--- a/shared/src/main/kotlin/io/askimo/core/agent/AgentCancelledException.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/AgentCancelledException.kt
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.agent
+
+/**
+ * Thrown internally by [ExternalAgentTemplate.run] when the in-flight process was terminated
+ * via [ExternalAgent.cancel] rather than exiting on its own (successfully or with a genuine
+ * error). Wrapped in the [Result.failure] returned by `run`/`runTracked` — callers (e.g.
+ * `AgentRunViewModel`) should check for this type to render a "Cancelled" state instead of
+ * treating the turn as failed.
+ */
+class AgentCancelledException(message: String = "Cancelled by user") : Exception(message)

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgent.kt
@@ -148,6 +148,26 @@ interface ExternalAgent {
     fun saveApiKey(key: String) {}
 
     /**
+     * Best-effort request to terminate the turn currently in flight inside [run]/[runTracked],
+     * if any. Safe to call even when nothing is running (no-op in that case) — callers don't
+     * need to track whether a run is active before invoking this.
+     *
+     * Implementations should gracefully terminate the underlying OS process (e.g. `SIGTERM`
+     * then `SIGKILL` after a short grace period) so child processes it spawned (shell commands,
+     * etc.) get a chance to exit cleanly. Once cancelled, [run] returns a [Result.failure]
+     * wrapping [AgentCancelledException] rather than a generic exit-code error, so callers can
+     * distinguish "the user stopped this" from a genuine failure.
+     *
+     * Cancellation does not discard [lastExecutionSessionId] — whatever session id this agent's
+     * CLI reported before being killed remains valid, so a follow-up turn can still resume the
+     * same underlying conversation.
+     *
+     * Default implementation is a no-op — override in agents backed by [ExternalAgentTemplate],
+     * which already implements this for every subclass.
+     */
+    fun cancel() {}
+
+    /**
      * Runs the skill non-interactively.
      *
      * The agent receives the combined prompt via **stdin**:

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
@@ -353,7 +353,13 @@ abstract class ExternalAgentTemplate : ExternalAgent {
      */
     private fun terminateProcess(process: Process) {
         process.destroy()
-        if (!process.waitFor(3, TimeUnit.SECONDS)) {
+        val exitedInTime = try {
+            process.waitFor(3, TimeUnit.SECONDS)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            false
+        }
+        if (!exitedInTime) {
             log.debug("{} did not exit after destroy(); escalating to destroyForcibly()", id)
             process.destroyForcibly()
         }

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
@@ -15,6 +15,7 @@ import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Template base class for external CLI agents implementing the standard execution flow:
@@ -52,9 +53,12 @@ abstract class ExternalAgentTemplate : ExternalAgent {
     @Volatile
     private var currentProcess: Process? = null
 
-    /** Set by [cancel] before killing [currentProcess], so [run] can distinguish this from a genuine process failure. */
-    @Volatile
-    private var cancelRequested: Boolean = false
+    /**
+     * Set by [cancel] before killing [currentProcess], so [run] can distinguish this from a
+     * genuine process failure. Uses [AtomicBoolean] so [run]'s capture-then-clear on start is
+     * an atomic read-and-clear, not two racy steps that could drop a concurrent cancel().
+     */
+    private val cancelRequested = AtomicBoolean(false)
 
     override val lastExecutionSessionId: String?
         get() = executionSessionId
@@ -375,7 +379,7 @@ abstract class ExternalAgentTemplate : ExternalAgent {
      * see it. No-op (beyond recording intent) if nothing is currently tracked.
      */
     override fun cancel() {
-        cancelRequested = true
+        cancelRequested.set(true)
         val process = currentProcess ?: return
         if (!process.isAlive) return
         log.debug("Cancel requested for {} (pid={})", id, runCatching { process.pid() }.getOrNull())
@@ -401,11 +405,9 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         resultErrorMessage = null
         executionUsage = null
         // Capture-then-clear instead of a plain reset: a Stop click can land before this run()
-        // call is reached (e.g. while skills are still being materialized), setting
-        // cancelRequested with no process yet to kill. A plain reset would silently drop that
-        // request; capturing it first lets us abort below, while still clearing it for next time.
-        val cancelledBeforeStart = cancelRequested
-        cancelRequested = false
+        // call is reached (e.g. while skills are still being materialized). getAndSet(false)
+        // does this atomically so a concurrent cancel() can't be clobbered by our own clear.
+        val cancelledBeforeStart = cancelRequested.getAndSet(false)
         if (cancelledBeforeStart) {
             log.debug("{} cancel() was requested before this run started; aborting immediately", id)
             throw AgentCancelledException()
@@ -432,7 +434,7 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         // Honor a Stop click that landed in the tiny window between start() above and this
         // assignment — cancel() would have set cancelRequested but found currentProcess still
         // null/stale, so it couldn't terminate this process itself.
-        if (cancelRequested) {
+        if (cancelRequested.get()) {
             log.debug("{} cancel() was requested before process tracking began; terminating immediately", id)
             terminateProcess(process)
         }
@@ -500,7 +502,7 @@ abstract class ExternalAgentTemplate : ExternalAgent {
             // cancel() killed this process on purpose — report a distinct cancellation outcome
             // instead of a generic "exited with code N" error, regardless of the actual exit
             // code or any resultErrorMessage the partial output may have triggered.
-            if (cancelRequested) {
+            if (cancelRequested.get()) {
                 log.debug("{} run cancelled by user (exit code {})", id, exitCode)
                 throw AgentCancelledException()
             }
@@ -537,7 +539,7 @@ abstract class ExternalAgentTemplate : ExternalAgent {
             output.toString().trimEnd()
         } finally {
             currentProcess = null
-            cancelRequested = false
+            cancelRequested.set(false)
         }
     }.onFailure { e ->
         if (e is AgentCancelledException) {

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
@@ -14,6 +14,7 @@ import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
+import java.util.concurrent.TimeUnit
 
 /**
  * Template base class for external CLI agents implementing the standard execution flow:
@@ -46,6 +47,14 @@ abstract class ExternalAgentTemplate : ExternalAgent {
 
     @Volatile
     private var resultErrorMessage: String? = null
+
+    /** The OS process for the run currently in flight, if any — see [cancel]. */
+    @Volatile
+    private var currentProcess: Process? = null
+
+    /** Set by [cancel] before killing [currentProcess], so [run] can distinguish this from a genuine process failure. */
+    @Volatile
+    private var cancelRequested: Boolean = false
 
     override val lastExecutionSessionId: String?
         get() = executionSessionId
@@ -336,6 +345,26 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         return found
     }
 
+    /**
+     * Terminates [currentProcess], if any, gracefully first (`Process.destroy()` — `SIGTERM`
+     * on Unix), giving it up to 3 seconds to exit on its own so any child processes it spawned
+     * (shell commands, etc.) can clean up, then forcibly (`Process.destroyForcibly()` —
+     * `SIGKILL`) if it's still alive. Sets [cancelRequested] first so [run] reports
+     * [AgentCancelledException] instead of a generic "exited with code N" error once the
+     * process actually exits. No-op if nothing is currently running.
+     */
+    override fun cancel() {
+        val process = currentProcess ?: return
+        if (!process.isAlive) return
+        log.debug("Cancel requested for {} (pid={})", id, runCatching { process.pid() }.getOrNull())
+        cancelRequested = true
+        process.destroy()
+        if (!process.waitFor(3, TimeUnit.SECONDS)) {
+            log.debug("{} did not exit after destroy(); escalating to destroyForcibly()", id)
+            process.destroyForcibly()
+        }
+    }
+
     override fun run(
         systemPrompt: String,
         userInput: String,
@@ -354,6 +383,7 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         updateExecutionMetadata(sessionId = resumeSessionId)
         resultErrorMessage = null
         executionUsage = null
+        cancelRequested = false
 
         log.debug(
             "Starting {} for skill execution ({} chars systemPrompt, workDir={}, resume={})",
@@ -372,95 +402,114 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         }
         configureProcess(processBuilder, workDir, effectiveWorkDir, systemPrompt, userInput)
         val process = processBuilder.start()
+        currentProcess = process
 
-        // Drain stderr in background to prevent blocking
-        val stderrOutput = StringBuilder()
-        val stderrThread = Thread {
-            process.errorStream.bufferedReader().forEachLine { line ->
-                log.debug("{} stderr: {}", id, line)
-                stderrOutput.appendLine(line)
-                onStderrLine(line, onStatus)
-            }
-        }.also {
-            it.isDaemon = true
-            it.start()
-        }
-
-        var stdinWriteError: IOException? = null
-
-        // Write stdin in a background thread so stdout draining starts immediately.
-        // For long agent runs the stdout pipe buffer (~64 KB) fills up fast; if we
-        // block on stdin first the agent can't write more output → deadlock → broken pipe.
-        val stdinThread = Thread {
-            try {
-                process.outputStream.bufferedWriter().use { writer ->
-                    writeStdin(writer, systemPrompt, userInput)
+        try {
+            // Drain stderr in background to prevent blocking
+            val stderrOutput = StringBuilder()
+            val stderrThread = Thread {
+                process.errorStream.bufferedReader().forEachLine { line ->
+                    log.debug("{} stderr: {}", id, line)
+                    stderrOutput.appendLine(line)
+                    onStderrLine(line, onStatus)
                 }
-            } catch (e: IOException) {
-                stdinWriteError = e
-                val isStillRunning = process.isAlive
-                val exitCode = if (!isStillRunning) process.exitValue() else -1
-                val errMsg = stderrOutput.toString().trim()
+            }.also {
+                it.isDaemon = true
+                it.start()
+            }
+
+            var stdinWriteError: IOException? = null
+
+            // Write stdin in a background thread so stdout draining starts immediately.
+            // For long agent runs the stdout pipe buffer (~64 KB) fills up fast; if we
+            // block on stdin first the agent can't write more output → deadlock → broken pipe.
+            val stdinThread = Thread {
+                try {
+                    process.outputStream.bufferedWriter().use { writer ->
+                        writeStdin(writer, systemPrompt, userInput)
+                    }
+                } catch (e: IOException) {
+                    stdinWriteError = e
+                    val isStillRunning = process.isAlive
+                    val exitCode = if (!isStillRunning) process.exitValue() else -1
+                    val errMsg = stderrOutput.toString().trim()
+                    log.debug(
+                        "Deferred stdin write error for {} (exit code: {}, running: {}): {} — stderr: {}",
+                        id,
+                        exitCode,
+                        isStillRunning,
+                        e.message,
+                        errMsg,
+                    )
+                    // Some CLIs close stdin early after consuming enough input — safe to ignore.
+                }
+            }.also {
+                it.isDaemon = true
+                it.name = "$id-stdin"
+                it.start()
+            }
+
+            // Parse stdout — runs on calling thread while stdin is written concurrently.
+            // If cancel() destroys the process mid-read, this loop simply ends (stream closes)
+            // rather than throwing — the cancelRequested check below is what reports it.
+            val output = StringBuilder()
+            process.inputStream.bufferedReader().forEachLine { line ->
+                if (line.isBlank()) return@forEachLine
+                parseStdoutLine(line, onToken, onToolCall, onStatus, onThinking, output)
+            }
+
+            // Wait for stdin to finish (it is almost always done by the time stdout is drained).
+            stdinThread.join(5_000)
+
+            val exitCode = process.waitFor()
+            stderrThread.join(2_000)
+
+            // cancel() killed this process on purpose — report a distinct cancellation outcome
+            // instead of a generic "exited with code N" error, regardless of the actual exit
+            // code or any resultErrorMessage the partial output may have triggered.
+            if (cancelRequested) {
+                log.debug("{} run cancelled by user (exit code {})", id, exitCode)
+                throw AgentCancelledException()
+            }
+
+            // An application-level failure reported by the agent's own stream (e.g. "Not logged
+            // in · Please run /login") is the most accurate error message we have — prefer it over
+            // a generic "exited with code N" message, regardless of the OS exit code.
+            resultErrorMessage?.let { errMsg ->
+                error(errMsg)
+            }
+
+            if (exitCode != 0) {
+                val errMsg = buildString {
+                    val stderr = filterErrorStderr(stderrOutput.toString())
+                    if (stderr.isNotBlank()) append(stderr)
+                    stdinWriteError?.message?.takeIf { it.isNotBlank() }?.let { writeErr ->
+                        if (isNotEmpty()) append("\n")
+                        append("stdin write error: ")
+                        append(writeErr)
+                    }
+                }.trim()
+                onProcessError(exitCode, errMsg)
+                error("$name exited with code $exitCode${if (errMsg.isNotBlank()) ": $errMsg" else ""}")
+            }
+
+            if (stdinWriteError != null) {
                 log.debug(
-                    "Deferred stdin write error for {} (exit code: {}, running: {}): {} — stderr: {}",
+                    "Ignoring stdin write error for {} because process exited successfully: {}",
                     id,
-                    exitCode,
-                    isStillRunning,
-                    e.message,
-                    errMsg,
+                    stdinWriteError.message,
                 )
-                // Some CLIs close stdin early after consuming enough input — safe to ignore.
             }
-        }.also {
-            it.isDaemon = true
-            it.name = "$id-stdin"
-            it.start()
+
+            output.toString().trimEnd()
+        } finally {
+            currentProcess = null
         }
-
-        // Parse stdout — runs on calling thread while stdin is written concurrently.
-        val output = StringBuilder()
-        process.inputStream.bufferedReader().forEachLine { line ->
-            if (line.isBlank()) return@forEachLine
-            parseStdoutLine(line, onToken, onToolCall, onStatus, onThinking, output)
-        }
-
-        // Wait for stdin to finish (it is almost always done by the time stdout is drained).
-        stdinThread.join(5_000)
-
-        val exitCode = process.waitFor()
-        stderrThread.join(2_000)
-
-        // An application-level failure reported by the agent's own stream (e.g. "Not logged
-        // in · Please run /login") is the most accurate error message we have — prefer it over
-        // a generic "exited with code N" message, regardless of the OS exit code.
-        resultErrorMessage?.let { errMsg ->
-            error(errMsg)
-        }
-
-        if (exitCode != 0) {
-            val errMsg = buildString {
-                val stderr = filterErrorStderr(stderrOutput.toString())
-                if (stderr.isNotBlank()) append(stderr)
-                stdinWriteError?.message?.takeIf { it.isNotBlank() }?.let { writeErr ->
-                    if (isNotEmpty()) append("\n")
-                    append("stdin write error: ")
-                    append(writeErr)
-                }
-            }.trim()
-            onProcessError(exitCode, errMsg)
-            error("$name exited with code $exitCode${if (errMsg.isNotBlank()) ": $errMsg" else ""}")
-        }
-
-        if (stdinWriteError != null) {
-            log.debug(
-                "Ignoring stdin write error for {} because process exited successfully: {}",
-                id,
-                stdinWriteError.message,
-            )
-        }
-
-        output.toString().trimEnd()
     }.onFailure { e ->
-        log.error("{} run failed: {}", name, e.message, e)
+        if (e is AgentCancelledException) {
+            log.debug("{} run cancelled: {}", name, e.message)
+        } else {
+            log.error("{} run failed: {}", name, e.message, e)
+        }
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
@@ -394,7 +394,16 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         updateExecutionMetadata(sessionId = resumeSessionId)
         resultErrorMessage = null
         executionUsage = null
+        // Capture-then-clear instead of a plain reset: a Stop click can land before this run()
+        // call is reached (e.g. while skills are still being materialized), setting
+        // cancelRequested with no process yet to kill. A plain reset would silently drop that
+        // request; capturing it first lets us abort below, while still clearing it for next time.
+        val cancelledBeforeStart = cancelRequested
         cancelRequested = false
+        if (cancelledBeforeStart) {
+            log.debug("{} cancel() was requested before this run started; aborting immediately", id)
+            throw AgentCancelledException()
+        }
 
         log.debug(
             "Starting {} for skill execution ({} chars systemPrompt, workDir={}, resume={})",
@@ -522,6 +531,7 @@ abstract class ExternalAgentTemplate : ExternalAgent {
             output.toString().trimEnd()
         } finally {
             currentProcess = null
+            cancelRequested = false
         }
     }.onFailure { e ->
         if (e is AgentCancelledException) {

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
@@ -346,23 +346,34 @@ abstract class ExternalAgentTemplate : ExternalAgent {
     }
 
     /**
-     * Terminates [currentProcess], if any, gracefully first (`Process.destroy()` — `SIGTERM`
-     * on Unix), giving it up to 3 seconds to exit on its own so any child processes it spawned
-     * (shell commands, etc.) can clean up, then forcibly (`Process.destroyForcibly()` —
-     * `SIGKILL`) if it's still alive. Sets [cancelRequested] first so [run] reports
-     * [AgentCancelledException] instead of a generic "exited with code N" error once the
-     * process actually exits. No-op if nothing is currently running.
+     * Shared termination sequence used by both [cancel] and the early-cancellation check in
+     * [run]: gracefully first (`Process.destroy()` — `SIGTERM` on Unix), giving the process up
+     * to 3 seconds to exit on its own so any child processes it spawned (shell commands, etc.)
+     * can clean up, then forcibly (`Process.destroyForcibly()` — `SIGKILL`) if it's still alive.
      */
-    override fun cancel() {
-        val process = currentProcess ?: return
-        if (!process.isAlive) return
-        log.debug("Cancel requested for {} (pid={})", id, runCatching { process.pid() }.getOrNull())
-        cancelRequested = true
+    private fun terminateProcess(process: Process) {
         process.destroy()
         if (!process.waitFor(3, TimeUnit.SECONDS)) {
             log.debug("{} did not exit after destroy(); escalating to destroyForcibly()", id)
             process.destroyForcibly()
         }
+    }
+
+    /**
+     * Requests termination of the run currently in flight, if any. Sets [cancelRequested]
+     * unconditionally *before* looking at [currentProcess] — not only so [run] reports
+     * [AgentCancelledException] instead of a generic "exited with code N" error, but so a Stop
+     * click landing in the brief window between [run] starting the OS process and assigning it
+     * to [currentProcess] is still honored: [run] checks [cancelRequested] again immediately
+     * after that assignment and terminates the process itself if this method ran too early to
+     * see it. No-op (beyond recording intent) if nothing is currently tracked.
+     */
+    override fun cancel() {
+        cancelRequested = true
+        val process = currentProcess ?: return
+        if (!process.isAlive) return
+        log.debug("Cancel requested for {} (pid={})", id, runCatching { process.pid() }.getOrNull())
+        terminateProcess(process)
     }
 
     override fun run(
@@ -403,6 +414,13 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         configureProcess(processBuilder, workDir, effectiveWorkDir, systemPrompt, userInput)
         val process = processBuilder.start()
         currentProcess = process
+        // Honor a Stop click that landed in the tiny window between start() above and this
+        // assignment — cancel() would have set cancelRequested but found currentProcess still
+        // null/stale, so it couldn't terminate this process itself.
+        if (cancelRequested) {
+            log.debug("{} cancel() was requested before process tracking began; terminating immediately", id)
+            terminateProcess(process)
+        }
 
         try {
             // Drain stderr in background to prevent blocking

--- a/shared/src/main/kotlin/io/askimo/core/agent/domain/AgentRunRecord.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/domain/AgentRunRecord.kt
@@ -96,7 +96,10 @@ object AgentRunHistoryTable : Table("agent_run_history") {
     val response = text("response").default("")
     val error = text("error").nullable()
 
-    /** See [AgentRunRecord.isCancelled]. Nullable/defaulted so older rows read as `false`. */
+    /**
+     * See [AgentRunRecord.isCancelled]. Non-null with a `DEFAULT 0` — the migration backfills
+     * older rows to `false` rather than leaving them nullable, so reads never need a null check.
+     */
     val isCancelled = bool("is_cancelled").default(false)
     val agentId = varchar("agent_id", 64).nullable()
     val agentSessionId = text("agent_session_id").nullable()

--- a/shared/src/main/kotlin/io/askimo/core/agent/domain/AgentRunRecord.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/domain/AgentRunRecord.kt
@@ -32,6 +32,11 @@ import java.util.UUID
  * @param userInput   The context/prompt entered by the user before executing.
  * @param response    The full AI-generated response text; empty if the run failed.
  * @param error       Error message if the run failed; null on success.
+ * @param isCancelled True if this turn was stopped mid-flight via [io.askimo.core.agent.ExternalAgent.cancel]
+ *                    rather than failing or completing normally. [error] is typically null in
+ *                    this case — cancellation is a deliberate user action, not a failure.
+ *                    Defaults to `false` for backward compatibility with rows recorded before
+ *                    this column existed.
  * @param agentId     Id of the [io.askimo.core.agent.ExternalAgent] that ran this turn (e.g.
  *                    "claude-code") — persisted so a re-opened conversation can restore (and
  *                    lock) the exact agent it was conducted with, instead of falling back to
@@ -61,6 +66,7 @@ data class AgentRunRecord(
     val userInput: String,
     val response: String,
     val error: String?,
+    val isCancelled: Boolean = false,
     val agentId: String? = null,
     val agentSessionId: String? = null,
     val activityLog: List<String>,
@@ -89,6 +95,9 @@ object AgentRunHistoryTable : Table("agent_run_history") {
     val userInput = text("user_input").default("")
     val response = text("response").default("")
     val error = text("error").nullable()
+
+    /** See [AgentRunRecord.isCancelled]. Nullable/defaulted so older rows read as `false`. */
+    val isCancelled = bool("is_cancelled").default(false)
     val agentId = varchar("agent_id", 64).nullable()
     val agentSessionId = text("agent_session_id").nullable()
 

--- a/shared/src/main/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/repository/AgentRunHistoryRepository.kt
@@ -48,6 +48,7 @@ class AgentRunHistoryRepository internal constructor(
                 it[userInput] = record.userInput
                 it[response] = record.response
                 it[error] = record.error
+                it[isCancelled] = record.isCancelled
                 it[agentId] = record.agentId
                 it[agentSessionId] = record.agentSessionId
                 it[activityLog] = encodeLog(record.activityLog)
@@ -158,6 +159,7 @@ class AgentRunHistoryRepository internal constructor(
         userInput = row[AgentRunHistoryTable.userInput],
         response = row[AgentRunHistoryTable.response],
         error = row[AgentRunHistoryTable.error],
+        isCancelled = row[AgentRunHistoryTable.isCancelled],
         agentId = row[AgentRunHistoryTable.agentId],
         agentSessionId = row[AgentRunHistoryTable.agentSessionId],
         activityLog = decodeLog(row[AgentRunHistoryTable.activityLog]),

--- a/shared/src/main/kotlin/io/askimo/core/chat/dto/ChatMessageDTO.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/dto/ChatMessageDTO.kt
@@ -20,6 +20,11 @@ data class ChatMessageDTO(
     val isEdited: Boolean = false,
     val attachments: List<FileAttachmentDTO> = emptyList(),
     val isFailed: Boolean = false,
+    // True when this AI turn was stopped mid-flight via ExternalAgent.cancel() rather than
+    // failing or completing normally — rendered distinctly from isFailed (no retry action,
+    // a neutral "Cancelled" label instead of an error state). Only ever set for agentic runs
+    // (see AgentRunViewModel); regular chat messages never set this.
+    val isCancelled: Boolean = false,
     val inputTokens: Int? = null,
     val outputTokens: Int? = null,
     val totalTokens: Int? = null,

--- a/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
+++ b/shared/src/main/kotlin/io/askimo/core/db/DatabaseManager.kt
@@ -764,6 +764,12 @@ class DatabaseManager private constructor(
             } catch (_: Exception) {
                 // Column already exists — safe to ignore.
             }
+
+            try {
+                stmt.executeUpdate("ALTER TABLE agent_run_history ADD COLUMN is_cancelled INTEGER NOT NULL DEFAULT 0")
+            } catch (_: Exception) {
+                // Column already exists — safe to ignore.
+            }
         }
     }
 


### PR DESCRIPTION
- Introduces a formal cancellation mechanism for agent runs.
- Adds `isCancelled` tracking across AgentRunRecord, ChatMessageDTO, and UI state.
- Updates core agent logic to handle cancellation exceptions gracefully instead of failing.
- Refactors UI to include a 'Stop' state for ongoing agent runs.
- Adds new cancellation status to multilingual resources.