### PR TITLE
fix(memory): preserve tool calls and results in chat memory

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/memory/MemoryMessageTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/memory/MemoryMessageTest.kt
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.core.memory
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest
+import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.ToolExecutionResultMessage
+import dev.langchain4j.data.message.UserMessage
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests that tool_use/tool_result pairing survives a MemoryMessage round-trip
+ * (the serialization format used to persist session memory to the database).
+ *
+ * Regression coverage for: Anthropic error "tool_use ids were found without
+ * tool_result blocks immediately after" — which happens when the id linking a
+ * `tool_use` block to its `tool_result` is lost across a DB save/reload cycle.
+ */
+class MemoryMessageTest {
+
+    @Test
+    @DisplayName("should preserve AiMessage tool execution requests across MemoryMessage round-trip")
+    fun shouldPreserveToolExecutionRequests() {
+        val request1 = ToolExecutionRequest.builder()
+            .id("toolu_01Aoaxsi9ygKmuSFYAwcRFTf")
+            .name("list_files")
+            .arguments("{\"path\":\"a\"}")
+            .build()
+        val request2 = ToolExecutionRequest.builder()
+            .id("toolu_01VAxJvxu9WCD2Hb3yabKtPY")
+            .name("list_files")
+            .arguments("{\"path\":\"b\"}")
+            .build()
+
+        val aiMessage = AiMessage.from(listOf(request1, request2))
+
+        val memoryMessage = MemoryMessage.from(aiMessage)
+        val restored = memoryMessage.toChatMessage()
+
+        assertTrue(restored is AiMessage)
+        val restoredAi = restored
+        assertTrue(restoredAi.hasToolExecutionRequests())
+        assertEquals(2, restoredAi.toolExecutionRequests().size)
+        val restoredIds = restoredAi.toolExecutionRequests().map { it.id() }.toSet()
+        assertTrue(restoredIds.contains("toolu_01Aoaxsi9ygKmuSFYAwcRFTf"))
+        assertTrue(restoredIds.contains("toolu_01VAxJvxu9WCD2Hb3yabKtPY"))
+    }
+
+    @Test
+    @DisplayName("should preserve ToolExecutionResultMessage id and toolName across MemoryMessage round-trip")
+    fun shouldPreserveToolExecutionResultId() {
+        val request = ToolExecutionRequest.builder()
+            .id("toolu_middle_call")
+            .name("some_tool")
+            .arguments("{}")
+            .build()
+        val resultMessage = ToolExecutionResultMessage.from(request, "tool output")
+
+        val memoryMessage = MemoryMessage.from(resultMessage)
+        val restored = memoryMessage.toChatMessage()
+
+        assertTrue(restored is ToolExecutionResultMessage)
+        val restoredResult = restored
+        assertEquals("toolu_middle_call", restoredResult.id())
+        assertEquals("some_tool", restoredResult.toolName())
+        assertEquals("tool output", restoredResult.text())
+    }
+
+    @Test
+    @DisplayName("should preserve full tool_use/tool_result pairing through a JSON serialization round-trip")
+    fun shouldPreservePairingThroughJsonSerialization() {
+        val request = ToolExecutionRequest.builder()
+            .id("toolu_json_roundtrip")
+            .name("some_tool")
+            .arguments("{\"x\":1}")
+            .build()
+
+        val originalMessages = listOf(
+            UserMessage.from("Do the thing"),
+            AiMessage.from(request),
+            ToolExecutionResultMessage.from(request, "done"),
+        )
+
+        val memoryMessages = originalMessages.map { it.toMemoryMessage() }
+        val jsonSerialized = io.askimo.core.util.JsonUtils.json.encodeToString(
+            kotlinx.serialization.builtins.ListSerializer(MemoryMessage.serializer()),
+            memoryMessages,
+        )
+        val deserialized = io.askimo.core.util.JsonUtils.json.decodeFromString(
+            kotlinx.serialization.builtins.ListSerializer(MemoryMessage.serializer()),
+            jsonSerialized,
+        )
+        val restoredMessages = deserialized.map { it.toChatMessage() }
+
+        val restoredAi = restoredMessages[1] as AiMessage
+        val restoredResult = restoredMessages[2] as ToolExecutionResultMessage
+
+        assertTrue(restoredAi.hasToolExecutionRequests())
+        val toolUseId = restoredAi.toolExecutionRequests().first().id()
+        assertEquals(toolUseId, restoredResult.id(), "tool_use id must match tool_result id after JSON round-trip")
+    }
+}

--- a/cli/src/test/kotlin/io/askimo/core/memory/MemoryMessageTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/memory/MemoryMessageTest.kt
@@ -104,4 +104,44 @@ class MemoryMessageTest {
         val toolUseId = restoredAi.toolExecutionRequests().first().id()
         assertEquals(toolUseId, restoredResult.id(), "tool_use id must match tool_result id after JSON round-trip")
     }
