### PR TITLE
feat(agent): Introduce dedicated message handling for agent runs

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentMessageList.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentMessageList.kt
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.ui.agent
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import io.askimo.core.agent.dto.AgentTurnMessageDTO
+import io.askimo.core.chat.dto.ChatMessageDTO
+import io.askimo.core.chat.dto.TurnTimelineGroup
+import io.askimo.ui.chat.messageBubble
+import io.askimo.ui.chat.turnTimelineView
+import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
+import io.askimo.ui.common.theme.AppTextStyles
+import io.askimo.ui.common.theme.Spacing
+
+/**
+ * Slim transcript renderer for agentic runs, built on the same shared [messageBubble]/
+ * [turnTimelineView] blocks as `ui.chat`'s `chatMessageList` but without any of the chat-only
+ * features (search/edit/retry/bookmark/fork/attachments/day-separators/voice-autoplay) agent
+ * conversations don't support. The *currently streaming* turn's timeline is rendered separately
+ * by the caller; this only needs [completedGroupsByMessageId] to redraw *finalized* turns.
+ *
+ * Takes [AgentTurnMessageDTO] and adapts each one to a `ChatMessageDTO` via [toRenderableMessage]
+ * so it can reuse the shared bubble/timeline composables.
+ */
+@Composable
+fun agentMessageList(
+    messages: List<AgentTurnMessageDTO>,
+    isThinking: Boolean = false,
+    thinkingElapsedSeconds: Int = 0,
+    completedGroupsByMessageId: Map<String, List<TurnTimelineGroup>> = emptyMap(),
+    userAvatarPainter: BitmapPainter? = null,
+    aiAvatarPainter: BitmapPainter? = null,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.extraLarge),
+    ) {
+        messages.forEachIndexed { index, turn ->
+            val message = turn.toRenderableMessage()
+            val isStreamingMessage = !message.isUser && message.id == null
+            val resolvedGroups: List<TurnTimelineGroup> = if (message.isUser) {
+                emptyList()
+            } else {
+                message.id?.let { completedGroupsByMessageId[it] } ?: emptyList()
+            }
+            val hasToolCalls = resolvedGroups.any { it is TurnTimelineGroup.ToolGroup }
+            val fallbackThinkingContent = if (!hasToolCalls) {
+                resolvedGroups
+                    .filterIsInstance<TurnTimelineGroup.ThinkingGroup>()
+                    .joinToString("") { it.text }
+            } else {
+                ""
+            }
+            messageBubble(
+                message = message,
+                userAvatarPainter = userAvatarPainter,
+                aiAvatarPainter = aiAvatarPainter,
+                addTopPadding = index == 0,
+                isStreaming = isStreamingMessage,
+                thinkingContent = fallbackThinkingContent,
+                customBody = if (!message.isUser && hasToolCalls) {
+                    { turnTimelineView(resolvedGroups, isStreaming = isStreamingMessage) }
+                } else {
+                    null
+                },
+            )
+        }
+
+        // Show "Thinking..." indicator when the agent is processing but hasn't returned a first
+        // token/tool-call/thinking event yet.
+        if (isThinking) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = Spacing.small),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start,
+            ) {
+                Text(
+                    text = stringResource("message.thinking", thinkingElapsedSeconds),
+                    style = AppTextStyles.bodySecondary,
+                    color = AppColors.secondaryIconColor(),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Adapts an [AgentTurnMessageDTO] to a [ChatMessageDTO] purely for reuse of the shared
+ * `messageBubble`/`turnTimelineView` rendering — every chat-only field (attachments, edit/
+ * bookmark/fork/outdated-branch state, persisted content blocks) is left at its default since
+ * agent turns never populate them; only the fields both types share are copied across.
+ */
+private fun AgentTurnMessageDTO.toRenderableMessage(): ChatMessageDTO = ChatMessageDTO(
+    id = id,
+    content = content,
+    isUser = isUser,
+    timestamp = timestamp,
+    isFailed = isFailed,
+    isCancelled = isCancelled,
+    inputTokens = inputTokens,
+    outputTokens = outputTokens,
+    totalTokens = totalTokens,
+    durationMs = durationMs,
+)

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunArea.kt
@@ -72,7 +72,6 @@ import io.askimo.core.agent.domain.SkillDefinition
 import io.askimo.core.agent.domain.Workspace
 import io.askimo.core.chat.dto.grouped
 import io.askimo.core.user.repository.UserProfileRepository
-import io.askimo.ui.chat.messageList
 import io.askimo.ui.chat.turnTimelineView
 import io.askimo.ui.common.i18n.stringResource
 import io.askimo.ui.common.keymap.KeyMapManager
@@ -450,9 +449,10 @@ internal fun agenticRunArea(
                         }
                     }
 
-                    // ── Conversation transcript — same components as ChatView ────────────
+                    // ── Conversation transcript — shared bubble/timeline building blocks with
+                    // ChatView, but a slimmer orchestration composable (see AgentMessageList.kt) ──
                     if (viewModel.messages.isNotEmpty() || viewModel.isRunning) {
-                        messageList(
+                        agentMessageList(
                             messages = viewModel.messages,
                             isThinking = viewModel.isWaitingForFirstEvent,
                             thinkingElapsedSeconds = viewModel.elapsedSeconds,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentRunViewModel.kt
@@ -15,10 +15,10 @@ import io.askimo.core.agent.ExternalAgentLoader
 import io.askimo.core.agent.domain.AgentRunRecord
 import io.askimo.core.agent.domain.SkillDefinition
 import io.askimo.core.agent.domain.Workspace
+import io.askimo.core.agent.dto.AgentTurnMessageDTO
 import io.askimo.core.agent.repository.AgentRunHistoryRepository
 import io.askimo.core.chat.TitleGenerator
 import io.askimo.core.chat.domain.SESSION_TITLE_MAX_LENGTH
-import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.dto.ToolCallStatus
 import io.askimo.core.chat.dto.TurnTimelineEntry
@@ -48,19 +48,19 @@ import kotlin.time.Duration.Companion.milliseconds
 private val log = currentFileLogger()
 
 /** Ensures a (possibly empty) streaming AI placeholder message exists, so tool/thinking chips can render before the first token arrives. */
-private fun List<ChatMessageDTO>.ensureStreamingAiMessage(): List<ChatMessageDTO> {
+private fun List<AgentTurnMessageDTO>.ensureStreamingAiMessage(): List<AgentTurnMessageDTO> {
     if (any { !it.isUser && it.id == null }) return this
-    return this + ChatMessageDTO(id = null, content = "", isUser = false, timestamp = null)
+    return this + AgentTurnMessageDTO(id = null, content = "", isUser = false, timestamp = null)
 }
 
 /** Finalizes the trailing streaming AI message: assigns a stable id and marks failure/content/usage. */
-private fun List<ChatMessageDTO>.finalizeStreamingAiMessage(
+private fun List<AgentTurnMessageDTO>.finalizeStreamingAiMessage(
     finalContent: String,
     isFailed: Boolean,
     usage: AgentUsage? = null,
     messageId: String = "ai-${System.nanoTime()}",
     isCancelled: Boolean = false,
-): List<ChatMessageDTO> {
+): List<AgentTurnMessageDTO> {
     val idx = indexOfLast { !it.isUser && it.id == null }
     if (idx < 0) return this
     val updated = this[idx].copy(
@@ -158,7 +158,7 @@ internal class AgentRunViewModel(
     }
 
     // ── Conversation state ───────────────────────────────────────────────────
-    var messages by mutableStateOf(listOf<ChatMessageDTO>())
+    var messages by mutableStateOf(listOf<AgentTurnMessageDTO>())
         private set
 
     var isRunning by mutableStateOf(false)
@@ -332,13 +332,13 @@ internal class AgentRunViewModel(
         val turns = withContext(Dispatchers.IO) { historyRepo.findByConversationId(record.conversationId) }
         messages = turns.flatMap { r ->
             listOf(
-                ChatMessageDTO(
+                AgentTurnMessageDTO(
                     id = "${r.id}-user",
                     content = r.userInput,
                     isUser = true,
                     timestamp = r.createdAt,
                 ),
-                ChatMessageDTO(
+                AgentTurnMessageDTO(
                     id = "${r.id}-ai",
                     content = r.response.ifBlank { r.error.orEmpty() },
                     isUser = false,
@@ -400,7 +400,7 @@ internal class AgentRunViewModel(
             conversationTitle = TitleGenerator.fallbackTitle(input)
         }
 
-        val userMessage = ChatMessageDTO(
+        val userMessage = AgentTurnMessageDTO(
             id = "user-${System.nanoTime()}",
             content = input,
             isUser = true,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatMessageList.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatMessageList.kt
@@ -1,0 +1,339 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.ui.chat
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import io.askimo.core.chat.dto.ChatMessageDTO
+import io.askimo.core.chat.dto.FileAttachmentDTO
+import io.askimo.core.chat.dto.TurnTimelineEntry
+import io.askimo.core.chat.dto.TurnTimelineGroup
+import io.askimo.core.chat.dto.grouped
+import io.askimo.core.config.AppConfig
+import io.askimo.core.event.EventBus
+import io.askimo.core.event.error.AppErrorEvent
+import io.askimo.core.i18n.LocalizationManager
+import io.askimo.ui.common.components.primaryButton
+import io.askimo.ui.common.components.secondaryButton
+import io.askimo.ui.common.i18n.stringResource
+import io.askimo.ui.common.theme.AppColors
+import io.askimo.ui.common.theme.AppComponents
+import io.askimo.ui.common.theme.AppTextStyles
+import io.askimo.ui.common.theme.Spacing
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Full-featured chat transcript renderer — search/jump, inline edit, retry, bookmarks,
+ * forking, attachments, voice autoplay, day separators, outdated-branch collapsing. Split out
+ * of the old shared `messageList` (formerly in MessageComponents.kt): only `ChatView` needs
+ * this feature surface. Agentic runs use the much slimmer `agentMessageList`
+ * (`io.askimo.ui.agent.AgentMessageList.kt`) instead — see its doc for why they're kept as two
+ * separate composables rather than one shared one with a pile of params each caller only
+ * partially uses.
+ */
+@Composable
+fun chatMessageList(
+    messages: List<ChatMessageDTO>,
+    isThinking: Boolean = false,
+    thinkingElapsedSeconds: Int = 0,
+    spinnerFrame: String = "",
+    isLoadingPrevious: Boolean = false,
+    searchQuery: String = "",
+    currentSearchResultIndex: Int = 0,
+    onMessageClick: ((String, Instant) -> Unit)? = null,
+    onEditMessage: ((ChatMessageDTO) -> Unit)? = null,
+    onDownloadAttachment: ((FileAttachmentDTO) -> Unit)? = null,
+    userAvatarPainter: BitmapPainter? = null,
+    aiAvatarPainter: BitmapPainter? = null,
+    onRetryMessage: ((String) -> Unit)? = null,
+    viewportTopY: Float? = null,
+    projectId: String? = null,
+    // Ordered tool-call/text/thinking timeline for the *currently streaming/last* AI turn
+    // (this session only) — replaces the old activeToolCalls/activeThinkingContent pair so
+    // true chronological interleaving can be rendered. See SessionManager.StreamingThread.
+    activeTimeline: List<TurnTimelineEntry> = emptyList(),
+    // Session-only per-message lookup so completed AI messages (this session, or reloaded from
+    // persisted `ChatMessageDTO.contentBlocks`) can show their ordered tool/thinking/text
+    // timeline — kept visible for every past turn, not just the current "last" message (which
+    // instead uses activeTimeline above).
+    completedGroupsByMessageId: Map<String, List<TurnTimelineGroup>> = emptyMap(),
+    bookmarkedMessageIds: Set<String> = emptySet(),
+    onToggleBookmark: ((String) -> Unit)? = null,
+    onForkFromMessage: ((String) -> Unit)? = null,
+) {
+    // Retry confirmation dialog state
+    var showRetryConfirmDialog by remember { mutableStateOf(false) }
+    var retryMessageId by remember { mutableStateOf<String?>(null) }
+
+    // Cache voice-output enabled flag once for the whole list — AppConfig.voice resolves a key
+    // from the OS keychain, so read it off the UI thread (same pattern as chatInputField's
+    // voiceInputEnabled). Hidden entirely per-bubble when disabled (default) — zero UI impact
+    // for existing users.
+    var voiceOutputEnabled by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        voiceOutputEnabled = withContext(Dispatchers.IO) { AppConfig.voice.enabled }
+    }
+
+    // ── Auto-play AI responses (🔊) — opt-in "conversation mode" ──────────────────────
+    // Cache the flag the same way as voiceOutputEnabled above (keychain-adjacent config read).
+    var autoPlayResponses by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        autoPlayResponses = withContext(Dispatchers.IO) { AppConfig.voice.autoPlayResponses }
+    }
+    val voiceErrorTitle = stringResource("chat.voice.error.title")
+    val autoPlayScope = rememberCoroutineScope()
+
+    // Detect "a response just finished streaming" by watching the last AI message's id
+    // transition from null (in-flight placeholder — see ChatViewModel.upsertStreamingAiMessage)
+    // to non-null (persisted). Deliberately NOT keyed on `isThinking`: that flag flips to false
+    // as soon as the *first* token arrives (see ChatViewModel.subscribeToThread), not when the
+    // response actually completes, so it can't be used as a completion signal here.
+    val lastAiMessage = messages.lastOrNull { !it.isUser }
+    val lastAiMessageKey = when {
+        lastAiMessage == null -> "none"
+
+        lastAiMessage.id != null -> "id:${lastAiMessage.id}"
+
+        // Same key for every token update while streaming (id stays null, list size is stable)
+        // so this effect only re-fires on an actual streaming→persisted transition, not per token.
+        else -> "streaming:${messages.size}"
+    }
+    var sawStreamingForCurrentTurn by remember { mutableStateOf(false) }
+    var lastAutoPlayedMessageId by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(lastAiMessageKey) {
+        val message = lastAiMessage ?: return@LaunchedEffect
+        val id = message.id
+        if (id == null) {
+            // Actively streaming a new AI turn — remember this so the *next* transition to a
+            // real id is treated as "just completed" (not stale history from opening a session).
+            sawStreamingForCurrentTurn = true
+            return@LaunchedEffect
+        }
+        if (!sawStreamingForCurrentTurn) return@LaunchedEffect
+        sawStreamingForCurrentTurn = false
+        if (lastAutoPlayedMessageId == id) return@LaunchedEffect
+        lastAutoPlayedMessageId = id
+        if (!voiceOutputEnabled || !autoPlayResponses) return@LaunchedEffect
+        if (message.content.isBlank()) return@LaunchedEffect
+        VoicePlaybackController.toggle(id, message.content, autoPlayScope) { errorMessage ->
+            EventBus.post(AppErrorEvent(title = voiceErrorTitle, message = errorMessage))
+        }
+    }
+
+    // Current date — re-evaluated at midnight so "Today"/"Yesterday" labels stay accurate
+    // when the user keeps the app open across a day boundary.
+    val zone = ZoneId.systemDefault()
+    var currentDate by remember { mutableStateOf(LocalDate.now(zone)) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            val now = ZonedDateTime.now(zone)
+            val nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay(zone)
+            val millisUntilMidnight = Duration.between(now, nextMidnight).toMillis()
+            delay(millisUntilMidnight.milliseconds)
+            currentDate = LocalDate.now(zone)
+        }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.extraLarge),
+    ) {
+        // Show loading indicator when loading previous messages
+        if (isLoadingPrevious) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = Spacing.small),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = stringResource("message.loading.previous"),
+                    style = AppTextStyles.bodySecondary,
+                    color = AppColors.secondaryIconColor(),
+                )
+            }
+        }
+
+        // Group messages into active and outdated branches
+        val messageGroups = groupMessagesWithOutdatedBranches(messages)
+        var messageIndex = 0
+        var isFirstMessage = true
+        var lastDayLabel: String? = null
+        messageGroups.forEach { group ->
+            when (group) {
+                is MessageGroup.ActiveMessage -> {
+                    // Day separator — show when the message date is different from the previous one
+                    val ts = group.message.timestamp
+                    if (ts != null) {
+                        val dayLabel = LocalizationManager.formatDayLabel(ts, currentDate)
+                        if (dayLabel != lastDayLabel) {
+                            messageDaySeparator(label = dayLabel)
+                            lastDayLabel = dayLabel
+                        }
+                    }
+
+                    val isActiveResult = searchQuery.isNotBlank() && messageIndex == currentSearchResultIndex
+                    // A message is streaming when it's the last AI message still without a persisted ID.
+                    val isStreamingMessage = !group.message.isUser && group.message.id == null
+                    // "Last AI message" — used for the *live* activeTimeline. ChatViewModel
+                    // deliberately keeps this populated even after the message is finalized (real
+                    // id assigned) "until the user sends the next message" — so this must match by
+                    // id once finalized, not just while streaming (id == null).
+                    val lastAiMessageId = messages.lastOrNull { !it.isUser }?.id
+                    val isLastAiMsg = !group.message.isUser && (
+                        (group.message.id != null && group.message.id == lastAiMessageId) ||
+                            (group.message.id == null && lastAiMessageId == null)
+                        )
+                    // Resolve the ordered timeline for this AI message, preferring (in order):
+                    // 1. the live in-progress timeline, if this is the current/last turn
+                    // 2. the session-only completed-timeline cache (keyed by message id)
+                    // 3. the persisted tool/text blocks on the message itself (survives restarts)
+                    val resolvedGroups: List<TurnTimelineGroup> = if (group.message.isUser) {
+                        emptyList()
+                    } else if (isLastAiMsg && activeTimeline.isNotEmpty()) {
+                        activeTimeline.grouped()
+                    } else {
+                        group.message.id?.let { completedGroupsByMessageId[it] }
+                            ?: group.message.contentBlocks.grouped()
+                    }
+                    val hasToolCalls = resolvedGroups.any { it is TurnTimelineGroup.ToolGroup }
+                    val fallbackThinkingContent = if (!hasToolCalls) {
+                        resolvedGroups
+                            .filterIsInstance<TurnTimelineGroup.ThinkingGroup>()
+                            .joinToString("") { it.text }
+                    } else {
+                        ""
+                    }
+                    messageBubble(
+                        message = group.message,
+                        searchQuery = searchQuery,
+                        isActiveSearchResult = isActiveResult,
+                        onMessageClick = onMessageClick,
+                        onEditMessage = onEditMessage,
+                        onDownloadAttachment = onDownloadAttachment,
+                        userAvatarPainter = userAvatarPainter,
+                        aiAvatarPainter = aiAvatarPainter,
+                        onRetryMessage = onRetryMessage,
+                        addTopPadding = isFirstMessage,
+                        viewportTopY = viewportTopY,
+                        allMessages = messages,
+                        onShowRetryConfirmDialog = { messageId ->
+                            retryMessageId = messageId
+                            showRetryConfirmDialog = true
+                        },
+                        isStreaming = isStreamingMessage,
+                        projectId = projectId,
+                        toolCalls = emptyList(),
+                        thinkingContent = fallbackThinkingContent,
+                        // Any AI message with a resolved tool-call timeline (live, session-cached,
+                        // or persisted) renders the ordered timeline instead of the fixed
+                        // thinking-then-tools-then-text layout — for every past turn, not just
+                        // the last one.
+                        customBody = if (!group.message.isUser && hasToolCalls) {
+                            { turnTimelineView(resolvedGroups, isStreaming = isStreamingMessage) }
+                        } else {
+                            null
+                        },
+                        bookmarkedMessageIds = bookmarkedMessageIds,
+                        onToggleBookmark = onToggleBookmark,
+                        onForkFromMessage = onForkFromMessage,
+                        voiceOutputEnabled = voiceOutputEnabled,
+                    )
+                    isFirstMessage = false
+                    messageIndex++
+                }
+
+                is MessageGroup.OutdatedBranch -> {
+                    outdatedBranchComponent(
+                        messages = group.messages,
+                        userAvatarPainter = userAvatarPainter,
+                        aiAvatarPainter = aiAvatarPainter,
+                    )
+                    isFirstMessage = false
+                    messageIndex += group.messages.size
+                }
+            }
+        }
+
+        // Show "Thinking..." indicator when AI is processing but hasn't returned first token
+        if (isThinking) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = Spacing.small),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start,
+            ) {
+                Text(
+                    text = "$spinnerFrame ${stringResource("message.thinking", thinkingElapsedSeconds)}",
+                    style = AppTextStyles.bodySecondary,
+                    color = AppColors.secondaryIconColor(),
+                )
+            }
+        }
+    }
+
+    // Retry confirmation dialog
+    if (showRetryConfirmDialog) {
+        AppComponents.alertDialog(
+            onDismissRequest = {
+                showRetryConfirmDialog = false
+                retryMessageId = null
+            },
+            title = {
+                Text(stringResource("message.ai.try.again.confirm.title"))
+            },
+            text = {
+                Text(stringResource("message.ai.try.again.confirm.message"))
+            },
+            confirmButton = {
+                primaryButton(
+                    onClick = {
+                        retryMessageId?.let { messageId ->
+                            onRetryMessage?.invoke(messageId)
+                        }
+                        showRetryConfirmDialog = false
+                        retryMessageId = null
+                    },
+                ) {
+                    Text(stringResource("message.ai.try.again.confirm.confirm"))
+                }
+            },
+            dismissButton = {
+                secondaryButton(
+                    onClick = {
+                        showRetryConfirmDialog = false
+                        retryMessageId = null
+                    },
+                ) {
+                    Text(stringResource("message.ai.try.again.confirm.cancel"))
+                }
+            },
+        )
+    }
+}

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/ChatView.kt
@@ -1083,7 +1083,7 @@ fun chatView(
                                 }
 
                                 isSearchMode -> {
-                                    messageList(
+                                    chatMessageList(
                                         messages = searchResults,
                                         isThinking = false,
                                         thinkingElapsedSeconds = 0,
@@ -1121,7 +1121,7 @@ fun chatView(
                                 }
 
                                 else -> {
-                                    messageList(
+                                    chatMessageList(
                                         messages = messages,
                                         isThinking = isThinking,
                                         thinkingElapsedSeconds = thinkingElapsedSeconds,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -92,9 +92,7 @@ import io.askimo.core.chat.dto.ChatMessageDTO
 import io.askimo.core.chat.dto.FileAttachmentDTO
 import io.askimo.core.chat.dto.ToolCallInfo
 import io.askimo.core.chat.dto.ToolCallStatus
-import io.askimo.core.chat.dto.TurnTimelineEntry
 import io.askimo.core.chat.dto.TurnTimelineGroup
-import io.askimo.core.chat.dto.grouped
 import io.askimo.core.config.AppConfig
 import io.askimo.core.event.EventBus
 import io.askimo.core.event.error.AppErrorEvent
@@ -128,11 +126,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.awt.Desktop
 import java.io.File
-import java.time.Duration
 import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -143,7 +137,7 @@ import kotlin.time.Duration.Companion.seconds
  * every [aiMessageBubble] instance reactively reflects whichever message (if any) is currently
  * synthesizing/playing — no per-bubble player instances, no manual cross-bubble coordination.
  */
-private object VoicePlaybackController {
+internal object VoicePlaybackController {
     private val player = AudioPlayer()
 
     /** ID of the message currently awaiting TTS synthesis, or null. */
@@ -200,294 +194,6 @@ private object VoicePlaybackController {
                 onError(e.message ?: "Voice playback failed")
             }
         }
-    }
-}
-
-@Composable
-fun messageList(
-    messages: List<ChatMessageDTO>,
-    isThinking: Boolean = false,
-    thinkingElapsedSeconds: Int = 0,
-    spinnerFrame: String = "",
-    isLoadingPrevious: Boolean = false,
-    searchQuery: String = "",
-    currentSearchResultIndex: Int = 0,
-    onMessageClick: ((String, Instant) -> Unit)? = null,
-    onEditMessage: ((ChatMessageDTO) -> Unit)? = null,
-    onDownloadAttachment: ((FileAttachmentDTO) -> Unit)? = null,
-    userAvatarPainter: BitmapPainter? = null,
-    aiAvatarPainter: BitmapPainter? = null,
-    onRetryMessage: ((String) -> Unit)? = null,
-    viewportTopY: Float? = null,
-    projectId: String? = null,
-    // Ordered tool-call/text/thinking timeline for the *currently streaming/last* AI turn
-    // (this session only) — replaces the old activeToolCalls/activeThinkingContent pair so
-    // true chronological interleaving can be rendered. See SessionManager.StreamingThread.
-    activeTimeline: List<TurnTimelineEntry> = emptyList(),
-    // Session-only per-message lookup so completed AI messages (this session, or reloaded from
-    // persisted `AgentRunRecord.contentBlocks`/`ChatMessageDTO.contentBlocks`) can show their
-    // ordered tool/thinking/text timeline — e.g. an agentic run (or regular chat) keeping this
-    // visible for every past turn, not just the current "last" message (which instead uses
-    // activeTimeline above).
-    completedGroupsByMessageId: Map<String, List<TurnTimelineGroup>> = emptyMap(),
-    bookmarkedMessageIds: Set<String> = emptySet(),
-    onToggleBookmark: ((String) -> Unit)? = null,
-    onForkFromMessage: ((String) -> Unit)? = null,
-) {
-    // Retry confirmation dialog state
-    var showRetryConfirmDialog by remember { mutableStateOf(false) }
-    var retryMessageId by remember { mutableStateOf<String?>(null) }
-
-    // Cache voice-output enabled flag once for the whole list — AppConfig.voice resolves a key
-    // from the OS keychain, so read it off the UI thread (same pattern as chatInputField's
-    // voiceInputEnabled). Hidden entirely per-bubble when disabled (default) — zero UI impact
-    // for existing users.
-    var voiceOutputEnabled by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        voiceOutputEnabled = withContext(Dispatchers.IO) { AppConfig.voice.enabled }
-    }
-
-    // ── Auto-play AI responses (🔊) — opt-in "conversation mode" ──────────────────────
-    // Cache the flag the same way as voiceOutputEnabled above (keychain-adjacent config read).
-    var autoPlayResponses by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        autoPlayResponses = withContext(Dispatchers.IO) { AppConfig.voice.autoPlayResponses }
-    }
-    val voiceErrorTitle = stringResource("chat.voice.error.title")
-    val autoPlayScope = rememberCoroutineScope()
-
-    // Detect "a response just finished streaming" by watching the last AI message's id
-    // transition from null (in-flight placeholder — see ChatViewModel.upsertStreamingAiMessage)
-    // to non-null (persisted). Deliberately NOT keyed on `isThinking`: that flag flips to false
-    // as soon as the *first* token arrives (see ChatViewModel.subscribeToThread), not when the
-    // response actually completes, so it can't be used as a completion signal here.
-    val lastAiMessage = messages.lastOrNull { !it.isUser }
-    val lastAiMessageKey = when {
-        lastAiMessage == null -> "none"
-
-        lastAiMessage.id != null -> "id:${lastAiMessage.id}"
-
-        // Same key for every token update while streaming (id stays null, list size is stable)
-        // so this effect only re-fires on an actual streaming→persisted transition, not per token.
-        else -> "streaming:${messages.size}"
-    }
-    var sawStreamingForCurrentTurn by remember { mutableStateOf(false) }
-    var lastAutoPlayedMessageId by remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(lastAiMessageKey) {
-        val message = lastAiMessage ?: return@LaunchedEffect
-        val id = message.id
-        if (id == null) {
-            // Actively streaming a new AI turn — remember this so the *next* transition to a
-            // real id is treated as "just completed" (not stale history from opening a session).
-            sawStreamingForCurrentTurn = true
-            return@LaunchedEffect
-        }
-        if (!sawStreamingForCurrentTurn) return@LaunchedEffect
-        sawStreamingForCurrentTurn = false
-        if (lastAutoPlayedMessageId == id) return@LaunchedEffect
-        lastAutoPlayedMessageId = id
-        if (!voiceOutputEnabled || !autoPlayResponses) return@LaunchedEffect
-        if (message.content.isBlank()) return@LaunchedEffect
-        VoicePlaybackController.toggle(id, message.content, autoPlayScope) { errorMessage ->
-            EventBus.post(AppErrorEvent(title = voiceErrorTitle, message = errorMessage))
-        }
-    }
-
-    // Current date — re-evaluated at midnight so "Today"/"Yesterday" labels stay accurate
-    // when the user keeps the app open across a day boundary.
-    val zone = ZoneId.systemDefault()
-    var currentDate by remember { mutableStateOf(LocalDate.now(zone)) }
-    LaunchedEffect(Unit) {
-        while (true) {
-            val now = ZonedDateTime.now(zone)
-            val nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay(zone)
-            val millisUntilMidnight = Duration.between(now, nextMidnight).toMillis()
-            delay(millisUntilMidnight.milliseconds)
-            currentDate = LocalDate.now(zone)
-        }
-    }
-
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(Spacing.extraLarge),
-    ) {
-        // Show loading indicator when loading previous messages
-        if (isLoadingPrevious) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = Spacing.small),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center,
-            ) {
-                Text(
-                    text = stringResource("message.loading.previous"),
-                    style = AppTextStyles.bodySecondary,
-                    color = AppColors.secondaryIconColor(),
-                )
-            }
-        }
-
-        // Group messages into active and outdated branches
-        val messageGroups = groupMessagesWithOutdatedBranches(messages)
-        var messageIndex = 0
-        var isFirstMessage = true
-        var lastDayLabel: String? = null
-        messageGroups.forEach { group ->
-            when (group) {
-                is MessageGroup.ActiveMessage -> {
-                    // Day separator — show when the message date is different from the previous one
-                    val ts = group.message.timestamp
-                    if (ts != null) {
-                        val dayLabel = LocalizationManager.formatDayLabel(ts, currentDate)
-                        if (dayLabel != lastDayLabel) {
-                            messageDaySeparator(label = dayLabel)
-                            lastDayLabel = dayLabel
-                        }
-                    }
-
-                    val isActiveResult = searchQuery.isNotBlank() && messageIndex == currentSearchResultIndex
-                    // A message is streaming when it's the last AI message still without a persisted ID.
-                    val isStreamingMessage = !group.message.isUser && group.message.id == null
-                    // "Last AI message" — used for the *live* activeTimeline. ChatViewModel
-                    // deliberately keeps this populated even after the message is finalized (real
-                    // id assigned) "until the user sends the next message" — so this must match by
-                    // id once finalized, not just while streaming (id == null).
-                    val lastAiMessageId = messages.lastOrNull { !it.isUser }?.id
-                    val isLastAiMsg = !group.message.isUser && (
-                        (group.message.id != null && group.message.id == lastAiMessageId) ||
-                            (group.message.id == null && lastAiMessageId == null)
-                        )
-                    // Resolve the ordered timeline for this AI message, preferring (in order):
-                    // 1. the live in-progress timeline, if this is the current/last turn
-                    // 2. the session-only completed-timeline cache (keyed by message id)
-                    // 3. the persisted tool/text blocks on the message itself (survives restarts)
-                    val resolvedGroups: List<TurnTimelineGroup> = if (group.message.isUser) {
-                        emptyList()
-                    } else if (isLastAiMsg && activeTimeline.isNotEmpty()) {
-                        activeTimeline.grouped()
-                    } else {
-                        group.message.id?.let { completedGroupsByMessageId[it] }
-                            ?: group.message.contentBlocks.grouped()
-                    }
-                    val hasToolCalls = resolvedGroups.any { it is TurnTimelineGroup.ToolGroup }
-                    // Only switch to the ordered-timeline renderer when there's an actual tool
-                    // call to show — otherwise keep the existing rich-text rendering path
-                    // (streaming reveal, run-code dialog, link clicks, attachments) for the
-                    // common tool-free case.
-                    val fallbackThinkingContent = if (!hasToolCalls) {
-                        resolvedGroups
-                            .filterIsInstance<TurnTimelineGroup.ThinkingGroup>()
-                            .joinToString("") { it.text }
-                    } else {
-                        ""
-                    }
-                    messageBubble(
-                        message = group.message,
-                        searchQuery = searchQuery,
-                        isActiveSearchResult = isActiveResult,
-                        onMessageClick = onMessageClick,
-                        onEditMessage = onEditMessage,
-                        onDownloadAttachment = onDownloadAttachment,
-                        userAvatarPainter = userAvatarPainter,
-                        aiAvatarPainter = aiAvatarPainter,
-                        onRetryMessage = onRetryMessage,
-                        addTopPadding = isFirstMessage,
-                        viewportTopY = viewportTopY,
-                        allMessages = messages,
-                        onShowRetryConfirmDialog = { messageId ->
-                            retryMessageId = messageId
-                            showRetryConfirmDialog = true
-                        },
-                        isStreaming = isStreamingMessage,
-                        projectId = projectId,
-                        toolCalls = emptyList(),
-                        thinkingContent = fallbackThinkingContent,
-                        // Any AI message with a resolved tool-call timeline (live, session-cached,
-                        // or persisted) renders the ordered timeline instead of the fixed
-                        // thinking-then-tools-then-text layout — for every past turn, not just
-                        // the last one.
-                        customBody = if (!group.message.isUser && hasToolCalls) {
-                            { turnTimelineView(resolvedGroups, isStreaming = isStreamingMessage) }
-                        } else {
-                            null
-                        },
-                        bookmarkedMessageIds = bookmarkedMessageIds,
-                        onToggleBookmark = onToggleBookmark,
-                        onForkFromMessage = onForkFromMessage,
-                        voiceOutputEnabled = voiceOutputEnabled,
-                    )
-                    isFirstMessage = false
-                    messageIndex++
-                }
-
-                is MessageGroup.OutdatedBranch -> {
-                    outdatedBranchComponent(
-                        messages = group.messages,
-                        userAvatarPainter = userAvatarPainter,
-                        aiAvatarPainter = aiAvatarPainter,
-                    )
-                    isFirstMessage = false
-                    messageIndex += group.messages.size
-                }
-            }
-        }
-
-        // Show "Thinking..." indicator when AI is processing but hasn't returned first token
-        if (isThinking) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = Spacing.small),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Start,
-            ) {
-                Text(
-                    text = "$spinnerFrame ${stringResource("message.thinking", thinkingElapsedSeconds)}",
-                    style = AppTextStyles.bodySecondary,
-                    color = AppColors.secondaryIconColor(),
-                )
-            }
-        }
-    }
-
-    // Retry confirmation dialog
-    if (showRetryConfirmDialog) {
-        AppComponents.alertDialog(
-            onDismissRequest = {
-                showRetryConfirmDialog = false
-                retryMessageId = null
-            },
-            title = {
-                Text(stringResource("message.ai.try.again.confirm.title"))
-            },
-            text = {
-                Text(stringResource("message.ai.try.again.confirm.message"))
-            },
-            confirmButton = {
-                primaryButton(
-                    onClick = {
-                        retryMessageId?.let { messageId ->
-                            onRetryMessage?.invoke(messageId)
-                        }
-                        showRetryConfirmDialog = false
-                        retryMessageId = null
-                    },
-                ) {
-                    Text(stringResource("message.ai.try.again.confirm.confirm"))
-                }
-            },
-            dismissButton = {
-                secondaryButton(
-                    onClick = {
-                        showRetryConfirmDialog = false
-                        retryMessageId = null
-                    },
-                ) {
-                    Text(stringResource("message.ai.try.again.confirm.cancel"))
-                }
-            },
-        )
     }
 }
 
@@ -2095,7 +1801,7 @@ fun aiMessageEditDialog(
 
 /** Day separator shown between messages from different calendar days. */
 @Composable
-private fun messageDaySeparator(label: String) {
+internal fun messageDaySeparator(label: String) {
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/shared/src/main/kotlin/io/askimo/core/agent/dto/AgentTurnMessageDTO.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/dto/AgentTurnMessageDTO.kt
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.agent.dto
+
+import java.time.Instant
+
+/**
+ * UI-layer transcript entry for one turn (user input or AI response) of an agentic run —
+ * the agent-domain equivalent of [io.askimo.core.chat.dto.ChatMessageDTO] for regular chat,
+ * but slimmer: agent conversations never support inline edit, retry, bookmarking, forking, or
+ * attachments, so this type only carries the fields an agent turn actually produces.
+ *
+ * Rendered via the shared `messageBubble`/`turnTimelineView` blocks by `agentMessageList`,
+ * which adapts instances of this type to a `ChatMessageDTO` at the rendering boundary.
+ */
+data class AgentTurnMessageDTO(
+    val id: String?,
+    val content: String,
+    val isUser: Boolean,
+    val timestamp: Instant?,
+    val isFailed: Boolean = false,
+    // True when this AI turn was stopped mid-flight via ExternalAgent.cancel() rather than
+    // failing or completing normally — rendered distinctly from isFailed (no retry action, a
+    // neutral "Cancelled" label instead of an error state).
+    val isCancelled: Boolean = false,
+    val inputTokens: Int? = null,
+    val outputTokens: Int? = null,
+    val totalTokens: Int? = null,
+    val durationMs: Long? = null,
+)

--- a/shared/src/main/kotlin/io/askimo/core/chat/dto/ChatMessageDTO.kt
+++ b/shared/src/main/kotlin/io/askimo/core/chat/dto/ChatMessageDTO.kt
@@ -20,10 +20,10 @@ data class ChatMessageDTO(
     val isEdited: Boolean = false,
     val attachments: List<FileAttachmentDTO> = emptyList(),
     val isFailed: Boolean = false,
-    // True when this AI turn was stopped mid-flight via ExternalAgent.cancel() rather than
-    // failing or completing normally — rendered distinctly from isFailed (no retry action,
-    // a neutral "Cancelled" label instead of an error state). Only ever set for agentic runs
-    // (see AgentRunViewModel); regular chat messages never set this.
+    // True when this turn was stopped mid-flight rather than failing or completing normally —
+    // rendered distinctly from isFailed (no retry action, a neutral "Cancelled" label instead
+    // of an error state). Regular chat never sets this; only agent-run turns do, via the
+    // `AgentTurnMessageDTO` -> `ChatMessageDTO` adapter used to reuse the shared bubble renderer.
     val isCancelled: Boolean = false,
     val inputTokens: Int? = null,
     val outputTokens: Int? = null,


### PR DESCRIPTION
- Separates the message flow and UI components between standard chat and agentic runs.
- Introduces AgentTurnMessageDTO for agent-specific messaging data.
- Updates AgentRunViewModel to use the new agent-specific DTOs.
- Refactors chat views to utilize a distinct chat message list component.