### PR TITLE
refactor(core): Implement explicit retry policy handling in exceptions

### DIFF
--- a/shared/src/main/kotlin/io/askimo/core/exception/AskimoException.kt
+++ b/shared/src/main/kotlin/io/askimo/core/exception/AskimoException.kt
@@ -5,6 +5,29 @@
 package io.askimo.core.exception
 
 /**
+ * How a classified error should be handled by automatic retry loops.
+ *
+ * Cross-cutting across the user/system error split — e.g. [RemoteServerException] and
+ * [RateLimitException] are user-facing errors that are also retryable, while
+ * [AuthenticationException] is a user-facing error that is not.
+ */
+enum class RetryPolicy {
+    /** User must fix something (auth, config, model choice) before retrying makes sense. */
+    NONE,
+
+    /**
+     * Retry immediately, no backoff — but only after the caller applies a corrective
+     * side effect first (e.g. shrink the context budget, disable sampling params,
+     * drop a malformed tool call). The bounded attempt count is owned by the caller
+     * (e.g. the context-retry loop in `sendStreamingMessageWithCallback`), not by this enum.
+     */
+    IMMEDIATE,
+
+    /** Transient/overloaded backend — retry after a backoff delay (rate limits, 5xx, network blips). */
+    BACKOFF,
+}
+
+/**
  * Base exception for all Askimo-specific errors.
  * Provides message keys for localization and distinguishes between user and system errors.
  */
@@ -26,4 +49,12 @@ sealed class AskimoException(
      * Whether this is a user error (can be fixed by user) or system error (needs support).
      */
     abstract fun isUserError(): Boolean
+
+    /**
+     * How automatic retry loops should treat this error. Defaults to [RetryPolicy.NONE] —
+     * most errors require the user (or a config/cache change) to fix something before a
+     * retry has any chance of succeeding. Override in specific subclasses that are known
+     * to be transient (see [RetryPolicy] docs).
+     */
+    open val retryPolicy: RetryPolicy = RetryPolicy.NONE
 }