+
+    @Test
+    @DisplayName("should drop (not throw) legacy TOOL_EXECUTION_RESULT_MESSAGE rows persisted before tool-call metadata existed")
+    fun shouldDropLegacyToolResultMessagesWithoutId() {
+        // Simulates a MemoryMessage row persisted by an older app version, before toolCallId/
+        // toolName/toolExecutionRequests existed — deserialization falls back to the field
+        // defaults (null / empty), exactly like this hand-built instance.
+        val legacyToolResult = MemoryMessage(
+            content = "some legacy tool output",
+            type = io.askimo.core.context.MessageRole.TOOL_EXECUTION_RESULT_MESSAGE.value,
+        )
+
+        val restored = legacyToolResult.toChatMessage()
+
+        assertEquals(null, restored, "Legacy tool_result rows without an id must be dropped, not reconstructed with a blank id")
+    }
+
+    @Test
+    @DisplayName("mapNotNull over a mixed legacy + modern history should keep only reconstructable messages")
+    fun shouldFilterOutOnlyLegacyToolResultsFromMixedHistory() {
+        val request = ToolExecutionRequest.builder()
+            .id("toolu_modern_call")
+            .name("some_tool")
+            .arguments("{}")
+            .build()
+
+        val history = listOf(
+            MemoryMessage(content = "Hello", type = io.askimo.core.context.MessageRole.USER.value),
+            MemoryMessage(content = "legacy tool output", type = io.askimo.core.context.MessageRole.TOOL_EXECUTION_RESULT_MESSAGE.value),
+            MemoryMessage.from(AiMessage.from(request)),
+            MemoryMessage.from(ToolExecutionResultMessage.from(request, "modern output")),
+        )
+
+        val restored = history.mapNotNull { it.toChatMessage() }
+
+        assertEquals(3, restored.size, "Only the unreconstructable legacy tool_result should be dropped")
+        assertTrue(restored.any { it is UserMessage })
+        assertTrue(restored.any { it is AiMessage && it.hasToolExecutionRequests() })
+        assertTrue(restored.any { it is ToolExecutionResultMessage && it.id() == "toolu_modern_call" })
+    }
 }

--- a/cli/src/test/kotlin/io/askimo/core/memory/MemoryMessageTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/memory/MemoryMessageTest.kt
@@ -144,4 +144,21 @@ class MemoryMessageTest {
         assertTrue(restored.any { it is AiMessage && it.hasToolExecutionRequests() })
         assertTrue(restored.any { it is ToolExecutionResultMessage && it.id() == "toolu_modern_call" })
     }
+
+    @Test
+    @DisplayName("should drop TOOL_EXECUTION_RESULT_MESSAGE rows with a valid toolCallId but blank/missing toolName")
+    fun shouldDropToolResultMessagesWithBlankToolName() {
+        // A tool_result missing its tool name is just as invalid for providers as one missing
+        // its id — must be dropped rather than reconstructed with a blank name fallback.
+        val missingToolName = MemoryMessage(
+            content = "output",
+            type = io.askimo.core.context.MessageRole.TOOL_EXECUTION_RESULT_MESSAGE.value,
+            toolCallId = "toolu_has_id_no_name",
+            toolName = null,
+        )
+        val blankToolName = missingToolName.copy(toolName = "   ")
+
+        assertEquals(null, missingToolName.toChatMessage(), "toolName == null must be dropped")
+        assertEquals(null, blankToolName.toChatMessage(), "toolName blank must be dropped")
+    }
 }

--- a/cli/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemoryTest.kt
@@ -396,6 +396,72 @@ class TokenAwareSummarizingMemoryTest {
         assertEquals(3, memory.messages().size)
     }
 
+    // ── loadFromFilteredMemory ───────────────────────────────────────────────
+
+    @Test
+    fun `loadFromFilteredMemory should keep valid text and tool-call messages`() {
+        memory = createMemory(asyncSummarization = false)
+
+        val request = dev.langchain4j.agent.tool.ToolExecutionRequest.builder()
+            .id("toolu_valid")
+            .name("some_tool")
+            .arguments("{}")
+            .build()
+
+        val filtered = listOf(
+            MemoryMessage(content = "Hello", type = io.askimo.core.context.MessageRole.USER.value),
+            MemoryMessage.from(AiMessage.from(request)),
+            MemoryMessage.from(dev.langchain4j.data.message.ToolExecutionResultMessage.from(request, "tool output")),
+        )
+
+        memory.loadFromFilteredMemory(filtered)
+
+        val messages = memory.messages()
+        assertEquals(3, messages.size, "All three reconstructable rows should be kept")
+    }
+
+    @Test
+    fun `loadFromFilteredMemory should drop a tool_result row with a non-null but blank toolCallId`() {
+        memory = createMemory(asyncSummarization = false)
+
+        val filtered = listOf(
+            MemoryMessage(content = "Hello", type = io.askimo.core.context.MessageRole.USER.value),
+            MemoryMessage(
+                content = "orphaned output",
+                type = io.askimo.core.context.MessageRole.TOOL_EXECUTION_RESULT_MESSAGE.value,
+                toolCallId = "   ", // non-null but blank — must be treated as invalid
+                toolName = "some_tool",
+            ),
+        )
+
+        memory.loadFromFilteredMemory(filtered)
+
+        val messages = memory.messages()
+        assertEquals(1, messages.size, "Blank toolCallId row must be filtered out, not just non-null")
+        assertTrue(messages[0] is UserMessage)
+    }
+
+    @Test
+    fun `loadFromFilteredMemory should drop a tool_result row with a valid toolCallId but blank toolName`() {
+        memory = createMemory(asyncSummarization = false)
+
+        val filtered = listOf(
+            MemoryMessage(content = "Hello", type = io.askimo.core.context.MessageRole.USER.value),
+            MemoryMessage(
+                content = "output",
+                type = io.askimo.core.context.MessageRole.TOOL_EXECUTION_RESULT_MESSAGE.value,
+                toolCallId = "toolu_has_id",
+                toolName = null, // missing tool name — must be treated as invalid too
+            ),
+        )
+
+        memory.loadFromFilteredMemory(filtered)
+
+        val messages = memory.messages()
+        assertEquals(1, messages.size, "Blank/missing toolName row must be filtered out")
+        assertTrue(messages[0] is UserMessage)
+    }
+
     // ── Persistence ──────────────────────────────────────────────────────────
 
     @Test

