### PR TITLE
refactor(theme): adjust application colors for consistent appearance

### DIFF
--- a/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/common/theme/AppComponents.kt
@@ -62,6 +62,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -226,6 +227,7 @@ object AppComponents {
         isError: Boolean = false,
         enabled: Boolean = true,
         singleLine: Boolean = true,
+        colors: TextFieldColors = AppColors.outlinedTextFieldColors(),
     ) {
         var showSecret by remember { mutableStateOf(false) }
 
@@ -255,7 +257,7 @@ object AppComponents {
                     )
                 }
             },
-            colors = AppColors.outlinedTextFieldColors(),
+            colors = colors,
         )
     }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AppearanceSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AppearanceSettingsSection.kt
@@ -1256,7 +1256,7 @@ private fun languageSelectionCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -1461,7 +1461,7 @@ private fun fontSettingsCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(Spacing.large),
@@ -1585,6 +1585,7 @@ private fun fontFamilySelector(
     availableFonts: List<String>,
     previewResolver: (String) -> FontFamily,
     onSelected: (String) -> Unit,
+    labelColor: Color = AppTextStyles.primaryContent,
 ) {
     var dropdownExpanded by remember { mutableStateOf(false) }
     Row(
@@ -1594,7 +1595,7 @@ private fun fontFamilySelector(
     ) {
         Text(
             text = label,
-            style = AppTextStyles.body,
+            style = AppTextStyles.body.copy(color = labelColor),
             modifier = Modifier.weight(1f).padding(end = Spacing.large),
         )
         Box(modifier = Modifier.widthIn(min = dropdownRegularMinWidth, max = dropdownRegularMaxWidth)) {

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/ShortcutsSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/ShortcutsSettingsSection.kt
@@ -182,7 +182,7 @@ fun keyboardShortcutsList(
         filteredByCategory.forEach { (category, shortcuts) ->
             Card(
                 modifier = Modifier.fillMaxWidth(),
-                colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                colors = AppColors.cardColors(AppColors.Elevation.RAISED),
             ) {
                 Column(
                     modifier = Modifier

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/shell/NavigationSidebar.kt
@@ -1235,7 +1235,7 @@ private fun navigationItemLabelWithMenu(
                 }
             }
         } else if (bookmarkCount > 0) {
-            // Bookmark badge — visible when not hovered, hidden when menu button appears
+            val bookmarkColor = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer else AppColors.countBadgeAccentColor()
             Row(
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -1245,12 +1245,12 @@ private fun navigationItemLabelWithMenu(
                     imageVector = Icons.Default.Bookmark,
                     contentDescription = null,
                     modifier = Modifier.size((10 * fontScale).dp),
-                    tint = AppColors.countBadgeAccentColor(),
+                    tint = bookmarkColor,
                 )
                 Text(
                     text = "$bookmarkCount",
                     style = AppTextStyles.hint,
-                    color = AppColors.countBadgeAccentColor(),
+                    color = bookmarkColor,
                 )
             }
         }

--- a/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/Main.kt
@@ -1336,9 +1336,6 @@ fun app(frameWindowScope: FrameWindowScope? = null, windowState: WindowState? = 
                                 onAddProvider = {
                                     settingsViewModel.openAddProviderWizard()
                                 },
-                                onShowAbout = {
-                                    showAboutDialog = true
-                                },
                             )
 
                             // Event Log Panel - BOTTOM position

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectView.kt
@@ -233,7 +233,7 @@ fun projectView(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(bottom = Spacing.large),
-                        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                         shape = MaterialTheme.shapes.large,
                     ) {
                         Row(

--- a/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsView.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/project/ProjectsView.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -308,7 +309,7 @@ internal fun embeddingModelNotConfiguredBanner(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Row(
             modifier = Modifier
@@ -326,17 +327,20 @@ internal fun embeddingModelNotConfiguredBanner(
                     Icons.Default.Info,
                     contentDescription = null,
                     modifier = Modifier.size(18.dp),
+                    tint = AppTextStyles.primaryContent,
                 )
-                Text(
-                    text = stringResource(
-                        if (providerSupportsEmbedding) {
-                            "projects.rag.embedding.not.configured"
-                        } else {
-                            "projects.rag.embedding.unsupported.provider"
-                        },
-                    ),
-                    style = AppTextStyles.caption,
-                )
+                SelectionContainer {
+                    Text(
+                        text = stringResource(
+                            if (providerSupportsEmbedding) {
+                                "projects.rag.embedding.not.configured"
+                            } else {
+                                "projects.rag.embedding.unsupported.provider"
+                            },
+                        ),
+                        style = AppTextStyles.caption.copy(color = AppTextStyles.secondaryContent),
+                    )
+                }
             }
             linkButton(onClick = onConfigureClick) {
                 Text(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AIProviderSettingsSection.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -104,7 +105,7 @@ fun aiProviderSettingsSection(viewModel: AIProviderViewModel) {
                 // Active provider card — Edit current instance or Add a new one
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Row(
                         modifier = Modifier
@@ -186,7 +187,7 @@ private fun providerModelConfigCard(instance: ProviderInstance, viewModel: AIPro
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -364,6 +365,8 @@ private fun providerModelSelectorField(
     value: String,
     placeholder: String,
     onClick: () -> Unit,
+    labelColor: Color = AppTextStyles.primaryContent,
+    hintColor: Color = AppTextStyles.secondaryContent,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -376,11 +379,11 @@ private fun providerModelSelectorField(
         ) {
             Text(
                 text = label,
-                style = AppTextStyles.body,
+                style = AppTextStyles.body.copy(color = labelColor),
             )
             Text(
                 text = hint,
-                style = AppTextStyles.caption,
+                style = AppTextStyles.caption.copy(color = hintColor),
             )
         }
 
@@ -500,8 +503,8 @@ private fun providerModelTypePickerDialog(
                             modifier = Modifier.fillMaxWidth().padding(Spacing.large),
                             verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
                         ) {
-                            Text(text = stringResource("settings.model.current"), style = AppTextStyles.fieldLabel, color = MaterialTheme.colorScheme.onSecondaryContainer)
-                            Text(text = currentValue, style = AppTextStyles.sectionTitle, color = MaterialTheme.colorScheme.onSecondaryContainer)
+                            Text(text = stringResource("settings.model.current"), style = AppTextStyles.fieldLabel, color = MaterialTheme.colorScheme.onPrimaryContainer)
+                            Text(text = currentValue, style = AppTextStyles.sectionTitle, color = MaterialTheme.colorScheme.onPrimaryContainer)
                         }
                     }
                 }
@@ -607,6 +610,8 @@ private fun providerModelTypePickerDialog(
 private fun providerConfigurableField(
     field: SettingField,
     onValueChange: (String) -> Unit,
+    labelColor: Color = AppTextStyles.primaryContent,
+    descriptionColor: Color = AppTextStyles.secondaryContent,
 ) {
     var showSavedIndicator by remember { mutableStateOf(false) }
 
@@ -628,11 +633,11 @@ private fun providerConfigurableField(
         ) {
             Text(
                 text = field.label,
-                style = AppTextStyles.body,
+                style = AppTextStyles.body.copy(color = labelColor),
             )
             Text(
                 text = field.description,
-                style = AppTextStyles.caption,
+                style = AppTextStyles.caption.copy(color = descriptionColor),
             )
         }
 

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutDialog.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutDialog.kt
@@ -51,7 +51,7 @@ fun aboutDialog(
                 // Version Info
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),
@@ -90,7 +90,7 @@ fun aboutDialog(
                 // Description
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),
@@ -110,7 +110,7 @@ fun aboutDialog(
                 // License
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Column(
                         modifier = Modifier.padding(Spacing.large),

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AboutSettingsSection.kt
@@ -76,7 +76,7 @@ fun aboutSettingsSection() {
                 // Application Info Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Column(
                         modifier = Modifier
@@ -145,7 +145,7 @@ fun aboutSettingsSection() {
                 // Description Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Column(
                         modifier = Modifier
@@ -167,7 +167,7 @@ fun aboutSettingsSection() {
                 // License Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Column(
                         modifier = Modifier
@@ -195,7 +195,7 @@ fun aboutSettingsSection() {
                 // Runtime Information Card
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Column(
                         modifier = Modifier
@@ -227,7 +227,7 @@ fun aboutSettingsSection() {
                 // Links Section
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                    colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                 ) {
                     Column(
                         modifier = Modifier

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/AdvancedSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/AdvancedSettingsSection.kt
@@ -155,7 +155,7 @@ private fun logLevelCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -250,7 +250,7 @@ private fun logViewerCard(
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -350,7 +350,7 @@ private fun analyticsSection() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -402,7 +402,7 @@ private fun developerModeSection() {
     // Developer Mode Card
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -442,7 +442,7 @@ private fun developerModeSection() {
 private fun ragConfigurationSection() {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -621,7 +621,7 @@ private fun ragConfigurationSection() {
 private fun modelsConfigurationSection() {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -658,7 +658,7 @@ private fun memoryConfigurationSection() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/McpServerManagementSection.kt
@@ -145,7 +145,7 @@ fun mcpServerTemplatesSection() {
 
                     Card(
                         modifier = Modifier.fillMaxWidth(),
-                        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+                        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
                     ) {
                         if (mcpInstances.isEmpty()) {
                             Box(

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/NetworkSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/NetworkSettingsSection.kt
@@ -118,7 +118,7 @@ private fun proxyConfigurationCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/VoiceSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/VoiceSettingsSection.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -42,6 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.style.TextOverflow
@@ -185,7 +187,7 @@ private fun voiceConfigCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -268,6 +270,7 @@ private fun voiceConfigCard() {
                 placeholder = { Text(stringResource("settings.voice.stt_model.placeholder")) },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
+                colors = AppColors.outlinedTextFieldColors(),
             )
 
             // Auto-send belongs to dictation (STT) — it decides what happens with the
@@ -326,6 +329,7 @@ private fun voiceConfigCard() {
                 placeholder = { Text(stringResource("settings.voice.tts_model.placeholder")) },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
+                colors = AppColors.outlinedTextFieldColors(),
             )
 
             // OpenAI's voice names are a fixed enum — offer a dropdown so users can't type an
@@ -353,6 +357,7 @@ private fun voiceConfigCard() {
                         placeholder = { Text(stringResource("settings.voice.tts_voice.placeholder_piper")) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
+                        colors = AppColors.outlinedTextFieldColors(),
                     )
                     Text(
                         text = stringResource("settings.voice.tts_voice.piper_hint"),
@@ -487,6 +492,7 @@ private fun voiceProviderSelector(
     expanded: Boolean,
     onExpandedChange: (Boolean) -> Unit,
     onSelect: (VoiceProvider) -> Unit,
+    labelColor: Color = AppTextStyles.primaryContent,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -495,7 +501,7 @@ private fun voiceProviderSelector(
     ) {
         Text(
             text = label,
-            style = AppTextStyles.fieldLabel,
+            style = AppTextStyles.fieldLabel.copy(color = labelColor),
             modifier = Modifier.weight(1f).padding(end = Spacing.large),
         )
 
@@ -575,6 +581,7 @@ private fun voiceOptionSelector(
     expanded: Boolean,
     onExpandedChange: (Boolean) -> Unit,
     onSelect: (String) -> Unit,
+    labelColor: Color = AppTextStyles.primaryContent,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -583,7 +590,7 @@ private fun voiceOptionSelector(
     ) {
         Text(
             text = label,
-            style = AppTextStyles.fieldLabel,
+            style = AppTextStyles.fieldLabel.copy(color = labelColor),
             modifier = Modifier.weight(1f).padding(end = Spacing.large),
         )
 
@@ -645,6 +652,7 @@ private fun endpointField(
     label: String,
     value: String,
     onValueChange: (String) -> Unit,
+    colors: TextFieldColors = AppColors.outlinedTextFieldColors(),
 ) {
     OutlinedTextField(
         value = value,
@@ -652,6 +660,7 @@ private fun endpointField(
         label = { Text(label) },
         modifier = Modifier.fillMaxWidth(),
         singleLine = true,
+        colors = colors,
     )
 }
 
@@ -661,6 +670,8 @@ private fun voiceToggleRow(
     description: String,
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
+    labelColor: Color = AppTextStyles.primaryContent,
+    descriptionColor: Color = AppTextStyles.secondaryContent,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -668,8 +679,8 @@ private fun voiceToggleRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f).padding(end = Spacing.large)) {
-            Text(text = label, style = AppTextStyles.fieldLabel)
-            Text(text = description, style = AppTextStyles.caption)
+            Text(text = label, style = AppTextStyles.fieldLabel.copy(color = labelColor))
+            Text(text = description, style = AppTextStyles.caption.copy(color = descriptionColor))
         }
         Switch(
             checked = checked,
@@ -693,6 +704,9 @@ private fun voiceIntField(
     value: Int,
     minValue: Int,
     onValueChange: (Int) -> Unit,
+    labelColor: Color = AppTextStyles.primaryContent,
+    hintColor: Color = AppTextStyles.secondaryContent,
+    colors: TextFieldColors = AppColors.outlinedTextFieldColors(),
 ) {
     var lastValidValue by remember { mutableStateOf(value) }
     var textValue by remember { mutableStateOf(LocalizationManager.formatNumber(value)) }
@@ -714,7 +728,7 @@ private fun voiceIntField(
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall)) {
-        Text(text = label, style = AppTextStyles.body)
+        Text(text = label, style = AppTextStyles.body.copy(color = labelColor))
         val parsedValue = textValue.toIntOrNull()
         OutlinedTextField(
             value = textValue,
@@ -739,7 +753,7 @@ private fun voiceIntField(
                         textValue = LocalizationManager.formatNumber(lastValidValue)
                     }
                 },
-            textStyle = AppTextStyles.body,
+            textStyle = AppTextStyles.body.copy(color = Color.Unspecified),
             singleLine = true,
             isError = isEditing && (parsedValue == null || parsedValue < minValue),
             trailingIcon = {
@@ -752,8 +766,8 @@ private fun voiceIntField(
                     )
                 }
             },
-            colors = AppColors.outlinedTextFieldColors(),
+            colors = colors,
         )
-        Text(text = hint, style = AppTextStyles.caption)
+        Text(text = hint, style = AppTextStyles.caption.copy(color = hintColor))
     }
 }

--- a/desktop/src/main/kotlin/io/askimo/desktop/settings/WebSearchSettingsSection.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/settings/WebSearchSettingsSection.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.style.TextOverflow
@@ -147,7 +148,7 @@ private fun webSearchConfigCard() {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        colors = AppColors.cardColors(AppColors.Elevation.ACCENT),
+        colors = AppColors.cardColors(AppColors.Elevation.RAISED),
     ) {
         Column(
             modifier = Modifier
@@ -398,6 +399,7 @@ private fun webSearchConfigCard() {
 private fun braveApiKeyField(
     value: String,
     onValueChange: (String) -> Unit,
+    linkColor: Color = AppTextStyles.primaryContent,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
         AppComponents.appSecretTextField(
@@ -416,10 +418,10 @@ private fun braveApiKeyField(
                 }
             },
         ) {
-            Icon(Icons.Default.Info, contentDescription = null, modifier = Modifier.size(14.dp))
+            Icon(Icons.Default.Info, contentDescription = null, tint = linkColor, modifier = Modifier.size(14.dp))
             Text(
                 text = stringResource("settings.web_search.get_api_key"),
-                style = AppTextStyles.caption,
+                style = AppTextStyles.caption.copy(color = linkColor),
                 modifier = Modifier.padding(start = 4.dp),
             )
         }
@@ -430,6 +432,7 @@ private fun braveApiKeyField(
 private fun tavilyApiKeyField(
     value: String,
     onValueChange: (String) -> Unit,
+    linkColor: Color = AppTextStyles.primaryContent,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
         AppComponents.appSecretTextField(
@@ -448,10 +451,10 @@ private fun tavilyApiKeyField(
                 }
             },
         ) {
-            Icon(Icons.Default.Info, contentDescription = null, modifier = Modifier.size(14.dp))
+            Icon(Icons.Default.Info, contentDescription = null, tint = linkColor, modifier = Modifier.size(14.dp))
             Text(
                 text = stringResource("settings.web_search.get_api_key"),
-                style = AppTextStyles.caption,
+                style = AppTextStyles.caption.copy(color = linkColor),
                 modifier = Modifier.padding(start = 4.dp),
             )
         }

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/FooterBar.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import io.askimo.core.VersionInfo
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.getConfigInfo
 import io.askimo.core.event.EventBus
@@ -214,7 +213,6 @@ private fun aiConfigInfo(
 fun footerBar(
     onShowUpdateDetails: () -> Unit = {},
     onAddProvider: () -> Unit = {},
-    onShowAbout: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -228,19 +226,6 @@ fun footerBar(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
-            themedTooltip(text = stringResource("menu.about")) {
-                Text(
-                    text = "v${VersionInfo.version}",
-                    style = AppTextStyles.caption,
-                    color = AppColors.tertiaryIconColor(),
-                    modifier = Modifier
-                        .align(Alignment.CenterStart)
-                        .pointerHoverIcon(PointerIcon.Hand)
-                        .clickableCard { onShowAbout() }
-                        .padding(horizontal = 4.dp, vertical = 2.dp),
-                )
-            }
-
             // Centre — unified provider + model selector
             Box(modifier = Modifier.align(Alignment.Center)) {
                 aiConfigInfo(onAddProvider = onAddProvider)

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/NavigationSidebar.kt
@@ -6,6 +6,7 @@ package io.askimo.desktop.shell
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -198,7 +199,10 @@ private fun communityUserProfileSection(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { showMenu = true }
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { showMenu = true }
                     .pointerHoverIcon(PointerIcon.Hand)
                     .padding((8 * fontScale).dp),
                 horizontalArrangement = Arrangement.spacedBy((12 * fontScale).dp),
@@ -238,13 +242,15 @@ private fun communityUserProfileSection(
                     tint = AppColors.tertiaryIconColor(),
                 )
             }
-            communityProfileMenu(
-                showMenu = showMenu,
-                onDismiss = { showMenu = false },
-                onEditUserProfile = onEditUserProfile,
-                onNavigateToSettings = onNavigateToSettings,
-                onNavigateToAbout = onNavigateToAbout,
-            )
+            Box(modifier = Modifier.align(Alignment.CenterEnd)) {
+                communityProfileMenu(
+                    showMenu = showMenu,
+                    onDismiss = { showMenu = false },
+                    onEditUserProfile = onEditUserProfile,
+                    onNavigateToSettings = onNavigateToSettings,
+                    onNavigateToAbout = onNavigateToAbout,
+                )
+            }
         }
     } else {
         Box {

--- a/desktop/src/main/kotlin/io/askimo/desktop/shell/ProviderModelPanel.kt
+++ b/desktop/src/main/kotlin/io/askimo/desktop/shell/ProviderModelPanel.kt
@@ -499,7 +499,7 @@ private fun modelListColumn(
                                                 Box(
                                                     modifier = Modifier
                                                         .background(
-                                                            MaterialTheme.colorScheme.tertiaryContainer,
+                                                            AppColors.variantBadgeContainerColor(AppColors.BadgeTone.BUILT_IN),
                                                             RoundedCornerShape(4.dp),
                                                         )
                                                         .padding(horizontal = 4.dp, vertical = 1.dp),
@@ -507,7 +507,7 @@ private fun modelListColumn(
                                                     Text(
                                                         text = stringResource("provider.model.default.badge"),
                                                         style = AppTextStyles.hint,
-                                                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                                        color = AppColors.variantBadgeContentColor(AppColors.BadgeTone.BUILT_IN),
                                                     )
                                                 }
                                             }
@@ -815,6 +815,20 @@ internal fun instanceRow(
         else -> Color.Transparent
     }
 
+    // Content tints follow the row's own background so text/icons stay legible and
+    // consistent whether the row is active (primaryContainer), previewed/pending
+    // (secondaryContainer), or at rest (transparent, plain surface).
+    val contentColor = when {
+        isActive -> MaterialTheme.colorScheme.onPrimaryContainer
+        isPending -> MaterialTheme.colorScheme.onSecondaryContainer
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+    val secondaryContentColor = when {
+        isActive -> MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.82f)
+        isPending -> MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.82f)
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
     val interactionSource = remember { MutableInteractionSource() }
     val isHovered by interactionSource.collectIsHoveredAsState()
 
@@ -855,11 +869,7 @@ internal fun instanceRow(
             Text(
                 text = instance.displayName,
                 style = AppTextStyles.caption,
-                color = when {
-                    isActive -> MaterialTheme.colorScheme.onPrimaryContainer
-                    isPending -> MaterialTheme.colorScheme.onSecondaryContainer
-                    else -> MaterialTheme.colorScheme.onSurface
-                },
+                color = contentColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
@@ -872,7 +882,7 @@ internal fun instanceRow(
                             Icon(
                                 Icons.Default.Edit,
                                 contentDescription = "Edit",
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                tint = secondaryContentColor,
                                 modifier = Modifier.size(13.dp),
                             )
                         }
@@ -891,7 +901,7 @@ internal fun instanceRow(
                     Icon(
                         Icons.Default.RadioButtonChecked,
                         contentDescription = "Active",
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = contentColor,
                         modifier = Modifier.size(14.dp),
                     )
                 }


### PR DESCRIPTION
When using the current  main  branch of Askimo, the UI colors no longer match the custom scheme we selected. This drift appears to be caused by recent style changes. The released tag ( v1.4.18 ) renders the theme correctly, so the issue is isolated to the development snapshot.