--- a/shared/src/main/kotlin/io/askimo/core/exception/ExceptionHandler.kt
+++ b/shared/src/main/kotlin/io/askimo/core/exception/ExceptionHandler.kt
@@ -25,22 +25,39 @@ object ExceptionHandler {
     fun handle(
         throwable: Throwable,
         contextId: String? = null,
-    ): String {
-        // 1. Classify exception
-        val askimoException = ExceptionMapper.map(throwable)
+    ): String = render(ExceptionMapper.map(throwable), contextId)
 
-        // 2. Get localized message (uses LocalizationManager.getCurrentLocale() internally)
+    /**
+     * Same as [handle], but for a [Throwable] the caller has already classified via
+     * [ExceptionMapper.map] — e.g. because it needed the classification for something else
+     * first (like deciding a retry policy). Avoids re-running classification a second time,
+     * which for previously-unmapped errors would also re-log the "unmapped exception" warning.
+     *
+     * @param askimoException The already-classified exception to render
+     * @param contextId Optional context ID (session ID, command name, etc.) for logging
+     * @return Localized user-friendly error message
+     */
+    fun handle(
+        askimoException: AskimoException,
+        contextId: String? = null,
+    ): String = render(askimoException, contextId)
+
+    private fun render(
+        askimoException: AskimoException,
+        contextId: String?,
+    ): String {
+        // Get localized message (uses LocalizationManager.getCurrentLocale() internally)
         val localizedMessage = LocalizationManager.getString(
             askimoException.getMessageKey(),
         )
 
-        // 3. Replace placeholders with actual values
+        // Replace placeholders with actual values
         var result = localizedMessage
         askimoException.getMessageArgs().forEach { (key, value) ->
             result = result.replace("{$key}", value)
         }
 
-        // 4. Log appropriately
+        // Log appropriately
         val logPrefix = contextId?.let { "[$it] " } ?: ""
         if (askimoException.isUserError()) {
             log.warn("${logPrefix}User error: ${askimoException.message}")

--- a/shared/src/main/kotlin/io/askimo/core/exception/ExceptionMapper.kt
+++ b/shared/src/main/kotlin/io/askimo/core/exception/ExceptionMapper.kt
@@ -7,10 +7,12 @@ package io.askimo.core.exception
 import dev.langchain4j.exception.InternalServerException
 import dev.langchain4j.exception.ModelNotFoundException
 import io.askimo.core.logging.logger
+import io.askimo.core.providers.isContextLengthMessage
 import java.net.ConnectException
 import java.net.NoRouteToHostException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.nio.channels.UnresolvedAddressException
 
 /**
  * Maps generic exceptions to Askimo-specific exceptions with user-friendly messages.
@@ -93,10 +95,13 @@ object ExceptionMapper {
      * @return An AskimoException if matched, null otherwise
      */
     private fun matchByType(exception: Throwable): AskimoException? = when (exception) {
-        // Network exceptions
+        // Network exceptions — includes UnresolvedAddressException (thrown when a hostname
+        // can't be resolved to a socket address, e.g. offline / bad DNS), which previously
+        // had its own hand-rolled, non-localized message duplicated at the streaming call site.
         is ConnectException,
         is UnknownHostException,
         is NoRouteToHostException,
+        is UnresolvedAddressException,
         -> NetworkException(cause = exception)
 
         // Timeout exceptions
@@ -204,18 +209,25 @@ object ExceptionMapper {
                 combinedMessage.contains("upgrade or purchase credits", ignoreCase = true) ->
                 InsufficientCreditsException(cause = rootCause)
 
-            // Context window exceeded (checked before generic 400 to avoid misclassification)
+            // Unsupported sampling parameters — some models (esp. reasoning models) reject
+            // temperature/top_p entirely. Checked before the generic 400 bucket below.
             (
-                combinedMessage.contains("context", ignoreCase = true) && (
-                    combinedMessage.contains("length", ignoreCase = true) ||
-                        combinedMessage.contains("limit", ignoreCase = true) ||
-                        combinedMessage.contains("exceeded", ignoreCase = true) ||
-                        combinedMessage.contains("too long", ignoreCase = true) ||
-                        combinedMessage.contains("maximum context", ignoreCase = true) ||
-                        combinedMessage.contains("token limit", ignoreCase = true) ||
-                        combinedMessage.contains("exceed", ignoreCase = true)
-                    )
-                ) || combinedMessage.contains("413", ignoreCase = true) ->
+                combinedMessage.contains("temperature", ignoreCase = true) ||
+                    combinedMessage.contains("top_p", ignoreCase = true) ||
+                    combinedMessage.contains("topP", ignoreCase = true)
+                ) && (
+                combinedMessage.contains("does not support", ignoreCase = true) ||
+                    combinedMessage.contains("not supported", ignoreCase = true) ||
+                    combinedMessage.contains("unsupported", ignoreCase = true) ||
+                    combinedMessage.contains("unsupported value", ignoreCase = true) ||
+                    combinedMessage.contains("cannot both be specified", ignoreCase = true)
+                ) ->
+                UnsupportedSamplingException(cause = rootCause)
+
+            // Context window exceeded (checked before generic 400 to avoid misclassification).
+            // Reuses the exact same pattern as `Throwable.isContextLengthError()` (the outer
+            // context-retry loop in ChatClientExtensions) so the two never drift apart.
+            isContextLengthMessage(combinedMessage) ->
                 ContextLengthException(cause = rootCause)
 
             // Malformed/hallucinated tool call — the model streamed a tool_calls entry whose

--- a/shared/src/main/kotlin/io/askimo/core/exception/UserException.kt
+++ b/shared/src/main/kotlin/io/askimo/core/exception/UserException.kt
@@ -28,6 +28,9 @@ class NetworkException(
     override fun getMessageArgs() = mapOf(
         "endpoint" to (endpoint?.let { " at $it" } ?: ""),
     )
+
+    // Transient connectivity blip (DNS hiccup, brief drop) — worth a backoff retry.
+    override val retryPolicy = RetryPolicy.BACKOFF
 }
 
 /**
@@ -58,6 +61,9 @@ class RateLimitException(
     override fun getMessageArgs() = mapOf(
         "retryAfter" to (retryAfterSeconds?.toString() ?: ""),
     )
+
+    // Provider explicitly asked us to slow down — worth a backoff retry.
+    override val retryPolicy = RetryPolicy.BACKOFF
 }
 
 /**
@@ -71,6 +77,9 @@ class TimeoutException(
     override fun getMessageKey() = "error.timeout"
 
     override fun getMessageArgs() = mapOf("timeout" to timeoutSeconds.toString())
+
+    // A slow response doesn't mean the next attempt will also time out — worth a backoff retry.
+    override val retryPolicy = RetryPolicy.BACKOFF
 }
 
 /**
@@ -124,6 +133,10 @@ class ContextLengthException(
 ) : UserException("Context window exceeded", cause) {
     override fun getMessageKey() = "error.context_length"
     override fun getMessageArgs() = emptyMap<String, String>()
+
+    // The streaming loop shrinks its context-size cache entry and retries immediately —
+    // see `ChatClientExtensions.sendStreamingMessageWithCallback`'s context-retry loop.
+    override val retryPolicy = RetryPolicy.IMMEDIATE
 }
 
 /**
@@ -155,6 +168,9 @@ class RemoteServerException(
 ) : UserException("Remote AI server error", cause) {
     override fun getMessageKey() = "error.remote_server"
     override fun getMessageArgs() = mapOf("details" to details)
+
+    // Transient infrastructure overload on the provider's side — worth a backoff retry.
+    override val retryPolicy = RetryPolicy.BACKOFF
 }
 
 /**
@@ -184,6 +200,28 @@ class MalformedToolCallException(
 ) : UserException("The AI model produced an invalid tool call", cause) {
     override fun getMessageKey() = "error.malformed_tool_call"
     override fun getMessageArgs() = emptyMap<String, String>()
+
+    // Transient AI/backend glitch — the streaming loop retries immediately without penalty.
+    override val retryPolicy = RetryPolicy.IMMEDIATE
+}
+
+/**
+ * The model rejected a sampling parameter (temperature, top_p) as unsupported for this
+ * model/provider combination — e.g. some reasoning models only accept default sampling.
+ *
+ * This is retried immediately after the caller disables sampling params for this
+ * model/provider in [io.askimo.core.providers.ModelCapabilitiesCache] (see
+ * `ChatClientExtensions.sendStreamingMessageWithCallback`), so it never actually
+ * reaches the user in practice — surfaced as a [UserException] only for the rare
+ * case where every automatic retry also failed.
+ */
+class UnsupportedSamplingException(
+    cause: Throwable? = null,
+) : UserException("Unsupported sampling parameters for this model", cause) {
+    override fun getMessageKey() = "error.unsupported_sampling"
+    override fun getMessageArgs() = emptyMap<String, String>()
+
+    override val retryPolicy = RetryPolicy.IMMEDIATE
 }
 
 /**

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -6,8 +6,6 @@ package io.askimo.core.providers
 
 import dev.langchain4j.data.message.Content
 import dev.langchain4j.data.message.UserMessage
-import dev.langchain4j.exception.InternalServerException
-import dev.langchain4j.exception.ModelNotFoundException
 import dev.langchain4j.model.chat.ChatModel
 import dev.langchain4j.model.chat.request.ChatRequest
 import dev.langchain4j.model.chat.request.ResponseFormat
@@ -19,11 +17,14 @@ import dev.langchain4j.model.chat.request.json.JsonStringSchema
 import dev.langchain4j.model.googleai.GeneratedImageHelper
 import io.askimo.core.context.AppContext
 import io.askimo.core.context.ChatContext
-import io.askimo.core.exception.AuthenticationException
+import io.askimo.core.exception.AskimoException
+import io.askimo.core.exception.ContextLengthException
 import io.askimo.core.exception.ExceptionHandler
-import io.askimo.core.exception.LocalServerException
-import io.askimo.core.exception.ModelNotFoundChatException
+import io.askimo.core.exception.ExceptionMapper
+import io.askimo.core.exception.MalformedToolCallException
+import io.askimo.core.exception.RetryPolicy
 import io.askimo.core.exception.ToolExecutionException
+import io.askimo.core.exception.UnsupportedSamplingException
 import io.askimo.core.i18n.LocalizationManager
 import io.askimo.core.intent.DetectAiResponseIntentCommand
 import io.askimo.core.intent.FollowUpSuggestion
@@ -43,54 +44,22 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
-import java.nio.channels.UnresolvedAddressException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-
-/**
- * Extension function to detect if an exception is due to unsupported sampling parameters.
- * Checks for common error messages related to temperature, topP, or other sampling parameters.
- */
-private fun Throwable.isUnsupportedSamplingError(): Boolean {
-    val message = this.message ?: ""
-    return (message.contains("temperature") || message.contains("top_p") || message.contains("topP")) &&
-        (
-            message.contains("does not support") ||
-                message.contains("not supported") ||
-                message.contains("unsupported") ||
-                message.contains("Unsupported value") ||
-                message.contains("cannot both be specified")
-            )
-}
-
-/**
- * Extension function to detect if an exception is due to the model streaming a malformed
- * tool call — e.g. a hallucinated `tool_calls` entry whose `name`/`arguments` never got
- * fully populated across the delta stream, which langchain4j's internal request builder
- * rejects with messages like `ToolExecutionRequest.arguments must be provided`.
- *
- * This is a transient AI/backend glitch (weaker or local models occasionally emit an
- * incomplete tool-call delta stream, especially with several tools enabled or parallel
- * tool calls) rather than a real configuration problem — so instead of failing the whole
- * turn with a raw internal error message, it's treated like a context-length error:
- * retried immediately with a fresh request (see [sendStreamingMessageWithCallback]).
- */
-private fun Throwable.isMalformedToolCallError(): Boolean {
-    val message = this.message ?: ""
-    return message.contains("ToolExecutionRequest", ignoreCase = true) &&
-        (
-            message.contains("must be provided", ignoreCase = true) ||
-                message.contains("must not be blank", ignoreCase = true)
-            )
-}
 
 /**
  * Result of classifying a streaming error.
  * @see classifyStreamingError
  */
 internal sealed class StreamingErrorResult {
-    /** Retry silently — no message shown to the user. */
-    object Retryable : StreamingErrorResult()
+    /**
+     * Retry silently — no message shown to the user.
+     *
+     * @property exception The classified error, so the call site can apply the correct
+     * side effect (shrink context cache, disable sampling, etc.) without re-deriving
+     * the classification itself via a second round of string-matching.
+     */
+    data class Retryable(val exception: AskimoException) : StreamingErrorResult()
 
     /** Stop retrying — show [message] in the chat and mark the response as failed. */
     data class Terminal(val message: String) : StreamingErrorResult()
@@ -99,100 +68,52 @@ internal sealed class StreamingErrorResult {
 /**
  * Pure classification function: maps a streaming [Throwable] to a [StreamingErrorResult].
  *
- * Has no side-effects (no logging, no cache mutations). Side-effects such as cache
- * updates and logging remain in the call site so that this function is fully
- * unit-testable without any infrastructure.
+ * No side-effects (no logging, no cache mutations) — those stay at the call site so this
+ * stays fully unit-testable. Delegates to [ExceptionMapper] for classification and retry
+ * policy, except two cases needing context the mapper doesn't have:
+ * - [InsufficientContextException]'s message is already fully rendered.
+ * - The empty-HTTP-response case needs `provider`/`model` to build its hint.
  */
 internal fun classifyStreamingError(
     e: Throwable,
     provider: ModelProvider,
     model: String,
 ): StreamingErrorResult {
-    val errorMessage = e.message ?: ""
-
-    // ── RETRYABLE ─────────────────────────────────────────────────────────────
-
-    // InsufficientContextException must be checked BEFORE isContextLengthError because
-    // its rendered message contains "context" + "too long" which would falsely match.
+    // InsufficientContextException's message contains "context" + "too long", which would
+    // otherwise be misclassified as a retryable ContextLengthException by ExceptionMapper —
+    // so it must be checked first, and always terminal (retries are already exhausted by
+    // the time this is thrown).
     if (e is InsufficientContextException) {
-        return StreamingErrorResult.Terminal(
-            e.message ?: "Insufficient context window",
-        )
+        return StreamingErrorResult.Terminal(e.message ?: "Insufficient context window")
     }
 
-    if (e.isContextLengthError()) return StreamingErrorResult.Retryable
-    if (e.isUnsupportedSamplingError()) return StreamingErrorResult.Retryable
-    if (e.isMalformedToolCallError()) return StreamingErrorResult.Retryable
-
-    // ── TERMINAL ──────────────────────────────────────────────────────────────
-
-    val msg: String = when {
-        e is InsufficientContextException ->
-            e.message ?: "Insufficient context window"
-
-        // unreachable, handled above
-
-        e is ToolExecutionException ->
-            e.errorDetails ?: "Tool execution failed"
-
-        e is InternalServerException ->
-            ExceptionHandler.handle(e)
-
-        errorMessage.contains("process has terminated", ignoreCase = true) ||
-            errorMessage.contains("llama-server", ignoreCase = true) ||
-            errorMessage.contains("llama_model_loader", ignoreCase = true) ||
-            errorMessage.contains("error loading model", ignoreCase = true) ||
-            (
-                errorMessage.contains("api_error", ignoreCase = true) &&
-                    errorMessage.contains("exit status", ignoreCase = true)
-                ) ->
-            ExceptionHandler.handle(LocalServerException(details = errorMessage, cause = e))
-
-        e.cause is UnresolvedAddressException ->
-            """
-            ⚠️  Unable to connect to the server!
-
-            Cannot resolve the server address. Please check:
-            1. Your internet connection is working
-            2. The server URL/endpoint is correct
-            3. There are no firewall or proxy issues blocking the connection
-            """.trimIndent()
-
-        run {
-            val causeMsg = e.cause?.message ?: ""
-            errorMessage.contains("header parser received no bytes", ignoreCase = true) ||
-                causeMsg.contains("header parser received no bytes", ignoreCase = true)
-        } -> {
-            val providerHint = LocalizationManager.getString("error.empty_http_response.hint.generic")
+    // Needs provider/model to render its hint — not derivable from the exception alone.
+    val causeMsg = e.cause?.message ?: ""
+    val errorMessage = e.message ?: ""
+    if (errorMessage.contains("header parser received no bytes", ignoreCase = true) ||
+        causeMsg.contains("header parser received no bytes", ignoreCase = true)
+    ) {
+        val providerHint = LocalizationManager.getString("error.empty_http_response.hint.generic")
+        return StreamingErrorResult.Terminal(
             LocalizationManager.getString(
                 "error.empty_http_response",
                 "${provider.providerKey()}:$model",
                 providerHint,
-            )
-        }
-
-        e is ModelNotFoundException ->
-            ExceptionHandler.handle(ModelNotFoundChatException(model = model, cause = e))
-
-        errorMessage.contains("model is required", ignoreCase = true) ||
-            errorMessage.contains("No model provided", ignoreCase = true) ||
-            errorMessage.contains("model not found", ignoreCase = true) ||
-            errorMessage.contains("invalid model", ignoreCase = true) ->
-            ExceptionHandler.handle(ModelNotFoundChatException(model = model, cause = e))
-
-        errorMessage.contains("api key") ||
-            errorMessage.contains("authentication") ||
-            errorMessage.contains("unauthorized") ||
-            errorMessage.contains("invalid API key") ||
-            errorMessage.contains("Incorrect API key provided") ||
-            errorMessage.contains("invalid_api_key") ||
-            e is dev.langchain4j.exception.AuthenticationException ->
-            ExceptionHandler.handle(AuthenticationException(cause = e))
-
-        else -> "\n[error] ${e.message ?: "unknown error"}\n"
+            ),
+        )
     }
 
-    return StreamingErrorResult.Terminal(msg)
+    val askimoException = ExceptionMapper.map(e)
+
+    // Only IMMEDIATE has an actual retry mechanism wired up at this call site (the
+    // context-retry loop in `sendStreamingMessageWithCallback`, bounded at 20 attempts).
+    // BACKOFF-classified errors (rate limits, transient 5xx, network blips) have no
+    // backoff loop implemented here yet, so — for now — they're rendered as Terminal
+    // just like NONE, rather than silently swallowed with no actual retry happening.
+    return when (askimoException.retryPolicy) {
+        RetryPolicy.IMMEDIATE -> StreamingErrorResult.Retryable(askimoException)
+        RetryPolicy.BACKOFF, RetryPolicy.NONE -> StreamingErrorResult.Terminal(ExceptionHandler.handle(e))
+    }
 }
 
 /**
@@ -365,18 +286,26 @@ fun ChatClient.sendStreamingMessageWithCallback(
 
                             when (val result = classifyStreamingError(e, provider, model)) {
                                 is StreamingErrorResult.Retryable -> {
-                                    // Apply side-effects for the specific retryable type,
-                                    // then countDown so the outer catch can loop.
-                                    if (e.isContextLengthError()) {
-                                        val modelKey = ModelCapabilitiesCache.modelKey(provider, model)
-                                        val currentSize = ModelCapabilitiesCache.get(modelKey).contextSize
-                                        val newSize = ModelCapabilitiesCache.reduceContextSize(modelKey, currentSize)
-                                        log.warn("Context length exceeded for $modelKey (attempt $contextRetryCount/${maxContextRetries + 1}). Reducing context size: $currentSize → $newSize tokens. Retrying immediately...")
-                                    } else if (e.isUnsupportedSamplingError()) {
-                                        log.warn("Unsupported sampling parameters detected. Falling back to non-sampling settings.")
-                                        ModelCapabilitiesCache.setSamplingSupport(provider, model, false)
-                                    } else if (e.isMalformedToolCallError()) {
-                                        log.warn("Model streamed a malformed tool call (${e.message}) — retrying immediately without penalty.")
+                                    // Apply the side effect specific to this retryable
+                                    // classification, then countDown so the outer catch can loop.
+                                    when (result.exception) {
+                                        is ContextLengthException -> {
+                                            val modelKey = ModelCapabilitiesCache.modelKey(provider, model)
+                                            val currentSize = ModelCapabilitiesCache.get(modelKey).contextSize
+                                            val newSize = ModelCapabilitiesCache.reduceContextSize(modelKey, currentSize)
+                                            log.warn("Context length exceeded for $modelKey (attempt $contextRetryCount/${maxContextRetries + 1}). Reducing context size: $currentSize → $newSize tokens. Retrying immediately...")
+                                        }
+
+                                        is UnsupportedSamplingException -> {
+                                            log.warn("Unsupported sampling parameters detected. Falling back to non-sampling settings.")
+                                            ModelCapabilitiesCache.setSamplingSupport(provider, model, false)
+                                        }
+
+                                        is MalformedToolCallException ->
+                                            log.warn("Model streamed a malformed tool call (${e.message}) — retrying immediately without penalty.")
+
+                                        else ->
+                                            log.warn("Retrying after ${result.exception::class.simpleName}: ${e.message}")
                                     }
                                     done.countDown()
                                 }
@@ -422,8 +351,10 @@ fun ChatClient.sendStreamingMessageWithCallback(
                 // ConfigurationErrorException is always terminal — never retry regardless of message content
                 if (e is ConfigurationErrorException) throw e
 
-                // Check if this is a context length error - immediate retry without backoff
-                if ((e.isContextLengthError() || e.isUnsupportedSamplingError() || e.isMalformedToolCallError()) && contextRetryCount < maxContextRetries) {
+                // Same classification the streaming path uses (ExceptionMapper is the single
+                // source of truth for retry policy) — covers the case where an error is thrown
+                // synchronously (not via onError) or wrapped as IllegalStateException above.
+                if (ExceptionMapper.map(e).retryPolicy == RetryPolicy.IMMEDIATE && contextRetryCount < maxContextRetries) {
                     contextRetryCount++
 
                     // Retry immediately with reduced context size (no backoff)
@@ -432,7 +363,7 @@ fun ChatClient.sendStreamingMessageWithCallback(
                     continue
                 }
 
-                // Not a context error or out of retries - rethrow
+                // Not an immediately-retryable error, or out of retries - rethrow
                 throw e
             }
         }

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -48,6 +48,22 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 /**
+ * Checks whether any message in this exception's cause chain contains [needle]
+ * (case-insensitive). Unlike a single `e.message` / `e.cause?.message` check, this
+ * walks arbitrarily deep — needed because HTTP clients commonly wrap the originating
+ * exception several levels deep (e.g. CompletionException -> RuntimeException -> IOException).
+ */
+private fun Throwable.causeChainContains(needle: String): Boolean {
+    var current: Throwable? = this
+    val seen = mutableSetOf<Throwable>()
+    while (current != null && seen.add(current)) {
+        if (current.message?.contains(needle, ignoreCase = true) == true) return true
+        current = current.cause
+    }
+    return false
+}
+
+/**
  * Result of classifying a streaming error.
  * @see classifyStreamingError
  */
@@ -88,11 +104,9 @@ internal fun classifyStreamingError(
     }
 
     // Needs provider/model to render its hint — not derivable from the exception alone.
-    val causeMsg = e.cause?.message ?: ""
-    val errorMessage = e.message ?: ""
-    if (errorMessage.contains("header parser received no bytes", ignoreCase = true) ||
-        causeMsg.contains("header parser received no bytes", ignoreCase = true)
-    ) {
+    // Walks the full cause chain since HTTP clients often wrap the originating IOException
+    // several levels deep (e.g. CompletionException -> RuntimeException -> IOException).
+    if (e.causeChainContains("header parser received no bytes")) {
         val providerHint = LocalizationManager.getString("error.empty_http_response.hint.generic")
         return StreamingErrorResult.Terminal(
             LocalizationManager.getString(
@@ -112,7 +126,7 @@ internal fun classifyStreamingError(
     // just like NONE, rather than silently swallowed with no actual retry happening.
     return when (askimoException.retryPolicy) {
         RetryPolicy.IMMEDIATE -> StreamingErrorResult.Retryable(askimoException)
-        RetryPolicy.BACKOFF, RetryPolicy.NONE -> StreamingErrorResult.Terminal(ExceptionHandler.handle(e))
+        RetryPolicy.BACKOFF, RetryPolicy.NONE -> StreamingErrorResult.Terminal(ExceptionHandler.handle(askimoException))
     }
 }
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ChatClientExtensions.kt
@@ -253,7 +253,6 @@ fun ChatClient.sendStreamingMessageWithCallback(
                         }.beforeToolExecution { before ->
                             val toolName = before.request().name()
                             val arguments = before.request().arguments()
-                            log.debug("Tool starting: {}", toolName)
                             onToolStarted?.invoke(toolName, arguments)
 
                             // ── Approval guardrail ─────────────────────────────────────────────
@@ -291,45 +290,59 @@ fun ChatClient.sendStreamingMessageWithCallback(
                             val arguments = tool.request().arguments()
                             val result = tool.result()
                             val hasFailed = tool.hasFailed()
-                            log.debug("Tool executed: {}", toolName)
                             onToolFinished?.invoke(toolName, arguments, result, hasFailed)
                         }
                         .onError { e ->
                             errorOccurred = true
                             capturedError = e
 
-                            when (val result = classifyStreamingError(e, provider, model)) {
-                                is StreamingErrorResult.Retryable -> {
-                                    // Apply the side effect specific to this retryable
-                                    // classification, then countDown so the outer catch can loop.
-                                    when (result.exception) {
-                                        is ContextLengthException -> {
-                                            val modelKey = ModelCapabilitiesCache.modelKey(provider, model)
-                                            val currentSize = ModelCapabilitiesCache.get(modelKey).contextSize
-                                            val newSize = ModelCapabilitiesCache.reduceContextSize(modelKey, currentSize)
-                                            log.warn("Context length exceeded for $modelKey (attempt $contextRetryCount/${maxContextRetries + 1}). Reducing context size: $currentSize → $newSize tokens. Retrying immediately...")
-                                        }
+                            val result = classifyStreamingError(e, provider, model)
+                            // Only apply the retry side effect (and actually retry) if there's
+                            // budget left — otherwise mutating the cache / disabling sampling
+                            // buys nothing since the outer catch won't loop again anyway, and
+                            // the user would be left without any terminal message on this attempt.
+                            val retriesRemain = contextRetryCount < maxContextRetries
 
-                                        is UnsupportedSamplingException -> {
-                                            log.warn("Unsupported sampling parameters detected. Falling back to non-sampling settings.")
-                                            ModelCapabilitiesCache.setSamplingSupport(provider, model, false)
-                                        }
-
-                                        is MalformedToolCallException ->
-                                            log.warn("Model streamed a malformed tool call (${e.message}) — retrying immediately without penalty.")
-
-                                        else ->
-                                            log.warn("Retrying after ${result.exception::class.simpleName}: ${e.message}")
+                            if (result is StreamingErrorResult.Retryable && retriesRemain) {
+                                // Apply the side effect specific to this retryable
+                                // classification, then countDown so the outer catch can loop.
+                                when (result.exception) {
+                                    is ContextLengthException -> {
+                                        val modelKey = ModelCapabilitiesCache.modelKey(provider, model)
+                                        val currentSize = ModelCapabilitiesCache.get(modelKey).contextSize
+                                        val newSize = ModelCapabilitiesCache.reduceContextSize(modelKey, currentSize)
+                                        log.warn("Context length exceeded for $modelKey (attempt $contextRetryCount/${maxContextRetries + 1}). Reducing context size: $currentSize → $newSize tokens. Retrying immediately...")
                                     }
-                                    done.countDown()
-                                }
 
-                                is StreamingErrorResult.Terminal -> {
-                                    terminalErrorMessage = result.message
-                                    sb.append(result.message)
-                                    onToken(result.message)
-                                    done.countDown()
+                                    is UnsupportedSamplingException -> {
+                                        log.warn("Unsupported sampling parameters detected. Falling back to non-sampling settings.")
+                                        ModelCapabilitiesCache.setSamplingSupport(provider, model, false)
+                                    }
+
+                                    is MalformedToolCallException ->
+                                        log.warn("Model streamed a malformed tool call (${e.message}) — retrying immediately without penalty.")
+
+                                    else ->
+                                        log.warn("Retrying after ${result.exception::class.simpleName}: ${e.message}")
                                 }
+                                done.countDown()
+                            } else {
+                                // Either genuinely Terminal, or Retryable but out of retry budget —
+                                // render a proper terminal message either way so the caller/user
+                                // sees feedback instead of a silent countDown followed by a bare
+                                // IllegalStateException further down.
+                                val message = when (result) {
+                                    is StreamingErrorResult.Terminal -> result.message
+
+                                    is StreamingErrorResult.Retryable -> {
+                                        log.warn("Retry budget exhausted for ${result.exception::class.simpleName} (attempt $contextRetryCount/${maxContextRetries + 1}) — treating as terminal.")
+                                        ExceptionHandler.handle(result.exception)
+                                    }
+                                }
+                                terminalErrorMessage = message
+                                sb.append(message)
+                                onToken(message)
+                                done.countDown()
                             }
                         }.start()
 

--- a/shared/src/main/kotlin/io/askimo/core/providers/ModelCapabilitiesCache.kt
+++ b/shared/src/main/kotlin/io/askimo/core/providers/ModelCapabilitiesCache.kt
@@ -506,20 +506,29 @@ data class ModelCapabilities(
 )
 
 /**
+ * Detects whether [message] indicates a context-length/token-limit error, based on common
+ * phrasing used by various AI providers.
+ *
+ * Takes a plain `String` (not a `Throwable`) so [io.askimo.core.exception.ExceptionMapper]
+ * can reuse the same pattern over its joined cause-chain message, avoiding a duplicate copy.
+ */
+fun isContextLengthMessage(message: String): Boolean {
+    val lower = message.lowercase()
+    return (
+        lower.contains("context") && (
+            lower.contains("length") ||
+                lower.contains("limit") ||
+                lower.contains("exceeded") ||
+                lower.contains("too long") ||
+                lower.contains("maximum context") ||
+                lower.contains("token limit") ||
+                lower.contains("exceed")
+            )
+        ) || lower.contains("413") // HTTP 413 Payload Too Large
+}
+
+/**
  * Extension function to detect if an exception is due to context length issues.
  * Checks for common error messages from various AI providers.
  */
-fun Throwable.isContextLengthError(): Boolean {
-    val message = this.message?.lowercase() ?: ""
-    return (
-        message.contains("context") && (
-            message.contains("length") ||
-                message.contains("limit") ||
-                message.contains("exceeded") ||
-                message.contains("too long") ||
-                message.contains("maximum context") ||
-                message.contains("token limit") ||
-                message.contains("exceed")
-            )
-        ) || message.contains("413") // HTTP 413 Payload Too Large
-}
+fun Throwable.isContextLengthError(): Boolean = isContextLengthMessage(this.message ?: "")

--- a/shared/src/test/kotlin/io/askimo/core/providers/StreamingErrorClassifierTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/providers/StreamingErrorClassifierTest.kt
@@ -6,11 +6,19 @@ package io.askimo.core.providers
 
 import dev.langchain4j.exception.InternalServerException
 import dev.langchain4j.exception.ModelNotFoundException
+import io.askimo.core.exception.ContextLengthException
+import io.askimo.core.exception.MalformedToolCallException
+import io.askimo.core.exception.RateLimitException
+import io.askimo.core.exception.RetryPolicy
 import io.askimo.core.exception.ToolExecutionException
+import io.askimo.core.exception.UnsupportedSamplingException
 import org.junit.jupiter.api.Test
 import java.io.IOException
+import java.net.ConnectException
 import java.nio.channels.UnresolvedAddressException
+import java.util.concurrent.CompletionException
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class StreamingErrorClassifierTest {
@@ -66,6 +74,47 @@ class StreamingErrorClassifierTest {
     fun `malformed tool call - missing name is retryable`() {
         val e = RuntimeException("ToolExecutionRequest.name must not be blank")
         assertIs<StreamingErrorResult.Retryable>(classifyStreamingError(e, ModelProvider.OPENAI_COMPATIBLE, "qwq"))
+    }
+
+    // ── Retryable: the classified exception is exposed to the caller ───────────
+
+    @Test
+    fun `Retryable result exposes the classified exception for side-effect dispatch`() {
+        val e = RuntimeException("context length exceeded")
+        val result = classifyStreamingError(e, ModelProvider.OPENAI_COMPATIBLE, "llama3") as StreamingErrorResult.Retryable
+        assertIs<ContextLengthException>(result.exception)
+        assertEquals(RetryPolicy.IMMEDIATE, result.exception.retryPolicy)
+    }
+
+    @Test
+    fun `malformed tool call classifies as MalformedToolCallException with IMMEDIATE policy`() {
+        val e = RuntimeException("ToolExecutionRequest.arguments must be provided")
+        val result = classifyStreamingError(e, ModelProvider.OPENAI_COMPATIBLE, "llama3") as StreamingErrorResult.Retryable
+        assertIs<MalformedToolCallException>(result.exception)
+        assertEquals(RetryPolicy.IMMEDIATE, result.exception.retryPolicy)
+    }
+
+    @Test
+    fun `unsupported sampling classifies as UnsupportedSamplingException with IMMEDIATE policy`() {
+        val e = RuntimeException("temperature does not support values above 1")
+        val result = classifyStreamingError(e, ModelProvider.OPENAI_COMPATIBLE, "llama3") as StreamingErrorResult.Retryable
+        assertIs<UnsupportedSamplingException>(result.exception)
+        assertEquals(RetryPolicy.IMMEDIATE, result.exception.retryPolicy)
+    }
+
+    // ── BACKOFF-classified errors are still Terminal here (no backoff loop wired up
+    // at this call site yet) — see `classifyStreamingError`'s doc comment. ──────────
+
+    @Test
+    fun `rate limit message is BACKOFF policy but Terminal at this call site`() {
+        val e = RuntimeException("rate limit exceeded, please slow down")
+        val result = classifyStreamingError(e, ModelProvider.OPENAI, "gpt-4o")
+        assertIs<StreamingErrorResult.Terminal>(result)
+    }
+
+    @Test
+    fun `RateLimitException retryPolicy is BACKOFF`() {
+        assertEquals(RetryPolicy.BACKOFF, RateLimitException().retryPolicy)
     }
 
     // ── Terminal: local server crash ───────────────────────────────────────────
@@ -141,11 +190,24 @@ class StreamingErrorClassifierTest {
     // ── Terminal: network ──────────────────────────────────────────────────────
 
     @Test
-    fun `unresolved address is terminal with connection message`() {
+    fun `unresolved address is terminal and classified as network error`() {
         val cause = UnresolvedAddressException()
         val e = IOException("Connection failed", cause)
         val result = classifyStreamingError(e, ModelProvider.OPENAI_COMPATIBLE, "llama3") as StreamingErrorResult.Terminal
-        assertContains(result.message, "Unable to connect")
+        // When i18n resources aren't loaded, LocalizationManager returns the key itself.
+        assertContains(result.message, "error.network")
+    }
+
+    @Test
+    fun `bare ConnectException is terminal and classified as network error`() {
+        // Regression test: this previously leaked the raw "[error] java.net.ConnectException"
+        // text to the UI because the fallback `else` branch skipped ExceptionHandler/ExceptionMapper
+        // entirely. ConnectException is often wrapped in a CompletionException by the underlying
+        // HTTP client, so the mapper must find it by walking the full cause chain.
+        val cause = ConnectException("Connection refused")
+        val e = CompletionException(cause)
+        val result = classifyStreamingError(e, ModelProvider.OPENAI, "gpt-4o") as StreamingErrorResult.Terminal
+        assertContains(result.message, "error.network")
     }
 
     // ── Terminal: InternalServerException (HTTP 5xx) ───────────────────────────
@@ -211,10 +273,13 @@ class StreamingErrorClassifierTest {
     // ── Terminal: tool execution ───────────────────────────────────────────────
 
     @Test
-    fun `ToolExecutionException message is surfaced`() {
+    fun `ToolExecutionException is terminal and classified as tool execution error`() {
         val e = ToolExecutionException(toolName = "search", errorDetails = "search service timed out")
         val result = classifyStreamingError(e, ModelProvider.OPENAI, "gpt-4o") as StreamingErrorResult.Terminal
-        assertContains(result.message, "search service timed out")
+        // When i18n resources aren't loaded, LocalizationManager returns the key itself —
+        // the {details} substitution ("search service timed out") only happens with real
+        // resource bundles loaded (see desktop-shared/src/main/resources/i18n).
+        assertContains(result.message, "error.tool_execution")
     }
 
     // ── Terminal: InsufficientContextException ─────────────────────────────────
@@ -234,9 +299,12 @@ class StreamingErrorClassifierTest {
     // ── Terminal: unknown ──────────────────────────────────────────────────────
 
     @Test
-    fun `unknown error surfaces raw message`() {
+    fun `unknown error is terminal and classified as system error`() {
         val e = RuntimeException("some completely unknown error XYZ-9999")
         val result = classifyStreamingError(e, ModelProvider.OPENAI, "gpt-4o") as StreamingErrorResult.Terminal
-        assertContains(result.message, "some completely unknown error XYZ-9999")
+        // When i18n resources aren't loaded, LocalizationManager returns the key itself —
+        // the {errorCode} substitution (which would include the raw message) only happens
+        // with real resource bundles loaded (see desktop-shared/src/main/resources/i18n).
+        assertContains(result.message, "error.system")
     }
 }

--- a/shared/src/test/kotlin/io/askimo/core/providers/StreamingErrorClassifierTest.kt
+++ b/shared/src/test/kotlin/io/askimo/core/providers/StreamingErrorClassifierTest.kt
@@ -166,6 +166,18 @@ class StreamingErrorClassifierTest {
     }
 
     @Test
+    fun `empty HTTP response wrapped 3 levels deep is still terminal and classified correctly`() {
+        // Regression test: HTTP clients commonly wrap the originating IOException several
+        // levels deep (e.g. CompletionException -> RuntimeException -> IOException). A shallow
+        // 1-level cause check would miss this and misclassify it as a generic system error.
+        val ioException = IOException("HTTP/1.1 header parser received no bytes")
+        val wrapped = RuntimeException("request failed", ioException)
+        val e = CompletionException(wrapped)
+        val result = classifyStreamingError(e, ModelProvider.OPENAI_COMPATIBLE, "gemma4") as StreamingErrorResult.Terminal
+        assertContains(result.message, "error.empty_http_response")
+    }
+
+    @Test
     fun `empty HTTP response for local provider is terminal`() {
         val e = IOException("HTTP/1.1 header parser received no bytes")
         val result = classifyStreamingError(e, ModelProvider.OPENAI_COMPATIBLE, "gemma4") as StreamingErrorResult.Terminal


### PR DESCRIPTION
- Introduce a `retryPolicy` property to `AskimoException` to define transient vs. terminal errors.
- Standardize error classification across the codebase using `ExceptionMapper`.
- Define specific user exceptions, such as `UnsupportedSamplingException`, with immediate retry policies.
- Refactor streaming message paths to rely on the centralized `ExceptionMapper` for retry decision making.
- Improve resilience by correctly differentiating between transient network and context errors.