--- a/cli/src/test/kotlin/io/askimo/core/providers/ChatRequestTransformersTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/ChatRequestTransformersTest.kt
@@ -540,6 +540,92 @@ class ChatRequestTransformersTest {
         }
 
         @Test
+        @DisplayName("should collapse a consecutive tool_result duplicate with the same id and text (retry)")
+        fun shouldCollapseSameIdSameTextToolResultDuplicate() {
+            // Given - a retry appended the exact same tool_result (same id, same text) twice
+            // in a row, e.g. because the streaming request was retried after a transient error
+            // and the memory ended up with the tool result persisted twice.
+            val request = ToolExecutionRequest.builder()
+                .id("toolu_retry_dup")
+                .name("some_tool")
+                .arguments("{}")
+                .build()
+
+            val aiMessage = AiMessage.from(request)
+            val result1 = ToolExecutionResultMessage.from(request, "same output")
+            val result2 = ToolExecutionResultMessage.from(request, "same output")
+
+            val messages = listOf(
+                UserMessage.from("Run the tool"),
+                aiMessage,
+                result1,
+                result2,
+            )
+            val chatRequest = ChatRequest.builder().messages(messages).build()
+
+            // When
+            val result = ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(
+                sessionId = null,
+                chatRequest = chatRequest,
+                memoryId = null,
+                provider = ModelProvider.ANTHROPIC,
+                settings = OpenAiSettings(defaultModel = "claude-3-opus"),
+            )
+
+            // Then - only one tool_result should remain for this id, avoiding a provider error
+            // ("multiple tool_result blocks for the same tool_use id") and wasted tokens.
+            val toolResults = result.messages().filterIsInstance<ToolExecutionResultMessage>()
+            assertEquals(1, toolResults.size, "Exact duplicate tool_result (same id + text) must be collapsed")
+            assertEquals("toolu_retry_dup", toolResults.first().id())
+        }
+
+        @Test
+        @DisplayName("should NOT collapse consecutive tool_result messages with the same text but different ids")
+        fun shouldNotCollapseDifferentIdSameTextToolResults() {
+            // Given - two different tool_use ids (not a retry) that both happen to return the
+            // exact same output text. These must both be preserved even though they are
+            // "consecutive" and "identical" by text alone.
+            val request1 = ToolExecutionRequest.builder()
+                .id("toolu_call_one")
+                .name("some_tool")
+                .arguments("{\"x\":1}")
+                .build()
+            val request2 = ToolExecutionRequest.builder()
+                .id("toolu_call_two")
+                .name("some_tool")
+                .arguments("{\"x\":2}")
+                .build()
+
+            val aiMessage = AiMessage.from(listOf(request1, request2))
+            val result1 = ToolExecutionResultMessage.from(request1, "identical output")
+            val result2 = ToolExecutionResultMessage.from(request2, "identical output")
+
+            val messages = listOf(
+                UserMessage.from("Run both tools"),
+                aiMessage,
+                result1,
+                result2,
+            )
+            val chatRequest = ChatRequest.builder().messages(messages).build()
+
+            // When
+            val result = ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(
+                sessionId = null,
+                chatRequest = chatRequest,
+                memoryId = null,
+                provider = ModelProvider.ANTHROPIC,
+                settings = OpenAiSettings(defaultModel = "claude-3-opus"),
+            )
+
+            // Then
+            val toolResults = result.messages().filterIsInstance<ToolExecutionResultMessage>()
+            assertEquals(2, toolResults.size, "Different tool_use ids must never be collapsed, even with identical text")
+            val resultIds = toolResults.map { it.id() }.toSet()
+            assertTrue(resultIds.contains("toolu_call_one"))
+            assertTrue(resultIds.contains("toolu_call_two"))
+        }
+
+        @Test
         @DisplayName("should keep tool_use/tool_result pairs atomic when truncating for token budget")
         fun shouldKeepToolCallPairsAtomicWhenTruncating() {
             val modelKey = ModelCapabilitiesCache.modelKey(ModelProvider.OPENAI, "gpt-3.5-turbo")

--- a/cli/src/test/kotlin/io/askimo/core/providers/ChatRequestTransformersTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/providers/ChatRequestTransformersTest.kt
@@ -4,9 +4,11 @@
  */
 package io.askimo.core.providers
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest
 import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.ChatMessage
 import dev.langchain4j.data.message.SystemMessage
+import dev.langchain4j.data.message.ToolExecutionResultMessage
 import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.model.chat.request.ChatRequest
 import io.askimo.core.context.AppContext
@@ -485,6 +487,102 @@ class ChatRequestTransformersTest {
                     foundNonSystemMessage = true
                 }
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("Tool Call Handling")
+    inner class ToolCallTests {
+
+        @Test
+        @DisplayName("should not drop tool_result messages with identical text from parallel tool calls")
+        fun shouldNotDropParallelToolResultsWithIdenticalText() {
+            // Given - an AiMessage with two parallel tool_use calls, both returning identical
+            // text results (e.g. two "list files" calls on empty directories both returning "[]")
+            val request1 = ToolExecutionRequest.builder()
+                .id("toolu_01Aoaxsi9ygKmuSFYAwcRFTf")
+                .name("list_files")
+                .arguments("{\"path\":\"a\"}")
+                .build()
+            val request2 = ToolExecutionRequest.builder()
+                .id("toolu_01VAxJvxu9WCD2Hb3yabKtPY")
+                .name("list_files")
+                .arguments("{\"path\":\"b\"}")
+                .build()
+
+            val aiMessage = AiMessage.from(listOf(request1, request2))
+            val result1 = ToolExecutionResultMessage.from(request1, "[]")
+            val result2 = ToolExecutionResultMessage.from(request2, "[]")
+
+            val messages = listOf(
+                UserMessage.from("List files in a and b"),
+                aiMessage,
+                result1,
+                result2,
+            )
+            val chatRequest = ChatRequest.builder().messages(messages).build()
+
+            // When
+            val result = ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(
+                sessionId = null,
+                chatRequest = chatRequest,
+                memoryId = null,
+                provider = ModelProvider.ANTHROPIC,
+                settings = OpenAiSettings(defaultModel = "claude-3-opus"),
+            )
+
+            // Then - both tool_result messages must survive, matching their tool_use ids
+            val toolResults = result.messages().filterIsInstance<ToolExecutionResultMessage>()
+            assertEquals(2, toolResults.size, "Both tool_result messages must be kept, not deduplicated")
+            val resultIds = toolResults.map { it.id() }.toSet()
+            assertTrue(resultIds.contains("toolu_01Aoaxsi9ygKmuSFYAwcRFTf"))
+            assertTrue(resultIds.contains("toolu_01VAxJvxu9WCD2Hb3yabKtPY"))
+        }
+
+        @Test
+        @DisplayName("should keep tool_use/tool_result pairs atomic when truncating for token budget")
+        fun shouldKeepToolCallPairsAtomicWhenTruncating() {
+            val modelKey = ModelCapabilitiesCache.modelKey(ModelProvider.OPENAI, "gpt-3.5-turbo")
+            ModelCapabilitiesCache.update(modelKey) { it.copy(contextSize = 16_384) }
+
+            val messages = mutableListOf<ChatMessage>(SystemMessage.from("System directive"))
+
+            // Add many large user/ai pairs to force truncation of older history
+            repeat(50) { i ->
+                messages.add(UserMessage.from("User message $i: " + "x".repeat(500)))
+                messages.add(AiMessage.from("AI response $i: " + "y".repeat(500)))
+            }
+
+            // Add a tool_use/tool_result pair near the middle of history (a truncation candidate)
+            val request = ToolExecutionRequest.builder()
+                .id("toolu_middle_call")
+                .name("some_tool")
+                .arguments("{}")
+                .build()
+            messages.add(AiMessage.from(request))
+            messages.add(ToolExecutionResultMessage.from(request, "tool output " + "z".repeat(500)))
+
+            repeat(20) { i ->
+                messages.add(UserMessage.from("Later user message $i: " + "x".repeat(500)))
+                messages.add(AiMessage.from("Later AI response $i: " + "y".repeat(500)))
+            }
+
+            val chatRequest = ChatRequest.builder().messages(messages).build()
+
+            // When
+            val result = ChatRequestTransformers.addCustomSystemMessagesAndRemoveDuplicates(
+                sessionId = null,
+                chatRequest = chatRequest,
+                memoryId = null,
+                provider = ModelProvider.OPENAI,
+                settings = OpenAiSettings(defaultModel = "gpt-3.5-turbo"),
+            )
+
+            // Then - if the tool_use AiMessage survived truncation, its tool_result must too (and vice versa)
+            val resultMessages = result.messages()
+            val hasToolUse = resultMessages.any { it is AiMessage && it.hasToolExecutionRequests() }
+            val hasToolResult = resultMessages.any { it is ToolExecutionResultMessage }
+            assertEquals(hasToolUse, hasToolResult, "tool_use and tool_result must be kept or dropped together")
         }
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
@@ -4,6 +4,7 @@
  */
 package io.askimo.core.memory
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest
 import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.ChatMessage
 import dev.langchain4j.data.message.SystemMessage
@@ -44,12 +45,39 @@ object InstantSerializer : KSerializer<Instant> {
 }
 
 /**
+ * Serializable snapshot of a single [ToolExecutionRequest] (the `tool_use` block LLM providers
+ * such as Anthropic attach to an assistant message).
+ *
+ * @property id The provider-assigned tool-call id. Must be echoed back verbatim in the matching
+ *               [ToolExecutionResultMessage]'s `id` — this is exactly what providers use to pair
+ *               `tool_use` and `tool_result` blocks. Losing this id on persistence/reload is what
+ *               causes errors like "tool_use ids were found without tool_result blocks".
+ * @property name The tool name that was called.
+ * @property arguments The raw (usually JSON) arguments string passed to the tool.
+ */
+@Serializable
+data class ToolCallData(
+    val id: String,
+    val name: String,
+    val arguments: String,
+)
+
+/**
  * Represents a chat message in memory with serialization support.
  * This is the persistent representation of a chat message that can be stored in the database.
  *
  * @property content The text content of the message
  * @property type The message type (USER, ASSISTANT, SYSTEM, TOOL_EXECUTION_RESULT_MESSAGE)
  * @property createdAt Timestamp when the message was created
+ * @property toolExecutionRequests For ASSISTANT messages that included one or more `tool_use`
+ *                                  calls, the full list of requests (id/name/arguments) so they
+ *                                  can be faithfully reconstructed after a DB round-trip. Empty
+ *                                  for plain text assistant messages.
+ * @property toolCallId For TOOL_EXECUTION_RESULT_MESSAGE messages, the id of the `tool_use` this
+ *                       result answers. Must match one of the ids in the preceding assistant
+ *                       message's [toolExecutionRequests].
+ * @property toolName For TOOL_EXECUTION_RESULT_MESSAGE messages, the name of the tool that was
+ *                     executed.
  */
 @Serializable
 data class MemoryMessage(
@@ -57,6 +85,9 @@ data class MemoryMessage(
     val type: String,
     @Serializable(with = InstantSerializer::class)
     val createdAt: Instant = Instant.now(),
+    val toolExecutionRequests: List<ToolCallData> = emptyList(),
+    val toolCallId: String? = null,
+    val toolName: String? = null,
 ) {
     /**
      * Convert this MemoryMessage to a LangChain4j ChatMessage
@@ -64,12 +95,32 @@ data class MemoryMessage(
     fun toChatMessage(): ChatMessage = when (this.type) {
         MessageRole.USER.value -> UserMessage.from(this.content)
 
-        MessageRole.ASSISTANT.value -> AiMessage.from(this.content)
+        MessageRole.ASSISTANT.value ->
+            if (toolExecutionRequests.isNotEmpty()) {
+                val requests = toolExecutionRequests.map {
+                    ToolExecutionRequest.builder()
+                        .id(it.id)
+                        .name(it.name)
+                        .arguments(it.arguments)
+                        .build()
+                }
+                if (this.content.isBlank()) {
+                    AiMessage.from(requests)
+                } else {
+                    AiMessage.from(this.content, requests)
+                }
+            } else {
+                AiMessage.from(this.content)
+            }
 
         MessageRole.SYSTEM.value -> SystemMessage.from(this.content)
 
         MessageRole.TOOL_EXECUTION_RESULT_MESSAGE.value ->
-            ToolExecutionResultMessage.builder().text(this.content).build()
+            ToolExecutionResultMessage.from(
+                this.toolCallId,
+                this.toolName ?: "",
+                this.content,
+            )
 
         else -> UserMessage.from(this.content) // fallback
     }
@@ -102,6 +153,12 @@ data class MemoryMessage(
          * Create a MemoryMessage from a LangChain4j ChatMessage.
          * Base64 image data is stripped and replaced with a short placeholder so
          * images are never persisted to the database or re-sent on every API call.
+         *
+         * Tool-call metadata ([ToolCallData] for AiMessage's `tool_use` requests, and the
+         * id/toolName for ToolExecutionResultMessage's `tool_result`) is preserved so the
+         * `tool_use`/`tool_result` pairing survives a DB round-trip (session reload, app
+         * restart). Without this, providers like Anthropic reject the next request with
+         * "tool_use ids were found without tool_result blocks".
          */
         fun from(chatMessage: ChatMessage): MemoryMessage {
             val rawContent = chatMessage.getTextContent()
@@ -113,10 +170,22 @@ data class MemoryMessage(
                 is ToolExecutionResultMessage -> MessageRole.TOOL_EXECUTION_RESULT_MESSAGE.value
                 else -> MessageRole.USER.value // fallback
             }
+            val toolExecutionRequests = if (chatMessage is AiMessage && chatMessage.hasToolExecutionRequests()) {
+                chatMessage.toolExecutionRequests().map {
+                    ToolCallData(id = it.id(), name = it.name(), arguments = it.arguments())
+                }
+            } else {
+                emptyList()
+            }
+            val toolCallId = (chatMessage as? ToolExecutionResultMessage)?.id()
+            val toolName = (chatMessage as? ToolExecutionResultMessage)?.toolName()
             return MemoryMessage(
                 content = content,
                 type = type,
                 createdAt = Instant.now(),
+                toolExecutionRequests = toolExecutionRequests,
+                toolCallId = toolCallId,
+                toolName = toolName,
             )
         }
     }

--- a/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
@@ -90,9 +90,18 @@ data class MemoryMessage(
     val toolName: String? = null,
 ) {
     /**
-     * Convert this MemoryMessage to a LangChain4j ChatMessage
+     * Convert this MemoryMessage to a LangChain4j ChatMessage.
+     *
+     * Returns `null` for a TOOL_EXECUTION_RESULT_MESSAGE whose [toolCallId] is missing/blank.
+     * This happens when loading sessions persisted *before* tool-call metadata was added to
+     * [MemoryMessage] — such legacy rows have no id to pair with a `tool_use` block (and the
+     * legacy assistant message that triggered them has no [toolExecutionRequests] either, since
+     * that metadata didn't exist yet). Reconstructing a `ToolExecutionResultMessage` with a
+     * blank/synthetic id would either throw or silently produce another orphaned `tool_result`
+     * — the exact class of bug this metadata was added to fix — so callers must drop it instead
+     * via `mapNotNull`.
      */
-    fun toChatMessage(): ChatMessage = when (this.type) {
+    fun toChatMessage(): ChatMessage? = when (this.type) {
         MessageRole.USER.value -> UserMessage.from(this.content)
 
         MessageRole.ASSISTANT.value ->
@@ -116,11 +125,15 @@ data class MemoryMessage(
         MessageRole.SYSTEM.value -> SystemMessage.from(this.content)
 
         MessageRole.TOOL_EXECUTION_RESULT_MESSAGE.value ->
-            ToolExecutionResultMessage.from(
-                this.toolCallId,
-                this.toolName ?: "",
-                this.content,
-            )
+            if (this.toolCallId.isNullOrBlank()) {
+                null
+            } else {
+                ToolExecutionResultMessage.from(
+                    this.toolCallId,
+                    this.toolName ?: "",
+                    this.content,
+                )
+            }
 
         else -> UserMessage.from(this.content) // fallback
     }

--- a/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/MemoryMessage.kt
@@ -92,14 +92,14 @@ data class MemoryMessage(
     /**
      * Convert this MemoryMessage to a LangChain4j ChatMessage.
      *
-     * Returns `null` for a TOOL_EXECUTION_RESULT_MESSAGE whose [toolCallId] is missing/blank.
-     * This happens when loading sessions persisted *before* tool-call metadata was added to
-     * [MemoryMessage] — such legacy rows have no id to pair with a `tool_use` block (and the
-     * legacy assistant message that triggered them has no [toolExecutionRequests] either, since
-     * that metadata didn't exist yet). Reconstructing a `ToolExecutionResultMessage` with a
-     * blank/synthetic id would either throw or silently produce another orphaned `tool_result`
-     * — the exact class of bug this metadata was added to fix — so callers must drop it instead
-     * via `mapNotNull`.
+     * Returns `null` for a TOOL_EXECUTION_RESULT_MESSAGE whose [toolCallId] or [toolName] is
+     * missing/blank. This happens when loading sessions persisted *before* tool-call metadata
+     * was added to [MemoryMessage] — such legacy rows have no id/name to pair with a `tool_use`
+     * block (and the legacy assistant message that triggered them has no [toolExecutionRequests]
+     * either, since that metadata didn't exist yet). Reconstructing a `ToolExecutionResultMessage`
+     * with a blank/synthetic id or name would either throw or silently produce another invalid
+     * `tool_result` — the exact class of bug this metadata was added to fix — so callers must
+     * drop it instead via `mapNotNull`.
      */
     fun toChatMessage(): ChatMessage? = when (this.type) {
         MessageRole.USER.value -> UserMessage.from(this.content)
@@ -125,12 +125,12 @@ data class MemoryMessage(
         MessageRole.SYSTEM.value -> SystemMessage.from(this.content)
 
         MessageRole.TOOL_EXECUTION_RESULT_MESSAGE.value ->
-            if (this.toolCallId.isNullOrBlank()) {
+            if (this.toolCallId.isNullOrBlank() || this.toolName.isNullOrBlank()) {
                 null
             } else {
                 ToolExecutionResultMessage.from(
                     this.toolCallId,
-                    this.toolName ?: "",
+                    this.toolName,
                     this.content,
                 )
             }

--- a/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
@@ -370,8 +370,18 @@ class TokenAwareSummarizingMemory(
         structuredSummary = null
         basicSummary = null
 
+        // Keep only rows that toChatMessage() can actually reconstruct: plain text messages,
+        // assistant tool-call messages, and TOOL_EXECUTION_RESULT_MESSAGE rows that have both a
+        // non-blank toolCallId AND toolName (see MemoryMessage.toChatMessage() for why both are
+        // required). Mirroring that predicate here — rather than the looser `toolCallId != null`
+        // check — keeps the "filtered out N blank messages" log below accurate, instead of
+        // undercounting rows that are dropped later by toChatMessage() for other reasons.
         val validMessages = filteredMessages
-            .filter { it.content.isNotBlank() || it.toolExecutionRequests.isNotEmpty() || it.toolCallId != null }
+            .filter {
+                it.content.isNotBlank() ||
+                    it.toolExecutionRequests.isNotEmpty() ||
+                    (!it.toolCallId.isNullOrBlank() && !it.toolName.isNullOrBlank())
+            }
             .mapNotNull { it.toChatMessage() }
 
         messages.addAll(validMessages)

--- a/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
@@ -4,11 +4,9 @@
  */
 package io.askimo.core.memory
 
-import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.ChatMessage
 import dev.langchain4j.data.message.ChatMessageType
 import dev.langchain4j.data.message.SystemMessage
-import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.memory.ChatMemory
 import io.askimo.core.chat.domain.SessionMemory
 import io.askimo.core.chat.repository.SessionMemoryRepository
@@ -372,7 +370,9 @@ class TokenAwareSummarizingMemory(
         structuredSummary = null
         basicSummary = null
 
-        val validMessages = filteredMessages.filter { it.content.isNotBlank() }.map { it.toChatMessage() }
+        val validMessages = filteredMessages
+            .filter { it.content.isNotBlank() || it.toolExecutionRequests.isNotEmpty() || it.toolCallId != null }
+            .map { it.toChatMessage() }
 
         messages.addAll(validMessages)
 
@@ -905,12 +905,10 @@ class TokenAwareSummarizingMemory(
          * silently exceeded.
          */
         fun defaultTokenEstimator(): (ChatMessage) -> Int = { message ->
-            val text = when (message) {
-                is UserMessage -> message.singleText() ?: ""
-                is AiMessage -> message.text() ?: ""
-                is SystemMessage -> message.text() ?: ""
-                else -> ""
-            }
+            // getTextContent() (defined in MemoryMessage.kt, same package) also handles
+            // ToolExecutionResultMessage — without it, tool results were estimated as 0
+            // tokens, silently undercounting budget usage for tool-heavy conversations.
+            val text = message.getTextContent()
             (text.split("\\s+".toRegex()).size * 1.75).toInt()
         }
     }

--- a/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
+++ b/shared/src/main/kotlin/io/askimo/core/memory/TokenAwareSummarizingMemory.kt
@@ -372,7 +372,7 @@ class TokenAwareSummarizingMemory(
 
         val validMessages = filteredMessages
             .filter { it.content.isNotBlank() || it.toolExecutionRequests.isNotEmpty() || it.toolCallId != null }
-            .map { it.toChatMessage() }
+            .mapNotNull { it.toChatMessage() }
 
         messages.addAll(validMessages)
 
@@ -749,7 +749,7 @@ class TokenAwareSummarizingMemory(
      */
     fun importState(state: MemoryState) {
         messages.clear()
-        messages.addAll(state.messages.map { it.toChatMessage() })
+        messages.addAll(state.messages.mapNotNull { it.toChatMessage() })
         structuredSummary = state.summary
         basicSummary = null // Clear basic summary when importing
         updatePressure()

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
@@ -108,23 +108,17 @@ object ChatRequestTransformers {
         // producing back-to-back identical USER (or AI) messages. Drop any message whose
         // type + text is identical to the immediately preceding message of the same type.
         //
-        // IMPORTANT: ToolExecutionResultMessage is NEVER deduplicated this way. Each one is
-        // tied to a distinct `tool_use` id (see getMessageText below), but as a safety net we
-        // also hard-exclude this type here — collapsing two "duplicate-looking" tool results
-        // (e.g. from parallel tool calls that both returned identical output) would silently
-        // drop the `tool_result` block for one of the ids. Providers like Anthropic then reject
-        // the whole request with: "tool_use ids were found without tool_result blocks".
+        // ToolExecutionResultMessage is included too: getMessageText() prefixes it with the
+        // tool-call `id`, so only a same-id + same-text retry duplicate collapses. Parallel
+        // calls with different ids never do, even with identical output text — preventing an
+        // orphaned `tool_use` (which providers like Anthropic reject).
         val deduplicatedNonSystem = nonSystemMessages.fold(mutableListOf<ChatMessage>()) { acc, msg ->
-            if (msg is ToolExecutionResultMessage) {
-                acc.also { it.add(msg) }
+            val lastSameType = acc.lastOrNull { it.type() == msg.type() }
+            if (lastSameType != null && getMessageText(lastSameType) == getMessageText(msg)) {
+                log.debug("Dropping consecutive duplicate {} message: {}", msg.type(), getMessageText(msg).take(100))
+                acc
             } else {
-                val lastSameType = acc.lastOrNull { it.type() == msg.type() }
-                if (lastSameType != null && getMessageText(lastSameType) == getMessageText(msg)) {
-                    log.debug("Dropping consecutive duplicate {} message: {}", msg.type(), getMessageText(msg).take(100))
-                    acc
-                } else {
-                    acc.also { it.add(msg) }
-                }
+                acc.also { it.add(msg) }
             }
         }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatRequestTransformers.kt
@@ -7,6 +7,7 @@ package io.askimo.core.providers
 import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.ChatMessage
 import dev.langchain4j.data.message.SystemMessage
+import dev.langchain4j.data.message.ToolExecutionResultMessage
 import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.model.chat.request.ChatRequest
 import io.askimo.core.context.AppContext
@@ -106,13 +107,24 @@ object ChatRequestTransformers {
         // Retries cause the same user message to be appended to memory on each attempt,
         // producing back-to-back identical USER (or AI) messages. Drop any message whose
         // type + text is identical to the immediately preceding message of the same type.
+        //
+        // IMPORTANT: ToolExecutionResultMessage is NEVER deduplicated this way. Each one is
+        // tied to a distinct `tool_use` id (see getMessageText below), but as a safety net we
+        // also hard-exclude this type here — collapsing two "duplicate-looking" tool results
+        // (e.g. from parallel tool calls that both returned identical output) would silently
+        // drop the `tool_result` block for one of the ids. Providers like Anthropic then reject
+        // the whole request with: "tool_use ids were found without tool_result blocks".
         val deduplicatedNonSystem = nonSystemMessages.fold(mutableListOf<ChatMessage>()) { acc, msg ->
-            val lastSameType = acc.lastOrNull { it.type() == msg.type() }
-            if (lastSameType != null && getMessageText(lastSameType) == getMessageText(msg)) {
-                log.debug("Dropping consecutive duplicate {} message: {}", msg.type(), getMessageText(msg).take(100))
-                acc
-            } else {
+            if (msg is ToolExecutionResultMessage) {
                 acc.also { it.add(msg) }
+            } else {
+                val lastSameType = acc.lastOrNull { it.type() == msg.type() }
+                if (lastSameType != null && getMessageText(lastSameType) == getMessageText(msg)) {
+                    log.debug("Dropping consecutive duplicate {} message: {}", msg.type(), getMessageText(msg).take(100))
+                    acc
+                } else {
+                    acc.also { it.add(msg) }
+                }
             }
         }
 
@@ -165,9 +177,15 @@ object ChatRequestTransformers {
 
         // Add non-system messages from most recent, staying within budget
         // IMPORTANT: Always keep the most recent message (usually user message) to ensure AI has something to respond to
-        val recentMessages = nonSystemMessages.asReversed()
+        //
+        // Messages are grouped into atomic units first: a `ToolExecutionResultMessage` is always
+        // attached to the group of the message immediately preceding it (typically the AiMessage
+        // that made the `tool_use` call). This guarantees truncation can never keep a `tool_use`
+        // while dropping its matching `tool_result` (or vice versa), which providers like
+        // Anthropic reject outright.
+        val recentGroups = groupIntoToolCallUnits(nonSystemMessages).asReversed()
 
-        if (recentMessages.isEmpty()) {
+        if (recentGroups.isEmpty()) {
             log.warn("No conversation messages found for {}:{}. Sending only system messages.", provider, model)
             return chatRequest.toBuilder().messages(keptMessages).build()
         }
@@ -175,18 +193,18 @@ object ChatRequestTransformers {
         // Track the index where system messages end, so we can insert conversation messages after them
         val systemMessagesEndIndex = keptMessages.size
 
-        // Always add the first (most recent) message, even if it exceeds budget
+        // Always add the first (most recent) group, even if it exceeds budget
         // Better to get a context length error than send no user input
-        val firstMessage = recentMessages.first()
-        val firstMessageTokens = estimateTokens(getMessageText(firstMessage))
-        keptMessages.add(systemMessagesEndIndex, firstMessage) // Insert after system messages
-        totalTokens += firstMessageTokens
+        val firstGroup = recentGroups.first()
+        val firstGroupTokens = firstGroup.sumOf { estimateTokens(getMessageText(it)) }
+        keptMessages.addAll(systemMessagesEndIndex, firstGroup) // Insert after system messages
+        totalTokens += firstGroupTokens
 
-        // Now add remaining messages if they fit within budget
-        for (msg in recentMessages.drop(1)) {
-            val msgTokens = estimateTokens(getMessageText(msg))
+        // Now add remaining groups if they fit within budget
+        for (group in recentGroups.drop(1)) {
+            val groupTokens = group.sumOf { estimateTokens(getMessageText(it)) }
 
-            if (totalTokens + msgTokens > availableForMessages) {
+            if (totalTokens + groupTokens > availableForMessages) {
                 log.debug(
                     "Truncating message history for {}:{} at {} conversation messages ({} tokens used)",
                     provider,
@@ -197,8 +215,8 @@ object ChatRequestTransformers {
                 break
             }
 
-            keptMessages.add(systemMessagesEndIndex, msg) // Insert after system messages, maintaining chronological order
-            totalTokens += msgTokens
+            keptMessages.addAll(systemMessagesEndIndex, group) // Insert after system messages, maintaining chronological order
+            totalTokens += groupTokens
         }
 
         // Check if there's enough space left for a quality AI response
@@ -230,12 +248,54 @@ object ChatRequestTransformers {
 
     /**
      * Extracts text content from a ChatMessage based on its type.
+     *
+     * For [AiMessage] with tool calls, the tool-call ids are appended so that two distinct
+     * tool-call-only messages (both with blank [AiMessage.text]) are never considered
+     * "identical" by the dedup logic in [buildRequestWithCustomMessages].
+     *
+     * For [ToolExecutionResultMessage], the id is prefixed so each result is treated as a
+     * unique message even if two parallel tool calls happen to return identical text — see the
+     * dedup guard for why this matters.
      */
     private fun getMessageText(message: ChatMessage): String = when (message) {
         is UserMessage -> message.singleText() ?: ""
-        is AiMessage -> message.text() ?: ""
+
+        is AiMessage -> {
+            val text = message.text() ?: ""
+            if (message.hasToolExecutionRequests()) {
+                text + "::" + message.toolExecutionRequests().joinToString(",") { it.id() }
+            } else {
+                text
+            }
+        }
+
         is SystemMessage -> message.text()
+
+        is ToolExecutionResultMessage -> "${message.id()}::${message.text() ?: ""}"
+
         else -> ""
+    }
+
+    /**
+     * Groups messages into atomic truncation units: a [ToolExecutionResultMessage] is always
+     * merged into the group of the message immediately preceding it (normally the [AiMessage]
+     * that issued the corresponding `tool_use` call, or a sibling tool result from the same
+     * parallel tool-call batch). All other messages start a new singleton group.
+     *
+     * This ensures [enforceTokenBudget] can only ever keep or drop a `tool_use`/`tool_result`
+     * pair (or group of pairs) together, never split them across the truncation boundary —
+     * which would otherwise produce orphaned `tool_use` ids that providers like Anthropic reject.
+     */
+    private fun groupIntoToolCallUnits(messages: List<ChatMessage>): List<List<ChatMessage>> {
+        val groups = mutableListOf<MutableList<ChatMessage>>()
+        for (msg in messages) {
+            if (msg is ToolExecutionResultMessage && groups.isNotEmpty()) {
+                groups.last().add(msg)
+            } else {
+                groups.add(mutableListOf(msg))
+            }
+        }
+        return groups
     }
 
     /**


### PR DESCRIPTION
- Retain tool execution requests and results when converting messages
- Keep paired tool calls and results together during truncation
- Include tool result content in token budget calculations
- Add coverage for memory serialization and message transformation behavior