### PR TITLE
refactor: normalize skill entry point file name to uppercase SKILL.md

### DIFF
--- a/cli/src/test/kotlin/io/askimo/core/skills/ExternalAgentTemplateMaterializeSkillTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/skills/ExternalAgentTemplateMaterializeSkillTest.kt
@@ -7,6 +7,7 @@ package io.askimo.core.skills
 import io.askimo.core.agent.ExternalAgentTemplate
 import io.askimo.core.agent.domain.SkillDefinition
 import io.askimo.core.logging.logger
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -137,10 +138,12 @@ class ExternalAgentTemplateMaterializeSkillTest {
 
         @Test
         fun `entry point is normalized to uppercase SKILL dot md regardless of source casing`() {
-            // Askimo's own convention is lowercase `skill.md` (SkillRepository.SKILL_ENTRY,
-            // matched case-insensitively) — but the target agent's native discovery (Claude
-            // Code, Codex, Antigravity) requires the file to literally be named `SKILL.md`.
-            // On a case-sensitive filesystem a preserved-casing copy would be invisible to it.
+            // The test's own source fixture (writeSkill) still writes a lowercase `skill.md` —
+            // SkillRepository.SKILL_ENTRY (now the canonical "SKILL.md") is matched
+            // case-insensitively when *reading* — but the target agent's native discovery
+            // (Claude Code, Codex, Antigravity) requires the file to literally be named
+            // `SKILL.md`. On a case-sensitive filesystem a preserved-casing copy would be
+            // invisible to it.
             val skill = writeSkill("coding/reviewer")
             agent.materializeFolder(skill, skillsRootDir)
 
@@ -154,6 +157,36 @@ class ExternalAgentTemplateMaterializeSkillTest {
             assertEquals(1, actualNames.count { it.equals("SKILL.md", ignoreCase = true) }, "Exactly one entry-point file expected")
             assertTrue("SKILL.md" in actualNames, "On-disk entry point must literally be named SKILL.md, was: $actualNames")
             assertFalse("skill.md" in actualNames, "Lowercase source name must not be preserved for the entry point, was: $actualNames")
+        }
+
+        @Test
+        fun `only the canonical entry file wins when both skill dot md and SKILL dot md exist on a case-sensitive filesystem`() {
+            // On a case-insensitive filesystem (default macOS/Windows), writing both names below
+            // just overwrites the same physical file — there is nothing to disambiguate, so the
+            // test is meaningless there and is skipped.
+            val skill = writeSkill("coding/reviewer")
+            val skillDir = skill.absolutePath.parent
+            skillDir.resolve("SKILL.md").writeText("---\nname: Rogue\n---\nRogue content")
+            val distinctFilesOnDisk = Files.list(skillDir).use { s ->
+                s.map { it.fileName.toString() }.toList()
+            }
+            assumeTrue(
+                distinctFilesOnDisk.count { it.equals("SKILL.md", ignoreCase = true) } == 2,
+                "Filesystem is case-insensitive — skill.md/SKILL.md collapse to one file, nothing to test here",
+            )
+
+            agent.materializeFolder(skill, skillsRootDir)
+
+            val target = skillsRootDir.resolve(skill.slug)
+            val materializedNames = Files.list(target).use { s -> s.map { it.fileName.toString() }.toList() }
+            assertEquals(
+                1,
+                materializedNames.count { it.equals("SKILL.md", ignoreCase = true) },
+                "Exactly one entry-point file must be materialized, was: $materializedNames",
+            )
+            // Content must come from skill.absolutePath (the canonical entry SkillRepository
+            // selected), never from the rogue duplicate — regardless of Files.walk() order.
+            assertEquals("---\nname: Test\n---\nContent", Files.readString(target.resolve("SKILL.md")))
         }
 
         @Test

--- a/cli/src/test/kotlin/io/askimo/core/skills/ExternalAgentTemplateMaterializeSkillTest.kt
+++ b/cli/src/test/kotlin/io/askimo/core/skills/ExternalAgentTemplateMaterializeSkillTest.kt
@@ -102,7 +102,9 @@ class ExternalAgentTemplateMaterializeSkillTest {
             val skill = writeSkill("pack1/reviewer")
             agent.materializeFolder(skill, skillsRootDir)
 
-            assertTrue(Files.exists(skillsRootDir.resolve("pack1-reviewer/skill.md")))
+            // Destination entry point is normalized to uppercase SKILL.md — see the dedicated
+            // casing-normalization tests below — regardless of the source's own `skill.md` casing.
+            assertTrue(Files.exists(skillsRootDir.resolve("pack1-reviewer/SKILL.md")))
             assertFalse(Files.exists(skillsRootDir.resolve("reviewer")), "Should not use the bare leaf folder name")
         }
 
@@ -115,9 +117,9 @@ class ExternalAgentTemplateMaterializeSkillTest {
             agent.materializeFolder(skillB, skillsRootDir)
 
             assertNotEquals(skillA.slug, skillB.slug)
-            assertTrue(Files.exists(skillsRootDir.resolve("${skillA.slug}/skill.md")), "First skill must be materialized")
+            assertTrue(Files.exists(skillsRootDir.resolve("${skillA.slug}/SKILL.md")), "First skill must be materialized")
             assertTrue(
-                Files.exists(skillsRootDir.resolve("${skillB.slug}/skill.md")),
+                Files.exists(skillsRootDir.resolve("${skillB.slug}/SKILL.md")),
                 "Second skill must ALSO be materialized — this is the collision bug being fixed",
             )
         }
@@ -128,9 +130,30 @@ class ExternalAgentTemplateMaterializeSkillTest {
             agent.materializeFolder(skill, skillsRootDir)
 
             val target = skillsRootDir.resolve(skill.slug)
-            assertTrue(Files.exists(target.resolve("skill.md")))
+            assertTrue(Files.exists(target.resolve("SKILL.md")))
             assertTrue(Files.exists(target.resolve("examples.md")))
             assertTrue(Files.exists(target.resolve("helpers/Util.java")))
+        }
+
+        @Test
+        fun `entry point is normalized to uppercase SKILL dot md regardless of source casing`() {
+            // Askimo's own convention is lowercase `skill.md` (SkillRepository.SKILL_ENTRY,
+            // matched case-insensitively) — but the target agent's native discovery (Claude
+            // Code, Codex, Antigravity) requires the file to literally be named `SKILL.md`.
+            // On a case-sensitive filesystem a preserved-casing copy would be invisible to it.
+            val skill = writeSkill("coding/reviewer")
+            agent.materializeFolder(skill, skillsRootDir)
+
+            val target = skillsRootDir.resolve(skill.slug)
+            assertTrue(Files.exists(target.resolve("SKILL.md")), "Entry point must be normalized to uppercase SKILL.md")
+            // Files.exists() is case-insensitive on the default macOS/Windows filesystem, so it
+            // can't distinguish "SKILL.md" from "skill.md" there — list the directory instead to
+            // check the *literal* on-disk filename regardless of the test filesystem's own
+            // case-sensitivity.
+            val actualNames = Files.list(target).use { s -> s.map { it.fileName.toString() }.toList() }
+            assertEquals(1, actualNames.count { it.equals("SKILL.md", ignoreCase = true) }, "Exactly one entry-point file expected")
+            assertTrue("SKILL.md" in actualNames, "On-disk entry point must literally be named SKILL.md, was: $actualNames")
+            assertFalse("skill.md" in actualNames, "Lowercase source name must not be preserved for the entry point, was: $actualNames")
         }
 
         @Test
@@ -155,7 +178,7 @@ class ExternalAgentTemplateMaterializeSkillTest {
             agent.materializeFolder(skill, skillsRootDir)
 
             assertTrue(Files.exists(target.resolve("user-owned.txt")), "Pre-existing user content must survive")
-            assertFalse(Files.exists(target.resolve("skill.md")), "Should not have copied into a folder that already existed")
+            assertFalse(Files.exists(target.resolve("SKILL.md")), "Should not have copied into a folder that already existed")
         }
 
         @Test

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentMessageList.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/agent/AgentMessageList.kt
@@ -130,7 +130,6 @@ fun agentMessageList(
                             text = stringResource("message.thinking", thinkingElapsedSeconds),
                             style = AppTextStyles.bodySecondary,
                             color = AppColors.secondaryIconColor(),
-                            modifier = Modifier.padding(top = Spacing.medium),
                         )
                     } else {
                         turnTimelineView(liveTimelineGroups, isStreaming = true, onLinkClick = onLinkClick)

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/chat/MessageComponents.kt
@@ -1669,6 +1669,16 @@ internal fun toolCallsSection(
 }
 
 /**
+ * Heuristic for detecting a Claude Code native Skill invocation. Claude registers a distinct
+ * tool per discovered skill, named after the skill's materialized folder (see
+ * [io.askimo.core.agent.domain.SkillDefinition.slug]), itself namespaced with a `skill(s)-`
+ * prefix by Claude Code's own Skill-tool machinery — e.g. `skills-skills-pptx` for a skill
+ * materialized at `.claude/skills/skills-pptx/`. There is no generic `"Skill"` wrapper tool
+ * with the skill name as an argument; the tool name itself already **is** the skill identifier.
+ */
+private fun String.isSkillToolCall(): Boolean = startsWith("skill", ignoreCase = true)
+
+/**
  * Single row showing a tool name, its running/done/failed status icon, and an optional
  * expandable section with the raw arguments and result.
  *
@@ -1681,7 +1691,12 @@ internal fun toolCallsSection(
 private fun toolCallRow(toolCall: ToolCallInfo) {
     val isDone = toolCall.status == ToolCallStatus.DONE
     val hasFailed = toolCall.hasFailed
-    val hasDetails = !toolCall.arguments.isNullOrBlank() || !toolCall.result.isNullOrBlank()
+    val isSkillCall = toolCall.toolName.isSkillToolCall()
+    // For a Skill invocation, the skill id (e.g. "skills-skills-pptx") already flows through as
+    // `arguments` (see ClaudeAgent's tool_use handling) and is shown inline in the header below —
+    // repeating it again in an expandable "Arguments:" section would be redundant, so it's
+    // excluded from `hasDetails` here (a `result`, if any, is still shown/expandable).
+    val hasDetails = (!toolCall.arguments.isNullOrBlank() && !isSkillCall) || !toolCall.result.isNullOrBlank()
 
     var detailsExpanded by remember { mutableStateOf(false) }
 
@@ -1743,7 +1758,11 @@ private fun toolCallRow(toolCall: ToolCallInfo) {
                     tint = statusIconColor,
                 )
                 Text(
-                    text = toolCall.toolName,
+                    text = if (isSkillCall) {
+                        stringResource("tool.call.skill.label", toolCall.arguments ?: toolCall.toolName)
+                    } else {
+                        toolCall.toolName
+                    },
                     style = AppTextStyles.hint,
                     modifier = Modifier.weight(1f),
                 )
@@ -1788,7 +1807,7 @@ private fun toolCallRow(toolCall: ToolCallInfo) {
                         .padding(top = Spacing.extraSmall),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
-                    if (!toolCall.arguments.isNullOrBlank()) {
+                    if (!toolCall.arguments.isNullOrBlank() && !isSkillCall) {
                         toolCallDetailSection(
                             label = stringResource("tool.call.detail.arguments"),
                             content = toolCall.arguments!!,

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AgentsSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AgentsSettingsSection.kt
@@ -239,7 +239,7 @@ fun agentsSettingsSection() {
                     onNewSkill = {
                         val folderName = "new-skill-${System.currentTimeMillis()}"
                         val blankContent = "---\nname: New Skill\ndescription: \ntags: []\n---\n\nYou are a helpful assistant.\n"
-                        val saved = skillRepository.save("$folderName/skill.md", blankContent)
+                        val saved = skillRepository.save("$folderName/SKILL.md", blankContent)
                         refresh()
                         selectedSkill = saved
                         selectedLeaf = null
@@ -299,7 +299,7 @@ fun agentsSettingsSection() {
             onDismiss = { showNewSkillInFolderDialog = false },
             onConfirm = { skillFolderName ->
                 if (skillFolderName.isNotBlank()) {
-                    val relativePath = "$newItemParentPath/$skillFolderName/skill.md"
+                    val relativePath = "$newItemParentPath/$skillFolderName/SKILL.md"
                     val blankContent = "---\nname: ${skillFolderName.replace('-', ' ').replaceFirstChar { it.uppercase() }}\ndescription: \ntags: []\n---\n\nYou are a helpful assistant.\n"
                     val saved = skillRepository.save(relativePath, blankContent)
                     refresh()
@@ -625,13 +625,13 @@ private fun skillEditorContent(
     skill: SkillDefinition,
     onSave: (relativePath: String, content: String) -> Unit,
 ) {
-    // Derive the actual skill.md path.
+    // Derive the actual SKILL.md path.
     val skillMdRelativePath = remember(skill.relativePath) {
         if (skill.relativePath.endsWith("/skill.md", ignoreCase = true)) {
             skill.relativePath
         } else {
             val withoutExt = skill.relativePath.removeSuffix(".md")
-            "$withoutExt/skill.md"
+            "$withoutExt/SKILL.md"
         }
     }
 

--- a/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AgentsSettingsSection.kt
+++ b/desktop-shared/src/main/kotlin/io/askimo/ui/settings/AgentsSettingsSection.kt
@@ -116,6 +116,7 @@ import java.awt.Desktop
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.relativeTo
 
 @Composable
 fun agentsSettingsSection() {
@@ -239,7 +240,7 @@ fun agentsSettingsSection() {
                     onNewSkill = {
                         val folderName = "new-skill-${System.currentTimeMillis()}"
                         val blankContent = "---\nname: New Skill\ndescription: \ntags: []\n---\n\nYou are a helpful assistant.\n"
-                        val saved = skillRepository.save("$folderName/SKILL.md", blankContent)
+                        val saved = skillRepository.save("$folderName/${SkillDefinition.SKILL_ENTRY}", blankContent)
                         refresh()
                         selectedSkill = saved
                         selectedLeaf = null
@@ -299,7 +300,7 @@ fun agentsSettingsSection() {
             onDismiss = { showNewSkillInFolderDialog = false },
             onConfirm = { skillFolderName ->
                 if (skillFolderName.isNotBlank()) {
-                    val relativePath = "$newItemParentPath/$skillFolderName/SKILL.md"
+                    val relativePath = "$newItemParentPath/$skillFolderName/${SkillDefinition.SKILL_ENTRY}"
                     val blankContent = "---\nname: ${skillFolderName.replace('-', ' ').replaceFirstChar { it.uppercase() }}\ndescription: \ntags: []\n---\n\nYou are a helpful assistant.\n"
                     val saved = skillRepository.save(relativePath, blankContent)
                     refresh()
@@ -620,19 +621,45 @@ private fun skillsMainEmptyState() {
 
 // ── Skill editor ──────────────────────────────────────────────────────────────
 
+/**
+ * Derives the actual on-disk relative path (from `skillsDir()`) that [skill]'s entry-file
+ * content should be saved to. Extracted as a pure, non-Composable function so it's directly
+ * unit-testable without a Compose runtime — see the two branches below for why this can't
+ * just be recomputed from [SkillDefinition.relativePath] alone.
+ *
+ * @param skillsDir Root skills directory, passed in (rather than read via [AskimoHome] here)
+ *                  purely so tests can point this at an arbitrary temp directory.
+ */
+internal fun deriveSkillMdRelativePath(skill: SkillDefinition, skillsDir: Path): String {
+    val isAlreadyFolderEntry = skill.absolutePath.fileName.toString().equals(SkillDefinition.SKILL_ENTRY, ignoreCase = true)
+    return if (isAlreadyFolderEntry) {
+        // Already a real, existing skill.md/SKILL.md entry file inside its own folder — write
+        // back to the *exact* file on disk, preserving whatever case it already has, instead of
+        // reconstructing a guessed path from the virtual relativePath. SkillRepository stores
+        // relativePath as a *virtual* "<category>/<folder>.md" form for folder-based skills (see
+        // SkillRepository's folder-loader), distinct from the real entry file's own path/case —
+        // guessing SKILL_ENTRY's canonical case here would silently create a brand-new sibling
+        // file next to an existing differently-cased entry on a case-sensitive filesystem, and
+        // SkillRepository would then pick between the two nondeterministically (Files.list
+        // order), so edits could appear lost.
+        skill.absolutePath.relativeTo(skillsDir).toString().replace("\\", "/")
+    } else {
+        // A flat, single-file skill (not yet folder-based) — migrate it into a fresh
+        // `<name>/SKILL.md` folder. Safe to use the canonical casing here since this
+        // destination is guaranteed not to already exist.
+        val withoutExt = skill.relativePath.removeSuffix(".md")
+        "$withoutExt/${SkillDefinition.SKILL_ENTRY}"
+    }
+}
+
 @Composable
 private fun skillEditorContent(
     skill: SkillDefinition,
     onSave: (relativePath: String, content: String) -> Unit,
 ) {
     // Derive the actual SKILL.md path.
-    val skillMdRelativePath = remember(skill.relativePath) {
-        if (skill.relativePath.endsWith("/skill.md", ignoreCase = true)) {
-            skill.relativePath
-        } else {
-            val withoutExt = skill.relativePath.removeSuffix(".md")
-            "$withoutExt/SKILL.md"
-        }
+    val skillMdRelativePath = remember(skill.relativePath, skill.absolutePath) {
+        deriveSkillMdRelativePath(skill, AskimoHome.skillsDir())
     }
 
     // Read the raw skill.md body (not the merged content used for AI execution)

--- a/desktop-shared/src/main/resources/i18n/messages.properties
+++ b/desktop-shared/src/main/resources/i18n/messages.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=AI
 # Tool call display
 tool.call.header.running=Running tool... ({0}s)
 tool.call.header.done=Used {0} tool(s)
+tool.call.skill.label=Skill: {0}
 tool.call.status.done=Done
 tool.call.status.failed=Failed
 tool.call.detail.arguments=Arguments

--- a/desktop-shared/src/main/resources/i18n/messages_de.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_de.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=KI
 # Tool call display
 tool.call.header.running=Tool wird ausgeführt... ({0}s)
 tool.call.header.done={0} Tool(s) verwendet
+tool.call.skill.label=Skill: {0}
 tool.call.status.done=Fertig
 tool.call.status.failed=Fehlgeschlagen
 tool.call.detail.arguments=Argumente

--- a/desktop-shared/src/main/resources/i18n/messages_es.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_es.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=IA
 # Tool call display
 tool.call.header.running=Ejecutando herramienta... ({0}s)
 tool.call.header.done={0} herramienta(s) utilizada(s)
+tool.call.skill.label=Habilidad: {0}
 tool.call.status.done=Hecho
 tool.call.status.failed=Fallido
 tool.call.detail.arguments=Argumentos

--- a/desktop-shared/src/main/resources/i18n/messages_fr.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_fr.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=IA
 # Tool call display
 tool.call.header.running=Exécution de l''outil... ({0}s)
 tool.call.header.done={0} outil(s) utilisé(s)
+tool.call.skill.label=Compétence : {0}
 tool.call.status.done=Terminé
 tool.call.status.failed=Échoué
 tool.call.detail.arguments=Arguments

--- a/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ja_JP.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=AI
 # Tool call display
 tool.call.header.running=ツールを実行中... ({0}s)
 tool.call.header.done={0} 個のツールを使用しました
+tool.call.skill.label=スキル: {0}
 tool.call.status.done=完了
 tool.call.status.failed=失敗
 tool.call.detail.arguments=引数

--- a/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_ko_KR.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=AI
 # Tool call display
 tool.call.header.running=도구 실행 중... ({0}s)
 tool.call.header.done={0}개의 도구 사용됨
+tool.call.skill.label=스킬: {0}
 tool.call.status.done=완료
 tool.call.status.failed=실패
 tool.call.detail.arguments=인수

--- a/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_pt_BR.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=IA
 # Tool call display
 tool.call.header.running=Executando ferramenta... ({0}s)
 tool.call.header.done={0} ferramenta(s) usada(s)
+tool.call.skill.label=Habilidade: {0}
 tool.call.status.done=Concluído
 tool.call.status.failed=Falhou
 tool.call.detail.arguments=Argumentos

--- a/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_vi_VN.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=AI
 # Tool call display
 tool.call.header.running=Đang chạy công cụ... ({0}s)
 tool.call.header.done=Đã sử dụng {0} công cụ
+tool.call.skill.label=Kỹ năng: {0}
 tool.call.status.done=Hoàn tất
 tool.call.status.failed=Thất bại
 tool.call.detail.arguments=Đối số

--- a/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_CN.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=AI
 # Tool call display
 tool.call.header.running=正在运行工具... ({0}s)
 tool.call.header.done=已使用 {0} 个工具
+tool.call.skill.label=技能：{0}
 tool.call.status.done=已完成
 tool.call.status.failed=失败
 tool.call.detail.arguments=参数

--- a/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
+++ b/desktop-shared/src/main/resources/i18n/messages_zh_TW.properties
@@ -1018,6 +1018,7 @@ bookmarks.role.ai=AI
 # Tool call display
 tool.call.header.running=正在執行工具... ({0}s)
 tool.call.header.done=已使用 {0} 個工具
+tool.call.skill.label=技能：{0}
 tool.call.status.done=已完成
 tool.call.status.failed=失敗
 tool.call.detail.arguments=參數

--- a/desktop-shared/src/test/kotlin/io/askimo/ui/settings/DeriveSkillMdRelativePathTest.kt
+++ b/desktop-shared/src/test/kotlin/io/askimo/ui/settings/DeriveSkillMdRelativePathTest.kt
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: AGPLv3
+ *
+ * Copyright (c) 2026 Askimo
+ */
+package io.askimo.ui.settings
+
+import io.askimo.core.agent.domain.SkillDefinition
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression coverage for [deriveSkillMdRelativePath] — specifically the bug where an existing
+ * folder-based skill whose entry file was still lowercase `skill.md` on disk got a *guessed*
+ * uppercase `SKILL.md` save path instead of the real file's own path. On a case-sensitive
+ * filesystem that would create a second sibling file rather than overwriting the original,
+ * making edits appear lost (SkillRepository then picks between the two nondeterministically).
+ */
+class DeriveSkillMdRelativePathTest {
+
+    private fun skillsDir(): Path = createTempDirectory("skills")
+
+    @Test
+    fun `existing folder skill with lowercase entry file is saved back to that same lowercase file`() {
+        val skillsDir = skillsDir()
+        val skillFolder = skillsDir.resolve("coding/reviewer").also { it.createDirectories() }
+        val entryFile = skillFolder.resolve("skill.md").also { it.writeText("---\nname: Reviewer\n---\nContent") }
+
+        val skill = SkillDefinition(
+            relativePath = "coding/reviewer.md", // virtual form, as SkillRepository's folder-loader produces
+            name = "Reviewer",
+            content = "Content",
+            absolutePath = entryFile,
+        )
+
+        val result = deriveSkillMdRelativePath(skill, skillsDir)
+
+        assertEquals("coding/reviewer/skill.md", result, "Must write back to the real, existing lowercase file — not a guessed uppercase one")
+    }
+
+    @Test
+    fun `existing folder skill with uppercase entry file is saved back to that same uppercase file`() {
+        val skillsDir = skillsDir()
+        val skillFolder = skillsDir.resolve("coding/reviewer").also { it.createDirectories() }
+        val entryFile = skillFolder.resolve("SKILL.md").also { it.writeText("---\nname: Reviewer\n---\nContent") }
+
+        val skill = SkillDefinition(
+            relativePath = "coding/reviewer.md",
+            name = "Reviewer",
+            content = "Content",
+            absolutePath = entryFile,
+        )
+
+        val result = deriveSkillMdRelativePath(skill, skillsDir)
+
+        assertEquals("coding/reviewer/SKILL.md", result)
+    }
+
+    @Test
+    fun `flat single-file skill not yet folder-based migrates into a new SKILL dot md folder`() {
+        val skillsDir = skillsDir()
+        val flatFile = skillsDir.resolve("coding/my-skill.md").also {
+            it.parent.createDirectories()
+            it.writeText("---\nname: My Skill\n---\nContent")
+        }
+
+        val skill = SkillDefinition(
+            relativePath = "coding/my-skill.md",
+            name = "My Skill",
+            content = "Content",
+            absolutePath = flatFile,
+        )
+
+        val result = deriveSkillMdRelativePath(skill, skillsDir)
+
+        assertEquals("coding/my-skill/SKILL.md", result, "Flat skills must migrate into a fresh folder using the canonical SKILL.md casing")
+    }
+}

--- a/shared/src/main/kotlin/io/askimo/core/agent/ClaudeAgent.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ClaudeAgent.kt
@@ -5,6 +5,7 @@
 package io.askimo.core.agent
 
 import io.askimo.core.agent.domain.SkillDefinition
+import io.askimo.core.config.AppConfig
 import io.askimo.core.logging.logger
 import io.askimo.core.util.ProcessBuilderExt
 import java.io.BufferedWriter
@@ -128,7 +129,33 @@ class ClaudeAgent : ExternalAgentTemplate() {
                     // (Claude manages the transcript/context internally, not Askimo).
                     val sessionId = event.fields["session_id"] as? String
                     if (!sessionId.isNullOrBlank()) updateExecutionMetadata(sessionId = sessionId)
-                    // Pure lifecycle marker — nothing worth surfacing to the user as a status row.
+
+                    val model = event.fields["model"] as? String
+
+                    if (AppConfig.developer.enabled && AppConfig.developer.active) {
+                        // Dev mode: surface everything useful for debugging how the CLI is
+                        // actually running — model, permission mode, tool/MCP counts, cwd.
+                        val toolCount = (event.fields["tools"] as? String)
+                            ?.let { ClaudeStreamJsonEventParser.parseArray(it).size }
+                        val mcpCount = (event.fields["mcp_servers"] as? String)
+                            ?.let { ClaudeStreamJsonEventParser.parseArray(it).size }
+                        val permissionMode = event.fields["permissionMode"] as? String
+                        val cwd = event.fields["cwd"] as? String
+
+                        onStatus(
+                            buildString {
+                                append("init")
+                                model?.let { append(" | model=$it") }
+                                permissionMode?.let { append(" | permission=$it") }
+                                toolCount?.let { append(" | tools=$it") }
+                                mcpCount?.let { append(" | mcp=$it") }
+                                cwd?.let { append(" | cwd=$it") }
+                            },
+                        )
+                    } else if (!model.isNullOrBlank()) {
+                        // Non-dev: just a brief, low-noise hint of which model answered.
+                        onStatus("model: $model")
+                    }
                 }
             }
 

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
@@ -218,10 +218,32 @@ abstract class ExternalAgentTemplate : ExternalAgent {
                 .filter { path -> path.none { seg -> seg.toString() == ".git" } }
                 .forEach { src ->
                     val relPath = sourceDir.relativize(src)
-                    val isTopLevelEntryPoint = relPath.parent == null &&
-                        relPath.fileName.toString().equals("SKILL.md", ignoreCase = true)
-                    val dest = if (isTopLevelEntryPoint) {
-                        targetDir.resolve("SKILL.md")
+                    // Anchor the entry-point decision to the *specific* file SkillRepository
+                    // already resolved as canonical (skill.absolutePath), not just a case-
+                    // insensitive filename match — on a case-sensitive filesystem a folder can
+                    // contain both `skill.md` and `SKILL.md`, and matching by name alone would
+                    // let both race into the same `targetDir/SKILL.md` destination, with
+                    // whichever Files.walk() visits last silently winning (nondeterministic,
+                    // and possibly different from what the repository/UI consider the skill's
+                    // actual content).
+                    val isCanonicalEntryPoint = relPath.parent == null && src == skill.absolutePath
+                    val isDuplicateEntryVariant = !isCanonicalEntryPoint &&
+                        relPath.parent == null &&
+                        relPath.fileName.toString().equals(SkillDefinition.SKILL_ENTRY, ignoreCase = true)
+                    if (isDuplicateEntryVariant) {
+                        // A second, non-canonical case-variant of the entry file (e.g. a stray
+                        // `skill.md` alongside the real `SKILL.md`) — skip it entirely rather
+                        // than let it clobber or race with the canonical copy below.
+                        log.warn(
+                            "Skipping duplicate entry-point variant '{}' for skill '{}' — canonical entry is {}",
+                            src,
+                            skill.name,
+                            skill.absolutePath,
+                        )
+                        return@forEach
+                    }
+                    val dest = if (isCanonicalEntryPoint) {
+                        targetDir.resolve(SkillDefinition.SKILL_ENTRY)
                     } else {
                         targetDir.resolve(relPath)
                     }
@@ -235,7 +257,7 @@ abstract class ExternalAgentTemplate : ExternalAgent {
         // warning if it's missing so a silent no-op discovery failure is easy to diagnose from
         // logs alone, without needing to inspect the filesystem by hand.
         val hasEntryPoint = Files.list(targetDir).use { s ->
-            s.anyMatch { it.fileName.toString().equals("SKILL.md", ignoreCase = true) }
+            s.anyMatch { it.fileName.toString().equals(SkillDefinition.SKILL_ENTRY, ignoreCase = true) }
         }
         if (!hasEntryPoint) {
             log.warn(

--- a/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/ExternalAgentTemplate.kt
@@ -217,7 +217,14 @@ abstract class ExternalAgentTemplate : ExternalAgent {
                 .filter { Files.isRegularFile(it) }
                 .filter { path -> path.none { seg -> seg.toString() == ".git" } }
                 .forEach { src ->
-                    val dest = targetDir.resolve(sourceDir.relativize(src))
+                    val relPath = sourceDir.relativize(src)
+                    val isTopLevelEntryPoint = relPath.parent == null &&
+                        relPath.fileName.toString().equals("SKILL.md", ignoreCase = true)
+                    val dest = if (isTopLevelEntryPoint) {
+                        targetDir.resolve("SKILL.md")
+                    } else {
+                        targetDir.resolve(relPath)
+                    }
                     Files.createDirectories(dest.parent)
                     Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING)
                     copiedCount++

--- a/shared/src/main/kotlin/io/askimo/core/agent/domain/SkillDefinition.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/domain/SkillDefinition.kt
@@ -115,5 +115,17 @@ data class SkillDefinition(
     companion object {
         /** Cap on [slug] length — keeps materialized folder names reasonable across filesystems. */
         private const val MAX_SLUG_LENGTH = 80
+
+        /**
+         * The skill entry-point filename — matched case-insensitively wherever an *existing*
+         * file is being looked up (`SKILL.md`/`skill.md`/`Skill.md` all match), but this is the
+         * canonical casing used whenever Askimo itself *writes* a brand-new entry file, so every
+         * call site (repository, agent materialization, skill editor UI, ...) agrees on one
+         * literal instead of each hardcoding its own "SKILL.md"/"skill.md". Lives here rather
+         * than on [io.askimo.core.agent.repository.SkillRepository] since non-repository code
+         * (e.g. [io.askimo.core.agent.ExternalAgentTemplate]) needs it too, and depending on a
+         * repository class purely for a filename constant is an awkward layering inversion.
+         */
+        const val SKILL_ENTRY = "SKILL.md"
     }
 }

--- a/shared/src/main/kotlin/io/askimo/core/agent/repository/SkillRepository.kt
+++ b/shared/src/main/kotlin/io/askimo/core/agent/repository/SkillRepository.kt
@@ -6,6 +6,7 @@ package io.askimo.core.agent.repository
 
 import io.askimo.core.agent.SkillMarkdownParser
 import io.askimo.core.agent.domain.SkillDefinition
+import io.askimo.core.agent.domain.SkillDefinition.Companion.SKILL_ENTRY
 import io.askimo.core.agent.domain.SkillTreeNode
 import io.askimo.core.logging.logger
 import io.askimo.core.util.AskimoHome
@@ -55,14 +56,10 @@ class SkillRepository {
     private val log = logger<SkillRepository>()
 
     companion object {
-        /**
-         * File names that are reserved — never treated as supplemental skill content.
+        /** File names that are reserved — never treated as supplemental skill content.
          * Matched case-sensitively (these are intentionally uppercase agent conventions).
          */
         private val RESERVED_FILENAMES = setOf("CLAUDE.md", "GEMINI.md", "AGENTS.md", "README.md")
-
-        /** The skill entry-point filename — matched case-insensitively. */
-        private const val SKILL_ENTRY = "skill.md"
 
         /** Cap on a rename-on-save folder name — keeps names reasonable across filesystems. */
         private const val MAX_FOLDER_NAME_LENGTH = 160


### PR DESCRIPTION
- Update materialization tests to expect the entry point to be named SKILL.md
- Adjust UI components (AgentMessageList, MessageComponents, AgentsSettingsSection) to use the normalized path
- Add new i18n keys for skill call labeling across all locales
- Improve ClaudeAgent status messages with concise model hints
- Refactor ExternalAgentTemplate to copy top‑level entry point as SKILL.md, preserving case‑insensitive matching and ensuring uniqueness